### PR TITLE
(fix): org-roam-graph--build notify user when build starts

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -233,6 +233,7 @@ CALLBACK is passed the graph file as its sole argument."
          (graph      (org-roam-graph--dot node-query))
          (temp-dot   (make-temp-file "graph." nil ".dot" graph))
          (temp-graph (make-temp-file "graph." nil ".svg")))
+    (org-roam-message "building graph")
     (make-process
      :name "*org-roam-graph--build-process*"
      :buffer "*org-roam-graph--build-process*"


### PR DESCRIPTION
Displays a message to user to let them know the build (which may take
a variable amount of time) has started.

###### Motivation for this change
#666