### PR TITLE
Reenable nested captures

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -152,6 +152,19 @@ buffer."
 		  (plist-get (buffer-local-value 'org-capture-current-plist (current-buffer)) :org-roam)))
 	   (buffer-list)))
 
+(define-minor-mode org-roam-capture-mode
+  "Minor mode for the `org-roam-captue'."
+  :lighter " orc"
+  ;; :keymap org-roam-capture-mode-map
+
+  (when (and org-roam-capture-mode
+             (eq (org-roam-capture--get :capture-fn)
+                 'org-roam-insert))
+    (add-hook 'org-capture-before-finalize-hook
+                #'org-roam-capture--insert-link-h nil 'local)))
+
+(add-hook 'org-capture-mode-hook #'org-roam-capture-mode)
+
 (defun org-roam-capture--fill-template (str &optional info)
   "Expand the template STR, returning the string.
 This is an extension of org-capture's template expansion.
@@ -180,7 +193,8 @@ This is added as a hook to `org-capture-after-finalize-hook'."
           (desc (org-roam-capture--get-local :link-description)))
       (org-with-point-at (org-roam-capture--get-local :insert-at)
         (insert (org-roam--format-link path desc)))))
-  (remove-hook 'org-capture-before-finalize-hook #'org-roam-capture--insert-link-h))
+  ;; (remove-hook 'org-capture-before-finalize-hook #'org-roam-capture--insert-link-h)
+  )
 
 (defun org-roam-capture--save-file-maybe-h ()
   "Save the file conditionally.

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -157,8 +157,9 @@ This is added as a hook to `org-capture-after-finalize-hook'."
                  'org-roam-insert))
     (when-let ((region (org-roam-capture--get :region))) ;; Remove previously selected text.
       (delete-region (car region) (cdr region)))
-    (insert (org-roam--format-link (org-roam-capture--get :file-path)
-                                   (org-roam-capture--get :link-description))))
+    (org-with-point-at (org-roam-capture--get :insert-at)
+      (insert (org-roam--format-link (org-roam-capture--get :file-path)
+                                     (org-roam-capture--get :link-description)))))
   (remove-hook 'org-capture-after-finalize-hook #'org-roam-capture--insert-link-h))
 
 (defun org-roam-capture--save-file-maybe-h ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -344,7 +344,7 @@ which takes as its argument an alist of path-completions.  See
       (let ((org-roam-capture--info (list (cons 'title title)
 					  (cons 'slug (org-roam--title-to-slug title))))
 	    (org-roam-capture--context 'title))
-	(add-hook 'org-capture-before-finalize-hook #'org-roam-capture--insert-link-h)
+	;; (add-hook 'org-capture-before-finalize-hook #'org-roam-capture--insert-link-h)
 	(setq org-roam-capture-additional-template-props
               (list :region region
 		    :link-description link-description

--- a/org-roam.el
+++ b/org-roam.el
@@ -345,9 +345,11 @@ which takes as its argument an alist of path-completions.  See
 					  (cons 'slug (org-roam--title-to-slug title))))
 	    (org-roam-capture--context 'title))
 	(add-hook 'org-capture-after-finalize-hook #'org-roam-capture--insert-link-h)
-	(setq org-roam-capture-additional-template-props (list :region region
-							       :link-description link-description
-							       :capture-fn 'org-roam-insert))
+	(setq org-roam-capture-additional-template-props
+              (list :region region
+		    :link-description link-description
+                    :insert-at (point-marker)
+		    :capture-fn 'org-roam-insert))
 	(org-roam--capture)))))
 
 ;;;; org-roam-find-file

--- a/org-roam.el
+++ b/org-roam.el
@@ -339,12 +339,12 @@ which takes as its argument an alist of path-completions.  See
           (when region ;; Remove previously selected text.
             (delete-region (car region) (cdr region)))
           (insert (org-roam--format-link target-file-path link-description)))
-      (when (org-roam-capture--in-process-p)
-	(user-error "Nested Org-roam capture processes not supported"))
+      ;; (when (org-roam-capture--in-process-p)
+      ;;   (user-error "Nested Org-roam capture processes not supported"))
       (let ((org-roam-capture--info (list (cons 'title title)
 					  (cons 'slug (org-roam--title-to-slug title))))
 	    (org-roam-capture--context 'title))
-	(add-hook 'org-capture-after-finalize-hook #'org-roam-capture--insert-link-h)
+	(add-hook 'org-capture-before-finalize-hook #'org-roam-capture--insert-link-h)
 	(setq org-roam-capture-additional-template-props
               (list :region region
 		    :link-description link-description


### PR DESCRIPTION
Fixes #527.

This is a going to be a long-running PR to address the nesting of `org-roam-capture` processes.

*Some* work has been done on it already, but it's very alpha.  Check the commit-messages for clarifications.

I'm busy this week, but I'll resume work on this next weekend.

Small demo of the current state (click it because it's quite long, height-wise):
![output-2020-04-27-00:48:47](https://user-images.githubusercontent.com/12202828/80321900-58014d00-8821-11ea-8314-f438cbfb2ecf.gif)