### PR TITLE
Update org-roam-bibtex link in docs

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -927,7 +927,7 @@ etc.) within Org-mode.
     :CUSTOM_ID: bibliography
     :END:
 
-[[https://github.com/zaeph/org-roam-bibtex][org-roam-bibtex]] offers
+[[https://github.com/org-roam/org-roam-bibtex][org-roam-bibtex]] offers
 tight integration between
 [[https://github.com/jkitchin/org-ref][org-ref]],
 [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]] and


### PR DESCRIPTION
This should point to the official repo, not a fork (right?)
