### PR TITLE
(fix): Require seq.el

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -42,6 +42,7 @@
 (require 's)
 (require 'f)
 (require 'cl-lib)
+(require 'seq)
 
 ;;;; org-roam features
 (require 'org-roam-compat)


### PR DESCRIPTION
seq.el is is not guaranteed to be loaded otherwise.
