### PR TITLE
(fix): move from alist to hash for find-ref

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -736,7 +736,8 @@ included as a candidate."
          (ref (org-roam-completion--completing-read "Ref: "
                                                     completions
                                                     :require-match t))
-         (file (cdr (assoc ref completions))))
+         (file (-> (gethash ref completions)
+                   (plist-get :path))))
     (find-file file)))
 
 (defun org-roam--get-roam-buffers ()


### PR DESCRIPTION
Yet another spot where we've forgotten to change to a hash-table.