### PR TITLE
(internal): revert completions from hash table to alist

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -333,7 +333,7 @@ This uses the templates defined at `org-roam-capture-templates'."
   (let* ((completions (org-roam--get-title-path-completions))
          (title-with-keys (org-roam-completion--completing-read "File: "
                                                                 completions))
-         (res (gethash title-with-keys completions))
+         (res (cdr (assoc title-with-keys completions)))
          (title (plist-get res :title))
          (file-path (plist-get res :file-path)))
     (let ((org-roam-capture--info (list (cons 'title title)

--- a/org-roam.el
+++ b/org-roam.el
@@ -588,7 +588,7 @@ plist containing the path to the file, and the original title."
                                    :left :join tags
                                    :on (= titles:file tags:file)]))
          completions)
-    (dolist (row rows)
+    (dolist (row rows completions)
       (pcase-let ((`(,file-path ,titles ,tags) row))
         (let ((titles (or titles (list (org-roam--path-to-slug file-path)))))
           (dolist (title titles)
@@ -597,8 +597,7 @@ plist containing the path to the file, and the original title."
                         (format "(%s) " (s-join org-roam-tag-separator tags)))
                       title))
                   (v (list :path file-path :title title)))
-              (push (cons k v) completions))))))
-    completions))
+              (push (cons k v) completions))))))))
 
 (defun org-roam-find-file (&optional initial-prompt completions filter-fn)
   "Find and open an Org-roam file.

--- a/org-roam.el
+++ b/org-roam.el
@@ -701,7 +701,7 @@ included as a candidate."
         (include-type (and interactive
                            org-roam-include-type-in-ref-path-completions))
         completions)
-    (dolist (row rows)
+    (dolist (row rows completions)
       (pcase-let ((`(,type ,ref ,file-path) row))
         (when (pcase filter
                 ('nil t)
@@ -715,8 +715,7 @@ included as a candidate."
                       (format "(%s) " type))
                     ref))
                 (v (list :path file-path :type type :ref ref)))
-            (push (cons k v) completions)))))
-    completions))
+            (push (cons k v) completions)))))))
 
 (defun org-roam--find-ref (ref)
   "Find and open and Org-roam file from REF if it exists.

--- a/org-roam.el
+++ b/org-roam.el
@@ -587,7 +587,7 @@ plist containing the path to the file, and the original title."
   (let* ((rows (org-roam-db-query [:select [titles:file titles:titles tags:tags] :from titles
                                    :left :join tags
                                    :on (= titles:file tags:file)]))
-         res)
+         completions)
     (dolist (row rows)
       (pcase-let ((`(,file-path ,titles ,tags) row))
         (let ((titles (or titles (list (org-roam--path-to-slug file-path)))))
@@ -597,8 +597,8 @@ plist containing the path to the file, and the original title."
                         (format "(%s) " (s-join org-roam-tag-separator tags)))
                       title))
                   (v (list :path file-path :title title)))
-              (push (cons k v) res))))))
-    res))
+              (push (cons k v) completions))))))
+    completions))
 
 (defun org-roam-find-file (&optional initial-prompt completions filter-fn)
   "Find and open an Org-roam file.
@@ -701,7 +701,7 @@ included as a candidate."
   (let ((rows (org-roam-db-query [:select [type ref file] :from refs]))
         (include-type (and interactive
                            org-roam-include-type-in-ref-path-completions))
-        res)
+        completions)
     (dolist (row rows)
       (pcase-let ((`(,type ,ref ,file-path) row))
         (when (pcase filter
@@ -716,8 +716,8 @@ included as a candidate."
                       (format "(%s) " type))
                     ref))
                 (v (list :path file-path :type type :ref ref)))
-            (push (cons k v) res)))))
-    res))
+            (push (cons k v) completions)))))
+    completions))
 
 (defun org-roam--find-ref (ref)
   "Find and open and Org-roam file from REF if it exists.


### PR DESCRIPTION
###### Motivation for this change

Initially we thought that using hash-tables would shave some seconds
because searching for a key is O(1), but when we present completions, we
typically want them sorted, and hash-tables do not support sorted keys.

