### PR TITLE
Add prefill-current argument to org-roam-insert

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -308,9 +308,17 @@ specified via the #+ROAM_ALIAS property."
      (concat "file:" (file-relative-name target here))
      description)))
 
-(defun org-roam-insert (prefix)
+(defcustom org-roam-title-separator ": "
+  "Separator to use when breaking off titles.
+See `org-roam-insert' for details."
+  :type 'string
+  :group 'org-roam)
+
+(defun org-roam-insert (prefix &optional prefill-current)
   "Find an Org-roam file, and insert a relative org link to it at point.
-If PREFIX, downcase the title before insertion."
+If PREFIX, downcase the title before insertion.
+If PREFILL-CURRENT is non-nil, insert the title of the current note in the
+completion form."
   (interactive "P")
   (unless (org-roam--org-roam-file-p
            (buffer-file-name (buffer-base-buffer)))
@@ -328,7 +336,7 @@ If PREFIX, downcase the title before insertion."
                  "File: " completions
                  :initial-input (if prefill-current
                                     (concat title-current
-                                            ": "
+                                            org-roam-title-separator
                                             region-text)
                                   region-text)))
          (region-or-title (or region-text title))

--- a/org-roam.el
+++ b/org-roam.el
@@ -361,6 +361,14 @@ completion form."
 							       :capture-fn 'org-roam-insert))
 	(org-roam--capture)))))
 
+(defun org-roam-insert-prefill-current (prefix)
+  "Find an Org-roam file, and insert a relative org link to it at point.
+The completion template will be prefilled with the title of the current note
+and followed by `org-roam-title-separator'.
+If PREFIX, downcase the title before insertion."
+  (interactive "P")
+  (org-roam-insert prefix t))
+
 ;;;; org-roam-find-file
 (defun org-roam--get-title-path-completions ()
   "Return a list of cons pairs for titles to absolute path of Org-roam files."

--- a/org-roam.el
+++ b/org-roam.el
@@ -322,8 +322,15 @@ If PREFIX, downcase the title before insertion."
                         (buffer-substring-no-properties
                          (car region) (cdr region))))
          (completions (org-roam--get-title-path-completions))
-         (title (org-roam-completion--completing-read "File: " completions
-                                                      :initial-input region-text))
+         (title-current (when prefill-current
+                          (org-roam--get-title-or-slug (buffer-file-name))))
+         (title (org-roam-completion--completing-read
+                 "File: " completions
+                 :initial-input (if prefill-current
+                                    (concat title-current
+                                            ": "
+                                            region-text)
+                                  region-text)))
          (region-or-title (or region-text title))
          (target-file-path (cdr (assoc title completions)))
          (link-description (org-roam--format-link-title (if prefix


### PR DESCRIPTION
This PR modifies `org-roam-insert` to accept a new optional, boolean argument, `prefill-current`.  When it is non-nil, `org-roam-insert` prefills the completion template with the title of the current entry.  It's useful for quickly creating notes from a topic card.

Here's a screencast:
![output-2020-04-15-08:39:39](https://user-images.githubusercontent.com/12202828/79306501-9cbde780-7ef5-11ea-9a8c-d8025d5dea81.gif)

Note that this is something that can be easily expanded.  For instance, I'd like to create a command to create a new version of the current note.  For example, if I'm on the note 'Metaphor', and I don't agree with what I've written anymore, I could run a command and have it automatically create a `Metaphor v2` note.  The command would also check the current version-number and increment it for further versions.

How do you like this?