### PR TITLE
"Refactor org-roam-message as a function"

### DIFF
--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -62,7 +62,7 @@ to look.
 (defun org-roam-message (format-string &rest args)
   "Pass FORMAT-STRING and ARGS to `message' when `org-roam-verbose' is t."
   (when org-roam-verbose
-    (apply #'message `(,(concat "(org-roam) " format-string) ,@args))))
+    (funcall #'message (concat "(org-roam) " format-string) args)))
 
 (provide 'org-roam-macs)
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -27,7 +27,7 @@
 
 ;;; Commentary:
 ;;
-;; This library implements macros used throughout org-roam
+;; This library implements macros and utiltiy functions used throughout org-roam
 ;;
 ;;
 ;;; Code:
@@ -58,11 +58,10 @@ to look.
                         (error-message-string err)
                         ,templates))))
 
-(defmacro org-roam-message (format-string &rest args)
-  "Message MSG with ARGS when `org-roam-verbose' is true."
-  (declare (indent 0) (debug t))
-  `(when org-roam-verbose
-     (message (concat "(org-roam) " ,format-string) ,@args)))
+(defun org-roam-messgae (format-string &rest args)
+  "Pass FORMAT-STRING and ARGS to `message' when `org-roam-verbose' is t."
+  (when org-roam-verbose
+    (message (concat "(org-roam) " format-string args))))
 
 (provide 'org-roam-macs)
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -27,7 +27,8 @@
 
 ;;; Commentary:
 ;;
-;; This library implements macros and utiltiy functions used throughout org-roam
+;; This library implements macros and utilty functions used throughout
+;; org-roam.
 ;;
 ;;
 ;;; Code:

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -62,7 +62,7 @@ to look.
 (defun org-roam-message (format-string &rest args)
   "Pass FORMAT-STRING and ARGS to `message' when `org-roam-verbose' is t."
   (when org-roam-verbose
-    (message (concat "(org-roam) " format-string args))))
+    (message (concat "(org-roam) " format-string) args)))
 
 (provide 'org-roam-macs)
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -59,7 +59,7 @@ to look.
                         (error-message-string err)
                         ,templates))))
 
-(defun org-roam-messgae (format-string &rest args)
+(defun org-roam-message (format-string &rest args)
   "Pass FORMAT-STRING and ARGS to `message' when `org-roam-verbose' is t."
   (when org-roam-verbose
     (message (concat "(org-roam) " format-string args))))

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -62,7 +62,7 @@ to look.
 (defun org-roam-message (format-string &rest args)
   "Pass FORMAT-STRING and ARGS to `message' when `org-roam-verbose' is t."
   (when org-roam-verbose
-    (funcall #'message (concat "(org-roam) " format-string) args)))
+    (apply #'message `(,(concat "(org-roam) " format-string) ,@args))))
 
 (provide 'org-roam-macs)
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -27,7 +27,7 @@
 
 ;;; Commentary:
 ;;
-;; This library implements macros and utilty functions used throughout
+;; This library implements macros and utility functions used throughout
 ;; org-roam.
 ;;
 ;;

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -62,7 +62,7 @@ to look.
 (defun org-roam-message (format-string &rest args)
   "Pass FORMAT-STRING and ARGS to `message' when `org-roam-verbose' is t."
   (when org-roam-verbose
-    (message (concat "(org-roam) " format-string) args)))
+    (apply #'message `(,(concat "(org-roam) " format-string) ,@args))))
 
 (provide 'org-roam-macs)
 


### PR DESCRIPTION
Add to commentary that org-roam-macs may contain other utility
functions (similar to org-macs).

###### Motivation for this change
Unless we need to use a macro, we should not.