### PR TITLE
(internal): org-roam-dev -> sentence-end-double-space nil

### DIFF
--- a/org-roam-dev.el
+++ b/org-roam-dev.el
@@ -34,6 +34,7 @@
 ;;; Code:
 (require 'emacsql)
 (emacsql-fix-vector-indentation)
+(setq-local sentence-end-double-space nil)
 (provide 'org-roam-dev)
 
 ;;; org-roam-dev.el ends here


### PR DESCRIPTION
Required by CI.


