### PR TITLE
(feature): org-roam-diagnostics command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,8 +36,8 @@ Example:
 
 <!-- Example: File A is missing -->
 
-### Versions
+### Environment
 
-- Emacs (Paste `M-x emacs-version` output here) 
-- Org   (Paste `M-x org-version` output here) 
+<!-- Please M-x org-roam-diagnostics and paste results here -->
+
 - Org-roam commit: https://github.com/jethrokuan/org-roam/commit/commithashhere

--- a/org-roam.el
+++ b/org-roam.el
@@ -1019,6 +1019,7 @@ Otherwise, behave as if called interactively."
           (org-roam-db--update-file file-from)))
       (org-roam-db--update-file new-path))))
 
+;;;; Diagnostics
 ;;;###autoload
 (defun org-roam-version (&optional message)
   "Return `org-roam' version.
@@ -1034,6 +1035,22 @@ Interactively, or when MESSAGE is non-nil, show in the echo area."
     (if (or message (called-interactively-p 'interactive))
         (message "%s" version)
       version)))
+
+;;;###autoload
+(defun org-roam-diagnostics ()
+  "Collect and print info for `org-roam' issues."
+  (interactive)
+  (with-current-buffer (switch-to-buffer-other-window (get-buffer-create "*org-roam diagnostics*"))
+    (erase-buffer)
+    (insert (propertize "Copy info below this line into issue:\n" 'face '(:weight bold)))
+    (insert (format "- Emacs: %s\n" (emacs-version)))
+    (insert (format "- Framework: %s\n"
+                    (condition-case _
+                        (completing-read "I'm using the following Emacs framework:"
+                                         '("Doom" "Spacemacs" "N/A" "I don't know"))
+                      (quit "N/A"))))
+    (insert (format "- Org: %s\n" (org-version nil 'full)))
+    (insert (format "- Org-roam: %s" (org-roam-version)))))
 
 (provide 'org-roam)
 ;;; org-roam.el ends here


### PR DESCRIPTION
Automates collection of user environment information.

###### Motivation for this change
An idea I had to help users provide us with useful debugging information.
Right now it just grabs `emacs-version`, the full `org-version` and prompts whether or not they are using a framework like Doom or Spacemacs. 

We might be able to grab org-roam git hash programatically as well, but I left that out for now.
Could easily be expanded to include more info  if needed.

Good idea?