### PR TITLE
(fix): fix support for Emacs 26 built-in org

### DIFF
--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -80,6 +80,9 @@
 (define-obsolete-function-alias 'org-roam-db--maybe-update 'org-roam-db--update-maybe
   "org-roam 1.1.0")
 
+(when (version< (org-version) "9.3")
+  (defalias 'org-link-make-string 'org-make-link-string))
+
 ;;;; Variables
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options
   'org-roam-graph-extra-config "org-roam 1.0.0")


### PR DESCRIPTION
`org-link-make-string` is not defined until org version `9.3`. Emacs 26 ships with org `9.1`, so this function is undefined if the user is using the built-in org version. Backporting this function to support Emacs 26, Since that is the minimum supported version.

