### PR TITLE
 (docs): Fix org-roam-buffer-no-delete-other-windows

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -372,7 +372,7 @@ The Org-roam buffer displays backlinks for the currently active Org-roam note.
   Height of =org-roam-buffer=. Has an effect only if =org-roam-buffer-position= is
   ='top= or ='bottom=.
 
-- User Option: org-roam-buffer-no-delete-window
+- User Option: org-roam-buffer-no-delete-other-windows
 
   The =no-delete-window= parameter for the org-roam buffer. Setting it to ='t= prevents the window from being deleted when calling =delete-other-windows=.
 

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -536,7 +536,7 @@ Height of @samp{org-roam-buffer}. Has an effect only if @samp{org-roam-buffer-po
 @samp{'top} or @samp{'bottom}.
 
 @item
-User Option: org-roam-buffer-no-delete-window
+User Option: org-roam-buffer-no-delete-other-windows
 
 The @samp{no-delete-window} parameter for the org-roam buffer. Setting it to @samp{'t} prevents the window from being deleted when calling @samp{delete-other-windows}.
 @end itemize


### PR DESCRIPTION

###### Motivation for this change
It appears the option has changed name, but this was not yet reflected
in the documentation.
