### PR TITLE
(fix): prevent org-roam-version from loading org-roam-dev

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1026,13 +1026,14 @@ Otherwise, behave as if called interactively."
   "Return `org-roam' version.
 Interactively, or when MESSAGE is non-nil, show in the echo area."
   (interactive)
-  (let ((version (with-current-buffer (find-file-noselect (locate-library "org-roam.el"))
-                   (save-excursion
-                     (save-match-data
-                       (goto-char (point-min))
-                       (if (re-search-forward "\\(?:;; Version: \\([^z-a]*?$\\)\\)" nil nil)
-                           (substring-no-properties (match-string 1))
-                         "N/A"))))))
+  (let* ((version
+          (with-temp-buffer
+            (insert-file-contents-literally (locate-library "org-roam.el"))
+            (goto-char (point-min))
+            (save-match-data
+              (if (re-search-forward "\\(?:;; Version: \\([^z-a]*?$\\)\\)" nil nil)
+                  (substring-no-properties (match-string 1))
+                "N/A")))))
     (if (or message (called-interactively-p 'interactive))
         (message "%s" version)
       version)))


### PR DESCRIPTION
Instead of visiting file, insert library into temp buffer.
Prevents loading .dir-local dev environment, accompanying unsafe-variable prompt.
Prevents interference with org-roam.el if already open.
