### PR TITLE
(refactor): org-roam-db--clear-file pull tables from schemata

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -187,11 +187,8 @@ the current `org-roam-directory'."
   "Clears all entries in the caches."
   (interactive)
   (when (file-exists-p (org-roam-db--get))
-    (org-roam-db-query [:delete :from files])
-    (org-roam-db-query [:delete :from titles])
-    (org-roam-db-query [:delete :from links])
-    (org-roam-db-query [:delete :from refs])))
-
+    (dolist (table (mapcar #'car org-roam-db--table-schemata))
+      (org-roam-db-query `[:delete :from ,table]))))
 
 (defun org-roam-db--clear-file (&optional filepath)
   "Remove any related links to the file at FILEPATH.

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -193,21 +193,11 @@ the current `org-roam-directory'."
 (defun org-roam-db--clear-file (&optional filepath)
   "Remove any related links to the file at FILEPATH.
 This is equivalent to removing the node from the graph."
-  (let* ((path (or filepath
-                   (buffer-file-name)))
-         (file (file-truename path)))
-    (org-roam-db-query [:delete :from files
-                        :where (= file $s1)]
-                       file)
-    (org-roam-db-query [:delete :from links
-                        :where (= from $s1)]
-                       file)
-    (org-roam-db-query [:delete :from titles
-                        :where (= file $s1)]
-                       file)
-    (org-roam-db-query [:delete :from refs
-                        :where (= file $s1)]
-                       file)))
+  (let ((file (file-truename (or filepath (buffer-file-name)))))
+    (dolist (table (mapcar #'car org-roam-db--table-schemata))
+      (org-roam-db-query `[:delete :from ,table
+                           :where (= ,(if (eq table 'links) 'from 'file) $s1)]
+                         file))))
 
 ;;;;; Insertion
 (defun org-roam-db--insert-links (links)


### PR DESCRIPTION
Programatically pull tables from schemata, rather than manually specifying them.