### PR TITLE
(fix): handle creation of org-roam-index-file

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -596,16 +596,8 @@ command will offer you to create one."
              (file-exists-p index))
         (find-file index)
       (when (y-or-n-p "Index file does not exist.  Would you like to create it? ")
-        (let ((org-roam-capture--context 'title)
-              (org-roam-capture-templates `(("i" "index" plain
-                                             (function org-roam-capture--get-point)
-                                             "%?"
-                                             :file-name ,(-> org-roam-index-file
-                                                             (file-name-nondirectory)
-                                                             (file-name-sans-extension))
-                                             :head "#+TITLE: Index\n\n"
-                                             :unnarrowed t))))
-          (org-roam-capture--capture))))))
+        (find-file (org-roam--get-index-path))
+        (insert "#+TITLE: Index\n\n")))))
 
 ;;;; org-roam-find-ref
 (defcustom org-roam-include-type-in-ref-path-completions nil

--- a/org-roam.el
+++ b/org-roam.el
@@ -600,7 +600,9 @@ command will offer you to create one."
               (org-roam-capture-templates '(("i" "index" plain
                                              (function org-roam-capture--get-point)
                                              "%?"
-                                             :file-name "index"
+                                             :file-name (-> org-roam-index-file
+                                                            (file-name-nondirectory)
+                                                            (file-name-sans-extension))
                                              :head "#+TITLE: Index\n\n"
                                              :unnarrowed t))))
           (org-roam-capture--capture))))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -596,7 +596,14 @@ command will offer you to create one."
              (file-exists-p index))
         (find-file index)
       (when (y-or-n-p "Index file does not exist.  Would you like to create it? ")
-        (org-roam-find-file "Index")))))
+        (let ((org-roam-capture--context 'title)
+              (org-roam-capture-templates '(("i" "index" plain
+                                             (function org-roam-capture--get-point)
+                                             "%?"
+                                             :file-name "index"
+                                             :head "#+TITLE: Index\n\n"
+                                             :unnarrowed t))))
+          (org-roam-capture--capture))))))
 
 ;;;; org-roam-find-ref
 (defcustom org-roam-include-type-in-ref-path-completions nil

--- a/org-roam.el
+++ b/org-roam.el
@@ -597,12 +597,12 @@ command will offer you to create one."
         (find-file index)
       (when (y-or-n-p "Index file does not exist.  Would you like to create it? ")
         (let ((org-roam-capture--context 'title)
-              (org-roam-capture-templates '(("i" "index" plain
+              (org-roam-capture-templates `(("i" "index" plain
                                              (function org-roam-capture--get-point)
                                              "%?"
-                                             :file-name (-> org-roam-index-file
-                                                            (file-name-nondirectory)
-                                                            (file-name-sans-extension))
+                                             :file-name ,(-> org-roam-index-file
+                                                             (file-name-nondirectory)
+                                                             (file-name-sans-extension))
                                              :head "#+TITLE: Index\n\n"
                                              :unnarrowed t))))
           (org-roam-capture--capture))))))


### PR DESCRIPTION
Clearly not the best implementation we could to, but it works.

Fixes #597.

-----

More work to come, especially there's no freedom in the creation of the index file, even if it's supposed to be a one-time transaction.

We're investigating either to replace the `:file-name` parameter in all templates to allow user freedom, or if we should rethink the way `org-roam-capture--info` works.
