### PR TITLE
(fix): set default org-roam-list-files-commands for windows to nil

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -126,7 +126,10 @@ Formatter may be a function that takes title as its only argument."
           (function :tag "Custom function"))
   :group 'org-roam)
 
-(defcustom org-roam-list-files-commands '(find rg)
+(defcustom org-roam-list-files-commands
+  (if (member system-type '(windows-nt ms-dos cygwin))
+      nil
+    '(find rg))
   "Commands that will be used to find Org-roam files.
 
 It should be a list of symbols or cons cells representing any of the following


### PR DESCRIPTION
###### Motivation for this change

The new 'find and 'rg methods for obtaining the list of org-roam files aren't working well for Windows, so for Windows users, we fall-back to the elisp implementation.