### PR TITLE
(docs): update manual location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
-[![Documentation Status](https://readthedocs.org/projects/org-roam/badge/?version=latest)](https://org-roam.readthedocs.io/en/latest/?badge=latest)
 [![GitHub Release](https://img.shields.io/github/v/release/org-roam/org-roam)](https://img.shields.io/github/v/release/org-roam/org-roam)
 [![MELPA](https://melpa.org/packages/org-roam-badge.svg)](https://melpa.org/#/org-roam)
 
@@ -22,13 +21,11 @@ describing Org-roam and the concepts behind it:
 
 [![Making Connections in your Notes](http://img.youtube.com/vi/Lg61ocfxk3c/0.jpg)](http://www.youtube.com/watch?v=Lg61ocfxk3c "Making Connections in your Notes")
 
-As of February 2020, it is in a very early stage of development. 
-
 Important links:
 
 - **[Documentation][docs]**
 - **[Discourse][discourse]**
-- **[Org-roam Slack][slack]**
+- **[Slack][slack]**
 
 ## A Preview
 
@@ -53,7 +50,7 @@ Here's a sample configuration with using `use-package`:
 
 ```emacs-lisp
 (use-package org-roam
-      :hook 
+      :hook
       (after-init . org-roam-mode)
       :custom
       (org-roam-directory "/path/to/org-files/")
@@ -73,7 +70,7 @@ different tool.
 
 For more detailed installation and configuration instructions (including for
 Doom and Spacemacs users), please see [the
-documentation](https://org-roam.readthedocs.io/en/master/installation/).
+documentation][docs].
 
 ## Knowledge Bases using Org-roam
 
@@ -98,6 +95,6 @@ General Public License, Version 3
 [roamresearch]: https://www.roamresearch.com/
 [org]: https://orgmode.org/
 [badge-license]: https://img.shields.io/badge/license-GPL_3-green.svg
-[docs]: https://org-roam.readthedocs.io/
+[docs]: https://org-roam.github.io/org-roam/manual/
 [discourse]: https://org-roam.discourse.group/
 [slack]: https://join.slack.com/t/orgroam/shared_invite/zt-deoqamys-043YQ~s5Tay3iJ5QRI~Lxg

--- a/org-roam.el
+++ b/org-roam.el
@@ -65,7 +65,7 @@
   :group 'org
   :prefix "org-roam-"
   :link '(url-link :tag "Github" "https://github.com/org-roam/org-roam")
-  :link '(url-link :tag "Online Manual" "https://org-roam.readthedocs.io/"))
+  :link '(url-link :tag "Online Manual" "https://org-roam.github.io/org-roam/manual/"))
 
 (defgroup org-roam-faces nil
   "Faces used by Org-roam."


### PR DESCRIPTION
###### Motivation for this change

In an effort to consolidate efforts on documentation, we have moved all the documentation into an Org file, to allow for the generation of Info pages in Emacs, as well as the generation of a HTML manual.

This is perhaps a step backward from the previous, arguably more consumable, online documentation, but I hope that this makes it easier to access and contribute to the documentation within Emacs.