### PR TITLE
(internal): use emacsql-sqlite3 everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.2 (TBD)
+
+### Breaking Changes
+
+- [#701](https://github.com/org-roam/org-roam/pull/701) Use `emacsql-sqlite3` instead of `emacsql-sqlite` for better Windows compatibility. This requires the presence of the standard `sqlite3` binary on your machine.
+
 ## 1.1.1 (18-05-2020)
 
 In this release, we added two new features:

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -55,9 +55,11 @@ Org-roam provides several benefits over other tooling:
 - Free and Open Source :: Org-roam is free and open-source, which means that if you feel unhappy with any part of Org-roam, you may choose to extend Org-roam, or open a PR.
 - Leverages the Org-mode ecosystem :: Over the years, Emacs and Org-mode has developed into a mature system for plain-text organization. Building upon Org-mode already puts Org-roam light-years ahead of many other solutions.
 - Built on Emacs :: Emacs is also a fantastic interface for editing text, and we can inherit many of the powerful text-navigation and editing packages available to Emacs.
+
 * Installation
-** _ :ignore:
-Org-roam can be installed using Emacs' package manager or manually from its development repository.
+
+Org-roam can be installed using Emacs' package manager or manually from its
+development repository.
 
 ** Installing from MELPA
 
@@ -97,7 +99,15 @@ Now see [[*Post-Installation Tasks][Post-Installation Tasks]].
 
 ** TODO Installing from the Git Repository
 
-** TODO Post-Installation Tasks
+** Post-Installation Tasks
+
+Org-roam uses ~emacsql-sqlite3~, which requires ~sqlite3~ to be located on
+~exec-path~. Please ensure that ~sqlite3~ is installed appropriately on your
+operating system. You can verify that this is the case by executing:
+
+#+BEGIN_SRC emacs-lisp
+  (executable-find "sqlite3")
+#+END_SRC
 
 * Getting Started
 

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -78,14 +78,13 @@ General Public License for more details.
 * Diagnosing and Repairing Files::
 * Appendix::
 * FAQ::
-* _: _ (2). 
+* _: _ (1). 
 
 @detailmenu
 --- The Detailed Node Listing ---
 
 Installation
 
-* _::
 * Installing from MELPA::
 * Installing from the Git Repository::
 * Post-Installation Tasks::
@@ -119,7 +118,7 @@ Graphing
 
 Roam Protocol
 
-* _: _ (1). 
+* _::
 * Installation: Installation (1). 
 * The @samp{roam-file} protocol::
 * The @samp{roam-ref} Protocol::
@@ -179,17 +178,14 @@ Emacs is also a fantastic interface for editing text, and we can inherit many of
 @node Installation
 @chapter Installation
 
+Org-roam can be installed using Emacs' package manager or manually from its
+development repository.
+
 @menu
-* _::
 * Installing from MELPA::
 * Installing from the Git Repository::
 * Post-Installation Tasks::
 @end menu
-
-@node _
-@section _ :ignore:
-
-Org-roam can be installed using Emacs' package manager or manually from its development repository.
 
 @node Installing from MELPA
 @section Installing from MELPA
@@ -238,7 +234,15 @@ Now see @ref{Post-Installation Tasks}.
 @section @strong{TODO} Installing from the Git Repository
 
 @node Post-Installation Tasks
-@section @strong{TODO} Post-Installation Tasks
+@section Post-Installation Tasks
+
+Org-roam uses @code{emacsql-sqlite3}, which requires @code{sqlite3} to be located on
+@code{exec-path}. Please ensure that @code{sqlite3} is installed appropriately on your
+operating system. You can verify that this is the case by executing:
+
+@lisp
+(executable-find "sqlite3")
+@end lisp
 
 @node Getting Started
 @chapter Getting Started
@@ -840,13 +844,13 @@ Other options include @samp{'ido}, and @samp{'ivy}.
 @chapter Roam Protocol
 
 @menu
-* _: _ (1). 
+* _::
 * Installation: Installation (1). 
 * The @samp{roam-file} protocol::
 * The @samp{roam-ref} Protocol::
 @end menu
 
-@node _ (1)
+@node _
 @section _ :ignore:
 
 Org-roam extending @samp{org-protocol} with 2 protocols: the @samp{roam-file}
@@ -1238,7 +1242,7 @@ etc.) within Org-mode.
 @node Bibliography
 @unnumberedsubsubsec Bibliography
 
-@uref{https://github.com/zaeph/org-roam-bibtex, org-roam-bibtex} offers
+@uref{https://github.com/org-roam/org-roam-bibtex, org-roam-bibtex} offers
 tight integration between
 @uref{https://github.com/jkitchin/org-ref, org-ref},
 @uref{https://github.com/tmalsburg/helm-bibtex, helm-bibtex} and
@@ -1280,7 +1284,7 @@ All files within that directory will be treated as their own separate
 set of Org-roam files. Remember to run @samp{org-roam-db-build-cache} from a
 file within that directory, at least once.
 
-@node _ (2)
+@node _ (1)
 @chapter _ :ignore:
 
 Emacs 28.0.50 (Org mode 9.4)

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-completion.el
+++ b/org-roam-completion.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -33,7 +33,7 @@
 ;;;; Library Requires
 (eval-when-compile (require 'subr-x))
 (require 'emacsql)
-(require 'emacsql-sqlite)
+(require 'emacsql-sqlite3)
 (require 'org-roam-macs)
 
 (defvar org-roam-directory)
@@ -58,10 +58,6 @@ when used with multiple Org-roam instances."
   :group 'org-roam)
 
 (defconst org-roam-db--version 5)
-(defconst org-roam-db--sqlite-available-p
-  (with-demoted-errors "Org-roam initialization: %S"
-    (emacsql-sqlite-ensure-binary)
-    t))
 
 (defvar org-roam-db--connection (make-hash-table :test #'equal)
   "Database connection to Org-roam database.")
@@ -87,7 +83,7 @@ Performs a database upgrade when required."
     (let* ((db-file (org-roam-db--get))
            (init-db (not (file-exists-p db-file))))
       (make-directory (file-name-directory db-file) t)
-      (let ((conn (emacsql-sqlite db-file)))
+      (let ((conn (emacsql-sqlite3 db-file)))
         (set-process-query-on-exit-flag (emacsql-process conn) nil)
         (puthash (file-truename org-roam-directory)
                  conn

--- a/org-roam-dev.el
+++ b/org-roam-dev.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/jethrokuan/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.1.1
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite "1.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
###### Motivation for this change

Emacsql-sqlite3 seems to work better for Windows, and has no effect for Linux users.

This is to address #682 .