### PR TITLE
(feat): Add a tagging system

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -174,7 +174,7 @@ Org-mode. However, to support additional functionality, Org-roam adds
 several Org-roam-specific keywords. These functionality are not crucial
 to effective use of Org-roam.
 
-** File Titles
+** Titles
 
 To easily find a note, a title needs to be prescribed to a note. A note can have
 many titles: this allows a note to be referred to by different names, which is
@@ -210,6 +210,31 @@ One can freely control which extraction methods to use by customizing
 =org-roam-title-sources=: see the doc-string for the variable for more
 information. If all methods of title extraction return no results, the file-name
 is used in place of the titles for completions.
+
+** Tags
+
+Tags are used as meta-data for files: they facilitate interactions with notes
+where titles are insufficient. For example, tags allow for categorization of
+notes: differentiating between bibliographical and structure notes during interactive commands.
+
+Org-roam calls =org-roam--extract-tags= to extract tags from files. It uses the
+variable =org-roam-tag-sources=, to control how tags are extracted. The tag
+extraction methods supported are:
+
+1. ='prop=: This extracts tags from the =#+ROAM_TAGS= property. Tags are space delimited, and can be multi-word using double quotes.
+2. ='all-directories=: All sub-directories relative to =org-roam-directory= are
+   extracted as tags. That is, if a file is located at relative path
+   =foo/bar/file.org=, the file will have tags =foo= and =bar=.
+3. ='last-directory=: Extracts the last directory relative to
+   =org-roam-directory= as the tag. That is, if a file is located at relative
+   path =foo/bar/file.org=, the file will have tag =bar=.
+
+By default, only the ='prop= extraction method is enabled. To enable the other
+extraction methods, you may modify =org-roam-tag-sources=:
+
+#+BEGIN_SRC emacs-lisp
+(setq org-roam-tag-sources '(prop last-directory))
+#+END_SRC
 
 ** File Refs
 

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -19,10 +19,9 @@ This manual is for Org-roam version 1.1.1.
 #+BEGIN_QUOTE
 Copyright (C) 2020-2020 Jethro Kuan <jethrokuan95@gmail.com>
 
-You can redistribute this document and/or modify it under the terms
-of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any
-later version.
+You can redistribute this document and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
 
 This document is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -211,6 +210,11 @@ One can freely control which extraction methods to use by customizing
 information. If all methods of title extraction return no results, the file-name
 is used in place of the titles for completions.
 
+If you wish to add your own title extraction method, you may push a symbol
+='foo= into =org-roam-title-sources=, and define a
+=org-roam--extract-titles-foo= which accepts no arguments. See
+=org-roam--extract-titles-title= for an example.
+
 ** Tags
 
 Tags are used as meta-data for files: they facilitate interactions with notes
@@ -235,6 +239,11 @@ extraction methods, you may modify =org-roam-tag-sources=:
 #+BEGIN_SRC emacs-lisp
 (setq org-roam-tag-sources '(prop last-directory))
 #+END_SRC
+
+If you wish to add your own tag extraction method, you may push a symbol ='foo=
+into =org-roam-tag-sources=, and define a =org-roam--extract-tags-foo= which
+accepts the absolute file path as its argument. See
+=org-roam--extract-tags-prop= for an example.
 
 ** File Refs
 
@@ -957,6 +966,7 @@ file within that directory, at least once.
 
 * _ :ignore:
 # Local Variables:
+# eval: (refill-mode +1)
 # before-save-hook: org-make-toc
 # after-save-hook: (lambda nil (progn (require 'ox-texinfo nil t) (org-texinfo-export-to-info)))
 # indent-tabs-mode: nil

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -93,7 +93,8 @@ Installation
 
 Anatomy of an Org-roam File
 
-* File Titles::
+* Titles::
+* Tags::
 * File Refs::
 
 The Templating System
@@ -317,12 +318,13 @@ several Org-roam-specific keywords. These functionality are not crucial
 to effective use of Org-roam.
 
 @menu
-* File Titles::
+* Titles::
+* Tags::
 * File Refs::
 @end menu
 
-@node File Titles
-@section File Titles
+@node Titles
+@section Titles
 
 To easily find a note, a title needs to be prescribed to a note. A note can have
 many titles: this allows a note to be referred to by different names, which is
@@ -368,6 +370,37 @@ One can freely control which extraction methods to use by customizing
 @samp{org-roam-title-sources}: see the doc-string for the variable for more
 information. If all methods of title extraction return no results, the file-name
 is used in place of the titles for completions.
+
+@node Tags
+@section Tags
+
+Tags are used as meta-data for files: they facilitate interactions with notes
+where titles are insufficient. For example, tags allow for categorization of
+notes: differentiating between bibliographical and structure notes during interactive commands.
+
+Org-roam calls @samp{org-roam--extract-tags} to extract tags from files. It uses the
+variable @samp{org-roam-tag-sources}, to control how tags are extracted. The tag
+extraction methods supported are:
+
+@enumerate
+@item
+@samp{'prop}: This extracts tags from the @samp{#+ROAM_TAGS} property. Tags are space delimited, and can be multi-word using double quotes.
+@item
+@samp{'all-directories}: All sub-directories relative to @samp{org-roam-directory} are
+extracted as tags. That is, if a file is located at relative path
+@samp{foo/bar/file.org}, the file will have tags @samp{foo} and @samp{bar}.
+@item
+@samp{'last-directory}: Extracts the last directory relative to
+@samp{org-roam-directory} as the tag. That is, if a file is located at relative
+path @samp{foo/bar/file.org}, the file will have tag @samp{bar}.
+@end enumerate
+
+By default, only the @samp{'prop} extraction method is enabled. To enable the other
+extraction methods, you may modify @samp{org-roam-tag-sources}:
+
+@lisp
+(setq org-roam-tag-sources '(prop last-directory))
+@end lisp
 
 @node File Refs
 @section File Refs

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -79,19 +79,21 @@ General Public License for more details.
 * Diagnosing and Repairing Files::
 * Appendix::
 * FAQ::
+* _: _ (2). 
 
 @detailmenu
 --- The Detailed Node Listing ---
 
 Installation
 
+* _::
 * Installing from MELPA::
 * Installing from the Git Repository::
 * Post-Installation Tasks::
 
 Anatomy of an Org-roam File
 
-* File Aliases::
+* File Titles::
 * File Refs::
 
 The Templating System
@@ -117,6 +119,7 @@ Graphing
 
 Roam Protocol
 
+* _: _ (1). 
 * Installation: Installation (1). 
 * The @samp{roam-file} protocol::
 * The @samp{roam-ref} Protocol::
@@ -176,13 +179,17 @@ Emacs is also a fantastic interface for editing text, and we can inherit many of
 @node Installation
 @chapter Installation
 
-Org-roam can be installed using Emacs' package manager or manually from its development repository.
-
 @menu
+* _::
 * Installing from MELPA::
 * Installing from the Git Repository::
 * Post-Installation Tasks::
 @end menu
+
+@node _
+@section _ :ignore:
+
+Org-roam can be installed using Emacs' package manager or manually from its development repository.
 
 @node Installing from MELPA
 @section Installing from MELPA
@@ -310,21 +317,57 @@ several Org-roam-specific keywords. These functionality are not crucial
 to effective use of Org-roam.
 
 @menu
-* File Aliases::
+* File Titles::
 * File Refs::
 @end menu
 
-@node File Aliases
-@section File Aliases
+@node File Titles
+@section File Titles
 
-Suppose you want a note to be referred to by different names (e.g.
-``World War 2'', ``WWII''). You may specify such aliases using the
-@samp{#+ROAM_ALIAS} attribute:
+To easily find a note, a title needs to be prescribed to a note. A note can have
+many titles: this allows a note to be referred to by different names, which is
+especially useful for topics or concepts with acronyms. For example, for a note
+like ``World War 2'', it may be desirable to also refer to it using the acronym
+``WWII''.
+
+Org-roam calls @samp{org-roam--extract-titles} to extract titles. It uses the
+variable @samp{org-roam-title-sources}, to control how the titles are extracted. The
+title extraction methods supported are:
+
+@enumerate
+@item
+@samp{'title}: This extracts the title using the file @samp{#+TITLE} property
+@item
+@samp{'headline}: This extracts the title from the first headline in the Org file
+@item
+@samp{'alias}: This extracts a list of titles using the @samp{#ROAM_ALIAS} property.
+The aliases are space-delimited, and can be multi-worded using quotes
+@end enumerate
+
+Take for example the following org file:
 
 @example
 #+TITLE: World War 2
 #+ROAM_ALIAS: "WWII" "World War II"
+
+* Headline
 @end example
+
+@multitable {aaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaa}
+@headitem Method
+@tab Titles
+@item @samp{'title}
+@tab '(``World War 2'')
+@item @samp{'headline}
+@tab '(``Headline'')
+@item @samp{'alias}
+@tab '(``WWII'' ``World War II'')
+@end multitable
+
+One can freely control which extraction methods to use by customizing
+@samp{org-roam-title-sources}: see the doc-string for the variable for more
+information. If all methods of title extraction return no results, the file-name
+is used in place of the titles for completions.
 
 @node File Refs
 @section File Refs
@@ -754,14 +797,18 @@ Other options include @samp{'ido}, and @samp{'ivy}.
 @node Roam Protocol
 @chapter Roam Protocol
 
-Org-roam extending @samp{org-protocol} with 2 protocols: the @samp{roam-file}
-and @samp{roam-ref} protocol.
-
 @menu
+* _: _ (1). 
 * Installation: Installation (1). 
 * The @samp{roam-file} protocol::
 * The @samp{roam-ref} Protocol::
 @end menu
+
+@node _ (1)
+@section _ :ignore:
+
+Org-roam extending @samp{org-protocol} with 2 protocols: the @samp{roam-file}
+and @samp{roam-ref} protocol.
 
 @node Installation (1)
 @section Installation
@@ -1190,6 +1237,9 @@ contain:
 All files within that directory will be treated as their own separate
 set of Org-roam files. Remember to run @samp{org-roam-db-build-cache} from a
 file within that directory, at least once.
+
+@node _ (2)
+@chapter _ :ignore:
 
 Emacs 28.0.50 (Org mode 9.4)
 @bye

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -51,10 +51,9 @@ This manual is for Org-roam version 1.1.1.
 @quotation
 Copyright (C) 2020-2020 Jethro Kuan <jethrokuan95@@gmail.com>
 
-You can redistribute this document and/or modify it under the terms
-of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any
-later version.
+You can redistribute this document and/or modify it under the terms of the GNU
+General Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
 
 This document is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -371,6 +370,11 @@ One can freely control which extraction methods to use by customizing
 information. If all methods of title extraction return no results, the file-name
 is used in place of the titles for completions.
 
+If you wish to add your own title extraction method, you may push a symbol
+@samp{'foo} into @samp{org-roam-title-sources}, and define a
+@samp{org-roam--extract-titles-foo} which accepts no arguments. See
+@samp{org-roam--extract-titles-title} for an example.
+
 @node Tags
 @section Tags
 
@@ -401,6 +405,11 @@ extraction methods, you may modify @samp{org-roam-tag-sources}:
 @lisp
 (setq org-roam-tag-sources '(prop last-directory))
 @end lisp
+
+If you wish to add your own tag extraction method, you may push a symbol @samp{'foo}
+into @samp{org-roam-tag-sources}, and define a @samp{org-roam--extract-tags-foo} which
+accepts the absolute file path as its argument. See
+@samp{org-roam--extract-tags-prop} for an example.
 
 @node File Refs
 @section File Refs

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -331,8 +331,11 @@ This uses the templates defined at `org-roam-capture-templates'."
   (when (org-roam-capture--in-process-p)
     (user-error "Nested Org-roam capture processes not supported"))
   (let* ((completions (org-roam--get-title-path-completions))
-         (title (org-roam-completion--completing-read "File: " completions))
-         (file-path (cdr (assoc title completions))))
+         (title-with-keys (org-roam-completion--completing-read "File: "
+                                                                completions))
+         (res (gethash title-with-keys completions))
+         (title (plist-get res :title))
+         (file-path (plist-get res :file-path)))
     (let ((org-roam-capture--info (list (cons 'title title)
                                         (cons 'slug (org-roam--title-to-slug title))
                                         (cons 'file file-path)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -134,7 +134,7 @@ space-delimited strings.
            (symbol)))
   :group 'org-roam)
 
-(defcustom org-roam-tag-sources '(directories global-prop)
+(defcustom org-roam-tag-sources '(prop)
   "Sources to obtain tags from."
   :type '(repeat symbol))
 
@@ -359,16 +359,24 @@ If NESTED, return the first successful result from SOURCES."
           (cl-return))))
     coll))
 
-(defun org-roam--extract-tags-directories (file)
-  "Extract tags from using the directory path FILE."
+(defun org-roam--extract-tags-all-directories (file)
+  "Extract tags from using the directory path FILE.
+All sub-directories relative to `org-roam-directory' are used as tags."
   (when-let ((dir-relative (file-name-directory
                             (file-relative-name file org-roam-directory))))
     (f-split dir-relative)))
 
-(defun org-roam--extract-tags-global-prop (_file)
+(defun org-roam--extract-tags-last-directory (file)
+  "Extract tags from using the directory path FILE.
+The final directory component is used as a tag."
+  (when-let ((dir-relative (file-name-directory
+                            (file-relative-name file org-roam-directory))))
+    (last (f-split dir-relative))))
+
+(defun org-roam--extract-tags-prop (_file)
   "Extract tags from the current buffer's \"#ROAM_TAGS\" global property."
-  (let* ((props (org-roam--extract-global-props '("ROAM_TAGS"))))
-    (org-roam--str-to-list (cdr (assoc "ROAM_TAGS" props)))))
+  (let* ((prop (org-roam--extract-global-props '("ROAM_TAGS"))))
+    (org-roam--str-to-list (cdr (assoc "ROAM_TAGS" prop)))))
 
 (defun org-roam--extract-tags (&optional file)
   "Extract tags from the current buffer.

--- a/org-roam.el
+++ b/org-roam.el
@@ -155,7 +155,9 @@ extraction methods:
     Extract the last directory relative to `org-roam-directory'.
     That is, if a file is located at relative path foo/bar/file.org,
     the file will have tag \"bar\"."
-  :type '(repeat symbol))
+  :type '(set (const :tag "#+ROAM_TAGS" prop)
+              (const :tag "sub-directories" all-directories)
+              (const :tag "parent directory" last-directory)))
 
 ;;;; Dynamic variables
 (defvar org-roam-last-window nil

--- a/org-roam.el
+++ b/org-roam.el
@@ -140,19 +140,21 @@ space-delimited strings.
 It should be a list of symbols representing any of the following
 extraction methods:
 
-1. 'prop: This extracts tags from the =#+ROAM_TAGS=
-   property.  Tags are space delimited, and can be multi-word
-   using double quotes.
+  `prop'
+    Extract tags from the #+ROAM_TAGS property.
+    Tags are space delimited.
+    Tags may contain spaces if they are double-quoted.
+    e.g. #+ROAM_TAGS: tag \"tag with spaces\"
 
-2. 'all-directories: All sub-directories relative to
-   =org-roam-directory= are extracted as tags.  That is, if a file
-   is located at relative path =foo/bar/file.org=, the file will
-   have tags =foo= and =bar=.
+  `all-directories'
+    Extract sub-directories relative to `org-roam-directory'.
+    That is, if a file is located at relative path foo/bar/file.org,
+    the file will have tags \"foo\" and \"bar\".
 
-3. 'last-directory: Extracts the last directory relative to
-   =org-roam-directory= as the tag.  That is, if a file is located
-   at relative path =foo/bar/file.org=, the file will have tag
-   =bar=."
+  `last-directory'
+    Extract the last directory relative to `org-roam-directory'.
+    That is, if a file is located at relative path foo/bar/file.org,
+    the file will have tag \"bar\"."
   :type '(repeat symbol))
 
 ;;;; Dynamic variables

--- a/org-roam.el
+++ b/org-roam.el
@@ -135,7 +135,24 @@ space-delimited strings.
   :group 'org-roam)
 
 (defcustom org-roam-tag-sources '(prop)
-  "Sources to obtain tags from."
+  "Sources to obtain tags from.
+
+It should be a list of symbols representing any of the following
+extraction methods:
+
+1. 'prop: This extracts tags from the =#+ROAM_TAGS=
+   property.  Tags are space delimited, and can be multi-word
+   using double quotes.
+
+2. 'all-directories: All sub-directories relative to
+   =org-roam-directory= are extracted as tags.  That is, if a file
+   is located at relative path =foo/bar/file.org=, the file will
+   have tags =foo= and =bar=.
+
+3. 'last-directory: Extracts the last directory relative to
+   =org-roam-directory= as the tag.  That is, if a file is located
+   at relative path =foo/bar/file.org=, the file will have tag
+   =bar=."
   :type '(repeat symbol))
 
 ;;;; Dynamic variables

--- a/org-roam.el
+++ b/org-roam.el
@@ -113,7 +113,7 @@ Each element in the list is either:
 1. a symbol -- this symbol corresponds to a title retrieval
 function, which returns the list of titles for the current buffer
 2. a list of symbols -- symbols in the list are treated as
-with (1). The return value of this list is the first symbol in
+with (1).  The return value of this list is the first symbol in
 the list returning a non-nil value.
 
 The return results of the root list are concatenated.
@@ -504,7 +504,7 @@ Examples:
 If LOWERCASE, downcase the title before insertion.
 FILTER-FN is the name of a function to apply on the candidates
 which takes as its argument an alist of path-completions.
-If DESCRIPTION is provided, use this as the link label. See
+If DESCRIPTION is provided, use this as the link label.  See
 `org-roam--get-title-path-completions' for details."
   (interactive "P")
   (let* ((region (and (region-active-p)

--- a/org-roam.el
+++ b/org-roam.el
@@ -544,6 +544,12 @@ If DESCRIPTION is provided, use this as the link label.  See
         (org-roam--with-template-error 'org-roam-capture-templates
           (org-roam-capture--capture))))))
 
+(defcustom org-roam-tag-separator ","
+  "String to use to separate tags.
+Only relevant when `org-roam-tag-sources' is non-nil."
+  :type 'string
+  :group 'org-roam)
+
 (defun org-roam--get-title-path-completions ()
   "Return a hash table for completion.
 The key is the displayed title for completion, and the value is a
@@ -558,7 +564,7 @@ plist containing the path to the file, and the original title."
           (dolist (title titles)
             (let ((k (concat
                       (if tags
-                          (concat "(" (s-join "," tags) ") ")
+                          (concat "(" (s-join org-roam-tag-separator tags) ") ")
                         "")
                       title))
                   (v (list :path file-path :title title)))

--- a/tests/roam-files/base.org
+++ b/tests/roam-files/base.org
@@ -1,0 +1,1 @@
+#+TITLE: Base

--- a/tests/roam-files/nested/deeply/deeply_nested_file.org
+++ b/tests/roam-files/nested/deeply/deeply_nested_file.org
@@ -1,0 +1,1 @@
+#+TITLE: Deeply Nested File

--- a/tests/roam-files/tags/no_tag.org
+++ b/tests/roam-files/tags/no_tag.org
@@ -1,0 +1,3 @@
+#+TITLE: Tagless File
+
+This file has no tags, and should not yield any tags on extracting via =#+ROAM_TAGS=.

--- a/tests/roam-files/tags/tag.org
+++ b/tests/roam-files/tags/tag.org
@@ -1,0 +1,4 @@
+#+ROAM_TAGS: "t1" "t2"
+#+TITLE: Tags
+
+This file is used to test functionality for =(org-roam--extract-tags)=

--- a/tests/roam-files/tags/tag.org
+++ b/tests/roam-files/tags/tag.org
@@ -1,4 +1,4 @@
-#+ROAM_TAGS: "t1" "t2"
+#+ROAM_TAGS: "t1" "t2 with space" t3
 #+TITLE: Tags
 
 This file is used to test functionality for =(org-roam--extract-tags)=

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -159,7 +159,7 @@
       (expect (test #'org-roam--extract-tags-prop
                     "tags/tag.org")
               :to-equal
-              '("t1" "t2"))
+              '("t1" "t2 with space" "t3"))
       (expect (test #'org-roam--extract-tags-prop
                     "tags/no_tag.org")
               :to-equal
@@ -199,13 +199,13 @@
                   (test #'org-roam--extract-tags
                         "tags/tag.org"))
                 :to-equal
-                '("t1" "t2")))
+                '("t1" "t2 with space" "t3")))
       (it "'(prop all-directories)"
         (expect (let ((org-roam-tag-sources '(prop all-directories)))
                   (test #'org-roam--extract-tags
                         "tags/tag.org"))
                 :to-equal
-                '("t1" "t2" "tags"))))))
+                '("t1" "t2 with space" "t3" "tags"))))))
 
 ;;; Tests
 (xdescribe "org-roam-db-build-cache"

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -202,7 +202,7 @@
     ;; Expect rebuilds to be really quick (nothing changed)
     (expect (org-roam-db-build-cache)
             :to-equal
-            (list :files 0 :links 0 :titles 0 :refs 0 :deleted 0))))
+            (list :files 0 :links 0 :tags 0 :titles 0 :refs 0 :deleted 0))))
 
 (xdescribe "org-roam-insert"
   (before-each
@@ -216,15 +216,15 @@
       (with-current-buffer buf
         (with-simulated-input
          "Foo RET"
-         (org-roam-insert nil))))
+         (org-roam-insert))))
     (expect (buffer-string) :to-match (regexp-quote "file:foo.org")))
 
   (it "temp2 -> nested/foo"
     (let ((buf (test-org-roam--find-file "temp2.org")))
       (with-current-buffer buf
         (with-simulated-input
-         "Nested SPC Foo RET"
-         (org-roam-insert nil))))
+         "(nested) SPC Nested SPC Foo RET"
+         (org-roam-insert))))
     (expect (buffer-string) :to-match (regexp-quote "file:nested/foo.org")))
 
   (it "nested/temp3 -> foo"
@@ -232,15 +232,15 @@
       (with-current-buffer buf
         (with-simulated-input
          "Foo RET"
-         (org-roam-insert nil))))
+         (org-roam-insert))))
     (expect (buffer-string) :to-match (regexp-quote "file:../foo.org")))
 
   (it "a/b/temp4 -> nested/foo"
     (let ((buf (test-org-roam--find-file "a/b/temp4.org")))
       (with-current-buffer buf
         (with-simulated-input
-         "Nested SPC Foo RET"
-         (org-roam-insert nil))))
+         "(nested) SPC Nested SPC Foo RET"
+         (org-roam-insert))))
     (expect (buffer-string) :to-match (regexp-quote "file:../../nested/foo.org"))))
 
 (xdescribe "rename file updates cache"

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -141,6 +141,72 @@
                 :to-equal
                 '("Headline" "roam" "alias" "TITLE PROP"))))))
 
+(describe "Tag extraction"
+  :var (org-roam-tag-sources)
+  (before-all
+    (test-org-roam--init))
+
+  (after-all
+    (test-org-roam--teardown))
+
+  (cl-flet
+      ((test (fn file)
+             (let* ((fname (test-org-roam--abs-path file))
+                    (buf (find-file-noselect fname)))
+               (with-current-buffer buf
+                 (funcall fn fname)))))
+    (it "extracts from prop"
+      (expect (test #'org-roam--extract-tags-prop
+                    "tags/tag.org")
+              :to-equal
+              '("t1" "t2"))
+      (expect (test #'org-roam--extract-tags-prop
+                    "tags/no_tag.org")
+              :to-equal
+              nil))
+
+    (it "extracts from all directories"
+      (expect (test #'org-roam--extract-tags-all-directories
+                    "base.org")
+              :to-equal
+              nil)
+      (expect (test #'org-roam--extract-tags-all-directories
+                    "tags/tag.org")
+              :to-equal
+              '("tags"))
+      (expect (test #'org-roam--extract-tags-all-directories
+                    "nested/deeply/deeply_nested_file.org")
+              :to-equal
+              '("nested" "deeply")))
+
+    (it "extracts from last directory"
+      (expect (test #'org-roam--extract-tags-last-directory
+                    "base.org")
+              :to-equal
+              nil)
+      (expect (test #'org-roam--extract-tags-last-directory
+                    "tags/tag.org")
+              :to-equal
+              '("tags"))
+      (expect (test #'org-roam--extract-tags-last-directory
+                    "nested/deeply/deeply_nested_file.org")
+              :to-equal
+              '("deeply")))
+
+    (describe "uses org-roam-tag-sources correctly"
+      (it "'(prop)"
+        (expect (let ((org-roam-tag-sources '(prop)))
+                  (test #'org-roam--extract-tags
+                        "tags/tag.org"))
+                :to-equal
+                '("t1" "t2")))
+      (it "'(prop all-directories)"
+        (expect (let ((org-roam-tag-sources '(prop all-directories)))
+                  (test #'org-roam--extract-tags
+                        "tags/tag.org"))
+                :to-equal
+                '("t1" "t2" "tags"))))))
+
 ;;; Tests
 (xdescribe "org-roam-db-build-cache"
   (before-each


### PR DESCRIPTION
###### Motivation for this change

Adds a tagging system to Org-roam. Addresses #572.

Tags are obtained in 2 ways:

1. Via sub-directories: "a/b/c/foo.org" will have tags `a, b, c`
2. Via `#+ROAM_TAG`: `#+ROAM_TAG: foo bar` will assign tags `foo bar`

These 2 means are freely combined.

@zaeph this PR removes your stuff on directory specific filtering, in favour of assigning tags based on directories, functionally they are equivalent, but this is more general.