### PR TITLE
(fix): org-roam-db-build-cache filter non-file input

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -34,6 +34,7 @@
 (eval-when-compile (require 'subr-x))
 (require 'emacsql)
 (require 'emacsql-sqlite3)
+(require 'seq)
 (require 'org-roam-macs)
 
 (defvar org-roam-directory)
@@ -379,7 +380,7 @@ If FORCE, force a rebuild of the cache from scratch."
   (when force (delete-file (org-roam-db--get)))
   (org-roam-db--close) ;; Force a reconnect
   (org-roam-db) ;; To initialize the database, no-op if already initialized
-  (let* ((org-roam-files (org-roam--list-all-files))
+  (let* ((org-roam-files (seq-filter #'org-roam--org-roam-file-p (org-roam--list-all-files)))
          (current-files (org-roam-db--get-current-files))
          all-files all-links all-titles all-refs all-tags)
     (dolist (file org-roam-files)


### PR DESCRIPTION
If a shell command is used to find files, it may include
output from another command.

see: #706, #688


