### PR TITLE
(internal): add `org-roam-message`

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -150,8 +150,8 @@ SQL can be either the emacsql vector representation, or a string."
     'ignore
     (if (< version org-roam-db--version)
         (progn
-          (message (format "Upgrading the Org-roam database from version %d to version %d"
-                           version org-roam-db--version))
+          (org-roam-message (format "Upgrading the Org-roam database from version %d to version %d"
+                                    version org-roam-db--version))
           (org-roam-db-build-cache t))))
   version)
 
@@ -403,13 +403,12 @@ If FORCE, force a rebuild of the cache from scratch."
                        :titles (length all-titles)
                        :refs (length all-refs)
                        :deleted (length (hash-table-keys current-files)))))
-      (when org-roam-verbose
-        (message "files: %s, links: %s, titles: %s, refs: %s, deleted: %s"
-                 (plist-get stats :files)
-                 (plist-get stats :links)
-                 (plist-get stats :titles)
-                 (plist-get stats :refs)
-                 (plist-get stats :deleted)))
+      (org-roam-message "files: %s, links: %s, titles: %s, refs: %s, deleted: %s"
+                        (plist-get stats :files)
+                        (plist-get stats :links)
+                        (plist-get stats :titles)
+                        (plist-get stats :refs)
+                        (plist-get stats :deleted))
       stats)))
 
 (provide 'org-roam-db)

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -44,6 +44,7 @@
 ;; Library Requires
 (require 'cl-lib)
 (require 'org)
+(require 'org-roam-macs)
 (require 'org-element)
 
 (declare-function org-roam-insert "org-roam")
@@ -118,7 +119,7 @@ CHECKERS is the list of checkers used."
 
 (defun org-roam-doctor--skip ()
   "Skip the current error."
-  (message "Skipping..."))
+  (org-roam-message "Skipping..."))
 
 (defun org-roam-doctor--replace-link ()
   "Replace the current link with a new link."
@@ -218,7 +219,7 @@ If CHECKALL, run the check only for all Org-roam files."
           (unless (memq buf existing-buffers)
             (save-buffer buf)
             (kill-buffer buf))))))
-  (message "Linting completed."))
+  (org-roam-message "Linting completed."))
 
 (provide 'org-roam-doctor)
 

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -52,6 +52,8 @@
 (declare-function org-roam--list-all-files "org-roam")
 (declare-function org-roam--org-roam-file-p "org-roam")
 
+(defvar org-roam-verbose)
+
 (cl-defstruct (org-roam-doctor-checker (:copier nil))
   (name 'missing-checker-name)
   (description "")

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -33,6 +33,8 @@
 ;;; Code:
 ;;;; Library Requires
 
+(defvar org-roam-verbose)
+
 (defmacro org-roam--with-temp-buffer (&rest body)
   "Execute BODY within a temp buffer.
 Like `with-temp-buffer', but propagates `org-roam-directory'."
@@ -56,7 +58,10 @@ to look.
                         (error-message-string err)
                         ,templates))))
 
-
+(defmacro org-roam-message (msg)
+  "Message MSG when `org-roam-verbose' is true."
+  `(when org-roam-verbose
+     (message msg)))
 
 (provide 'org-roam-macs)
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -58,10 +58,11 @@ to look.
                         (error-message-string err)
                         ,templates))))
 
-(defmacro org-roam-message (msg)
-  "Message MSG when `org-roam-verbose' is true."
+(defmacro org-roam-message (format-string &rest args)
+  "Message MSG with ARGS when `org-roam-verbose' is true."
+  (declare (indent 0) (debug t))
   `(when org-roam-verbose
-     (message "(org-roam) %s" ,msg)))
+     (message (concat "(org-roam) " ,format-string) ,@args)))
 
 (provide 'org-roam-macs)
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -61,7 +61,7 @@ to look.
 (defmacro org-roam-message (msg)
   "Message MSG when `org-roam-verbose' is true."
   `(when org-roam-verbose
-     (message msg)))
+     (message ,msg)))
 
 (provide 'org-roam-macs)
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -61,7 +61,7 @@ to look.
 (defmacro org-roam-message (msg)
   "Message MSG when `org-roam-verbose' is true."
   `(when org-roam-verbose
-     (message ,msg)))
+     (message "(org-roam) %s" ,msg)))
 
 (provide 'org-roam-macs)
 

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -64,7 +64,7 @@ It opens or creates a note with the given ref.
       (raise-frame)
       (org-roam--with-template-error 'org-roam-capture-ref-templates
         (org-roam-capture--capture nil template))
-      (message "Item captured.")))
+      (org-roam-message "Item captured.")))
   nil)
 
 (defun org-roam-protocol-open-file (info)


### PR DESCRIPTION
###### Motivation for this change

This macro simplifies message printing, so we can respect
`org-roam-verbose` in more places. Also silences more messages when
`org-roam-verbose` set to false.

