### PR TITLE
(bugfix) Respect exclude matcher in connected components graph

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -250,7 +250,9 @@ If MAX-DISTANCE is non-nil, only nodes within the given number of steps are show
                     (list file)))
          (query `[:select [file titles]
                   :from titles
-                  :where (in file [,@files])]))
+                  :where (in file [,@files])
+                  ,@(org-roam-graph--expand-matcher
+                     'file 'negate 'and)]))
     (org-roam-graph-build query)))
 
 (defun org-roam-graph-show-connected-component (&optional max-distance)


### PR DESCRIPTION
###### Motivation for this change

I think for consistency the excluded files filter should also be applied to the "connected components" graph. What do you think? 