### PR TITLE
Refactor org-roam-dev to utilize dir-local variable

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode . ((eval . (require 'org-roam-dev)))))

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -1,4 +1,4 @@
-;;; org-roam-buffer.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-buffer.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -1,4 +1,4 @@
-;;; org-roam-capture.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-capture.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -1,4 +1,4 @@
-;;; org-roam-compat.el --- Compatibility Code -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-compat.el --- Compatibility Code -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-completion.el
+++ b/org-roam-completion.el
@@ -1,4 +1,4 @@
-;;; org-roam-completion.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-completion.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -1,4 +1,4 @@
-;;; org-roam-dailies.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-dailies.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; -*-
 ;;;
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -1,4 +1,4 @@
-;;; org-roam-db.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-db.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-dev.el
+++ b/org-roam-dev.el
@@ -1,4 +1,4 @@
-;;; org-roam-dev.el --- Org-roam development code -mode -*- coding: utf-8; lexical-binding: t -*-
+;;; org-roam-dev.el --- Org-roam development code -mode -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -1,4 +1,4 @@
-;;; org-roam-graph.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-graph.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -1,4 +1,4 @@
-;;; org-roam-macs.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-macs.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -1,4 +1,4 @@
-;;; org-roam-protocol.el --- Protocol handler for roam:// links  -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam-protocol.el --- Protocol handler for roam:// links  -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 ;; Author: Jethro Kuan <jethrokuan95@gmail.com>

--- a/org-roam.el
+++ b/org-roam.el
@@ -1,4 +1,4 @@
-;;; org-roam.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; eval: (require 'org-roam-dev); -*-
+;;; org-roam.el --- Roam Research replica with Org-mode -*- coding: utf-8; lexical-binding: t; -*-
 
 ;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
 


### PR DESCRIPTION
###### Motivation for this change
Sorry! Missed this refactor before the merge.
I forgot Emacs has directory local variables.
Using this prevents us from having to add it to file-local variable line of each file.