### PR TITLE
(fix): allow group templates in capture-templates

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -289,7 +289,7 @@ This function is used solely in Org-roam's capture templates: see
            org-roam-plist
            key
            val)
-       ;;put positional args on converted template
+       ;; Convert positional args before taking care of the plist-args
        (dotimes (_ 5)
          (push (pop copy) converted))
        (while (setq key (pop copy)

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -281,7 +281,7 @@ This function is used solely in Org-roam's capture templates: see
 (defun org-roam-capture--convert-template (template)
   "Convert TEMPLATE from Org-roam syntax to `org-capture-templates' syntax."
   (pcase template
-    (`(,key ,description) template)
+    (`(,_key ,_description) template)
     (`(,key ,description ,type ,target . ,rest)
      (let ((converted `(,key ,description ,type ,target
                              ,(unless (keywordp (car rest)) (pop rest))))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -283,30 +283,38 @@ This function is used solely in Org-roam's capture templates: see
 Return t if the TEMPLATE is well-formed, nil otherwise.
 As a special case, return 'group if TEMPLATE is a template-group.
 See `org-roam-capture-templates' for details."
-  (condition-case err
-      (pcase template
-        (`(,(pred stringp) ,(pred stringp))
-         'group)
-        ((pred (lambda (x)
-                 (>= (length x) 5)))
-         (pcase (cl-subseq template 0 5)
-           (`(,(pred stringp)
-              ,(pred stringp)
-              ,(pred symbolp)
-              ,(pred listp)
-              ,(pred stringp))
-            t)
-           (malformed-template
-            (signal 'wrong-type-argument
-                    `((list stringp stringp symbolp listp stringp …)
-                      (list ,@malformed-template …))))))
-        ((pred (lambda (x) (not (listp x))))
-         (signal 'wrong-type-argument `((listp) ,template)))
-        (_
-         (signal 'wrong-type-argument `((,@template)))))
-    (wrong-type-argument
-     (user-error "Malformed template in `org-roam-capture-templates: %s"
-                 (error-message-string err)))))
+  (let ((correct-format '(list stringp stringp symbolp listp stringp …)))
+    (condition-case err
+        (pcase template
+          ;; Error if TEMPLATE is not a list
+          ((pred (lambda (x) (not (listp x))))
+           (signal 'wrong-type-argument `((listp) ,template)))
+          ;; Check if TEMPLATE is a special group-template
+          (`(,(pred stringp) ,(pred stringp))
+           'group)
+          ;; Validate elements in TEMPLATE
+          ((pred (lambda (x)
+                   (>= (length x) 5)))
+           (pcase (cl-subseq template 0 5)
+             (`(,(pred stringp)
+                ,(pred stringp)
+                ,(pred symbolp)
+                ,(pred listp)
+                ,(pred stringp))
+              t)
+             ;; Error if elements in TEMPLATE are not the right type
+             (malformed-template
+              (signal 'wrong-type-argument
+                      `(,correct-format
+                        (list ,@malformed-template …))))))
+
+          ;; Catch-all
+          (_
+           (signal 'wrong-type-argument `(,correct-format
+                                          (list ,@template)))))
+      (wrong-type-argument
+       (user-error "Malformed template in `org-roam-capture-templates: %s"
+                   (error-message-string err))))))
 
 (defun org-roam-capture--convert-template (template)
   "Convert TEMPLATE from Org-roam syntax to `org-capture-templates' syntax."

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -33,6 +33,7 @@
 (require 'org-capture)
 (require 'dash)
 (require 's)
+(require 'seq)
 
 ;; Declarations
 (defvar org-roam-encrypt-files)
@@ -291,7 +292,7 @@ See `org-roam-capture-templates' for details."
      'group)
     ((pred (lambda (x)
              (>= (length x) 5)))
-     (pcase (cl-subseq template 0 5)
+     (pcase (seq-subseq template 0 5)
        (`(,(pred stringp)
           ,(pred stringp)
           ,(pred symbolp)

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -310,7 +310,7 @@ See `org-roam-capture-templates' for details."
   (pcase (org-roam-capture--validate-template template)
     ('group
      template)
-    (t
+    (_
      (let ((copy (copy-tree template))
            converted
            org-roam-plist

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -281,26 +281,20 @@ This function is used solely in Org-roam's capture templates: see
 (defun org-roam-capture--convert-template (template)
   "Convert TEMPLATE from Org-roam syntax to `org-capture-templates' syntax."
   (pcase template
-    (`(,(pred stringp) ,(pred stringp))
-     template)
-    (_
-     (let ((copy (copy-tree template))
-           converted
+    (`(,key ,description) template)
+    (`(,key ,description ,type ,target . ,rest)
+     (let ((converted `(,key ,description ,type ,target
+                             ,(unless (keywordp (car rest)) (pop rest))))
            org-roam-plist
-           key
-           val)
-       ;; Convert positional args before taking care of the plist-args
-       (dotimes (_ 5)
-         (push (pop copy) converted))
-       (while (setq key (pop copy)
-                    val (pop copy))
-         (if (member key org-roam-capture--template-keywords)
-             (progn
-               (push val org-roam-plist)
-               (push key org-roam-plist))
-           (push key converted)
-           (push val converted)))
-       (append (nreverse converted) `(:org-roam ,org-roam-plist))))))
+           options)
+       (while rest
+         (let* ((key (pop rest))
+                (val (pop rest))
+                (custom (member key org-roam-capture--template-keywords)))
+           (push val (if custom org-roam-plist options))
+           (push key (if custom org-roam-plist options))))
+       (append converted options `(:org-roam ,org-roam-plist))))
+    (_ (user-error "Invalid capture template format: %s" template))))
 
 (defun org-roam-capture--find-file-h ()
   "Opens the newly created template file.

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -291,7 +291,7 @@ See `org-roam-capture-templates' for details."
      'group)
     ((pred (lambda (x)
              (>= (length x) 5)))
-     (pcase (subseq template 0 5)
+     (pcase (cl-subseq template 0 5)
        (`(,(pred stringp)
           ,(pred stringp)
           ,(pred symbolp)

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -283,12 +283,9 @@ This function is used solely in Org-roam's capture templates: see
 Return t if the TEMPLATE is well-formed, nil otherwise.
 As a special case, return 'group if TEMPLATE is a template-group.
 See `org-roam-capture-templates' for details."
-  (let ((correct-format '(list stringp stringp symbolp listp stringp …)))
+  (let ((correct-format '((stringp stringp symbolp listp stringp …))))
     (condition-case err
         (pcase template
-          ;; Error if TEMPLATE is not a list
-          ((pred (lambda (x) (not (listp x))))
-           (signal 'wrong-type-argument `((listp) ,template)))
           ;; Check if TEMPLATE is a special group-template
           (`(,(pred stringp) ,(pred stringp))
            'group)
@@ -306,12 +303,12 @@ See `org-roam-capture-templates' for details."
              (malformed-template
               (signal 'wrong-type-argument
                       `(,correct-format
-                        (list ,@malformed-template …))))))
+                        (,@malformed-template …))))))
 
           ;; Catch-all
-          (_
+          (wrong-type
            (signal 'wrong-type-argument `(,correct-format
-                                          (list ,@template)))))
+                                          ,wrong-type))))
       (wrong-type-argument
        (user-error "Malformed template in `org-roam-capture-templates: %s"
                    (error-message-string err))))))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -281,7 +281,7 @@ This function is used solely in Org-roam's capture templates: see
 (defun org-roam-capture--convert-template (template)
   "Convert TEMPLATE from Org-roam syntax to `org-capture-templates' syntax."
   (pcase template
-    (`(,_key ,_description) template)
+    (`(,_ ,_) template)
     (`(,key ,description ,type ,target . ,rest)
      (let ((converted `(,key ,description ,type ,target
                              ,(unless (keywordp (car rest)) (pop rest))))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -245,7 +245,7 @@ If the search is via title, it is assumed that the file does not
 yet exist, and Org-roam will attempt to create new file.
 
 If the search is via daily notes, 'time will be passed via
-`org-roam-capture--info'.  This is used to alter the default time
+`org-roam-capture--info'. This is used to alter the default time
 in `org-capture-templates'.
 
 If the search is via ref, it is matched against the Org-roam database.

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -321,10 +321,7 @@ GOTO and KEYS argument have the same functionality as
     (when (= (length org-capture-templates) 1)
       (setq keys (caar org-capture-templates)))
     (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--save-file-maybe-h)
-    (condition-case err
-        (org-capture goto keys)
-      (error (user-error "%s.  Please adjust `org-roam-capture-templates'"
-                         (error-message-string err))))))
+    (org-capture goto keys)))
 
 ;;;###autoload
 (defun org-roam-capture ()
@@ -341,7 +338,10 @@ This uses the templates defined at `org-roam-capture-templates'."
                                         (cons 'file file-path)))
           (org-roam-capture--context 'capture))
       (setq org-roam-capture-additional-template-props (list :capture-fn 'org-roam-capture))
-      (org-roam-capture--capture))))
+      (condition-case err
+          (org-roam-capture--capture)
+        (error (user-error "%s.  Please adjust `org-roam-capture-templates'"
+                           (error-message-string err)))))))
 
 (provide 'org-roam-capture)
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -281,7 +281,7 @@ This function is used solely in Org-roam's capture templates: see
 (defun org-roam-capture--convert-template (template)
   "Convert TEMPLATE from Org-roam syntax to `org-capture-templates' syntax."
   (pcase template
-    (`(,_ ,_) template)
+    (`(,_key ,_description) template)
     (`(,key ,description ,type ,target . ,rest)
      (let ((converted `(,key ,description ,type ,target
                              ,(unless (keywordp (car rest)) (pop rest))))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -327,7 +327,10 @@ GOTO and KEYS argument have the same functionality as
     (when (= (length org-capture-templates) 1)
       (setq keys (caar org-capture-templates)))
     (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--save-file-maybe-h)
-    (org-capture goto keys)))
+    (condition-case err
+        (org-capture goto keys)
+      (error (user-error "%s.  Please adjust `org-roam-capture-templates'"
+                         (error-message-string err))))))
 
 ;;;###autoload
 (defun org-roam-capture ()

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -283,7 +283,8 @@ This function is used solely in Org-roam's capture templates: see
 
 (defun org-roam-capture--validate-template (template)
   "Validate TEMPLATE by checking its elements.
-Return t if the TEMPLATE is well-formed.
+Return t if the TEMPLATE is well-formed, nil otherwise.
+As a special case, return 'group if TEMPLATE is a template-group.
 See `org-roam-capture-templates' for details."
   (pcase template
     (`(,(pred stringp) ,(pred stringp))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -300,12 +300,11 @@ See `org-roam-capture-templates' for details."
                 ,(pred stringp))
               t)
              ;; Error if elements in TEMPLATE are not the right type
-             (malformed-template
-              (signal 'wrong-type-argument
-                      `(,correct-format
-                        (,@malformed-template …))))))
+             (wrong-type
+              (signal 'wrong-type-argument `(,correct-format
+                                             (,@wrong-type …))))))
 
-          ;; Catch-all
+          ;; Catch-all if nothing matched
           (wrong-type
            (signal 'wrong-type-argument `(,correct-format
                                           ,wrong-type))))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -244,7 +244,7 @@ If the search is via title, it is assumed that the file does not
 yet exist, and Org-roam will attempt to create new file.
 
 If the search is via daily notes, 'time will be passed via
-`org-roam-capture--info'. This is used to alter the default time
+`org-roam-capture--info'.  This is used to alter the default time
 in `org-capture-templates'.
 
 If the search is via ref, it is matched against the Org-roam database.

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -33,7 +33,7 @@
 (require 'org-capture)
 (require 'dash)
 (require 's)
-(require 'seq)
+(require 'cl-lib)
 
 ;; Declarations
 (defvar org-roam-encrypt-files)
@@ -292,7 +292,7 @@ See `org-roam-capture-templates' for details."
      'group)
     ((pred (lambda (x)
              (>= (length x) 5)))
-     (pcase (seq-subseq template 0 5)
+     (pcase (cl-subseq template 0 5)
        (`(,(pred stringp)
           ,(pred stringp)
           ,(pred symbolp)

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -307,25 +307,31 @@ See `org-roam-capture-templates' for details."
 
 (defun org-roam-capture--convert-template (template)
   "Convert TEMPLATE from Org-roam syntax to `org-capture-templates' syntax."
-  (if (eq (org-roam-capture--validate-template template) 'group)
-      template
-    (let ((copy (copy-tree template))
-          converted
-          org-roam-plist
-          key
-          val)
-      ;;put positional args on converted template
-      (dotimes (_ 5)
-        (push (pop copy) converted))
-      (while (setq key (pop copy)
-                   val (pop copy))
-        (if (member key org-roam-capture--template-keywords)
-            (progn
-              (push val org-roam-plist)
-              (push key org-roam-plist))
-          (push key converted)
-          (push val converted)))
-      (append (nreverse converted) `(:org-roam ,org-roam-plist)))))
+  (pcase (org-roam-capture--validate-template template)
+    ('group
+     template)
+    (t
+     (let ((copy (copy-tree template))
+           converted
+           org-roam-plist
+           key
+           val)
+       ;;put positional args on converted template
+       (dotimes (_ 5)
+         (push (pop copy) converted))
+       (while (setq key (pop copy)
+                    val (pop copy))
+         (if (member key org-roam-capture--template-keywords)
+             (progn
+               (push val org-roam-plist)
+               (push key org-roam-plist))
+           (push key converted)
+           (push val converted)))
+       (append (nreverse converted) `(:org-roam ,org-roam-plist))))
+    ('nil
+     (signal 'org-roam-malformed-template
+             `((list stringp stringp symbolp listp stringp …)
+               (list ,@template))))))
 
 (defun org-roam-capture--find-file-h ()
   "Opens the newly created template file.

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -285,17 +285,25 @@ This function is used solely in Org-roam's capture templates: see
          key
          val)
     ;;put positional args on converted template
-    (dotimes (_ 5)
-      (push (pop copy) converted))
-    (while (setq key (pop copy)
-                 val (pop copy))
-      (if (member key org-roam-capture--template-keywords)
-          (progn
-            (push val org-roam-plist)
-            (push key org-roam-plist))
-        (push key converted)
-        (push val converted)))
-    (append (nreverse converted) `(:org-roam ,org-roam-plist))))
+    (pcase template
+      (`(,(pred stringp) ,(pred stringp))
+       template)
+      ((pred (lambda (x)
+               (> (length x) 2)))
+       (dotimes (_ 5)
+         (push (pop copy) converted))
+       (while (setq key (pop copy)
+                    val (pop copy))
+         (if (member key org-roam-capture--template-keywords)
+             (progn
+               (push val org-roam-plist)
+               (push key org-roam-plist))
+           (push key converted)
+           (push val converted)))
+       (append (nreverse converted) `(:org-roam ,org-roam-plist)))
+      (_
+       (user-error (concat "Malformed template.  "
+                           "Please adjust `org-roam-capture-templates'"))))))
 
 (defun org-roam-capture--find-file-h ()
   "Opens the newly created template file.

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -34,6 +34,7 @@
 ;;; Library Requires
 (require 'org-capture)
 (require 'org-roam-capture)
+(require 'org-roam-macs)
 
 (defvar org-roam-dailies-capture-templates
   '(("d" "daily" plain (function org-roam-capture--get-point)

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -52,7 +52,8 @@
         (org-roam-capture--info (list (cons 'time time)))
         (org-roam-capture--context 'dailies))
     (add-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h)
-    (org-roam-capture--capture)))
+    (org-roam--with-template-error 'org-roam-dailies-capture-templates
+      (org-roam-capture--capture))))
 
 (defun org-roam-dailies-today ()
   "Create and find the daily note for today."

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -43,6 +43,19 @@ Like `with-temp-buffer', but propagates `org-roam-directory'."
          (let ((org-roam-directory ,current-org-roam-directory))
            ,@body)))))
 
+(defmacro org-roam--with-template-error (templates &rest body)
+  "Eval BODY, and point user to TEMPLATES on error.
+
+\(fn TEMPLATES BODY...)"
+  (declare (debug (form body)) (indent 1))
+  `(condition-case err
+       ,@body
+     (error (user-error "%s.  Please adjust `%s'"
+                        (error-message-string err)
+                        ,templates))))
+
+
+
 (provide 'org-roam-macs)
 
 ;;; org-roam-macs.el ends here

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -44,7 +44,9 @@ Like `with-temp-buffer', but propagates `org-roam-directory'."
            ,@body)))))
 
 (defmacro org-roam--with-template-error (templates &rest body)
-  "Eval BODY, and point user to TEMPLATES on error.
+  "Eval BODY, and point to TEMPLATES on error.
+Provides more informative error messages so that users know where
+to look.
 
 \(fn TEMPLATES BODY...)"
   (declare (debug (form body)) (indent 1))

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -62,7 +62,8 @@ It opens or creates a note with the given ref.
            (org-roam-capture--info decoded-alist)
            (template (cdr (assoc 'template decoded-alist))))
       (raise-frame)
-      (org-roam-capture--capture nil template)
+      (org-roam--with-template-error 'org-roam-capture-ref-templates
+        (org-roam-capture--capture nil template))
       (message "Item captured.")))
   nil)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -441,18 +441,6 @@ Examples:
            (slug (-reduce-from #'cl-replace (strip-nonspacing-marks title) pairs)))
       (s-downcase slug))))
 
-;;;; Handler for template errors
-(defmacro org-roam--with-template-error (templates &rest body)
-  "Eval BODY, and point user to TEMPLATES on error.
-
-\(fn TEMPLATES BODY...)"
-  (declare (debug (form body)) (indent 1))
-  `(condition-case err
-       ,@body
-     (error (user-error "%s.  Please adjust `%s'"
-                        (error-message-string err)
-                        ,templates))))
-
 ;;; Interactive Commands
 (defun org-roam--format-link-title (title)
   "Return the link title, given the file TITLE."


### PR DESCRIPTION
Fixes #583.

@progfolio Do you think the pase is warranted, here?  Ever since you've shown me how to use `pred`, I want to use it all the time, even when its use isn't warranted.  But here, it allows to check `(str str)` quite nicely:
https://github.com/jethrokuan/org-roam/blob/cb448b6a325eb7c19574cf0e06d166bc6b1fe630/org-roam-capture.el#L288-L289