### PR TITLE
(fix): autoloaded commands load org-roam-mode

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -41,12 +41,14 @@
 (defvar org-roam-backlinks-mode)
 (defvar org-roam-last-window)
 (defvar org-ref-cite-types) ;; in org-ref-core.el
+(defvar org-roam-mode)
 
 (declare-function org-roam-db--ensure-built   "org-roam-db")
 (declare-function org-roam--extract-ref       "org-roam")
 (declare-function org-roam--get-title-or-slug "org-roam")
 (declare-function org-roam--get-backlinks     "org-roam")
 (declare-function org-roam-backlinks-mode     "org-roam")
+(declare-function org-roam-mode               "org-roam")
 
 (defcustom org-roam-buffer-position 'right
   "Position of `org-roam' buffer.
@@ -266,6 +268,7 @@ Valid states are 'visible, 'exists and 'none."
 (defun org-roam-buffer-toggle-display ()
   "Toggle display of the `org-roam-buffer'."
   (interactive)
+  (unless org-roam-mode (org-roam-mode))
   (setq org-roam-last-window (get-buffer-window))
   (pcase (org-roam-buffer--visibility)
     ('visible (delete-window (get-buffer-window org-roam-buffer)))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -38,11 +38,13 @@
 ;; Declarations
 (defvar org-roam-encrypt-files)
 (defvar org-roam-directory)
+(defvar org-roam-mode)
 (declare-function  org-roam--get-title-path-completions "org-roam")
 (declare-function  org-roam--get-ref-path-completions   "org-roam")
 (declare-function  org-roam--file-path-from-id          "org-roam")
 (declare-function  org-roam--format-link                "org-roam")
 (declare-function  org-roam--title-to-slug              "org-roam")
+(declare-function  org-roam-mode                        "org-roam")
 (declare-function  org-roam-completion--completing-read "org-roam-completion")
 
 (defvar org-roam-capture--file-name-default "%<%Y%m%d%H%M%S>"
@@ -330,6 +332,7 @@ GOTO and KEYS argument have the same functionality as
   "Launches an `org-capture' process for a new or existing note.
 This uses the templates defined at `org-roam-capture-templates'."
   (interactive)
+  (unless org-roam-mode (org-roam-mode))
   (when (org-roam-capture--in-process-p)
     (user-error "Nested Org-roam capture processes not supported"))
   (let* ((completions (org-roam--get-title-path-completions))

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -45,7 +45,9 @@
   "Capture templates for daily notes in Org-roam.")
 
 ;; Declarations
+(defvar org-roam-mode)
 (declare-function org-roam--file-path-from-id "org-roam")
+(declare-function org-roam-mode               "org-roam")
 
 (defun org-roam-dailies--file-for-time (time)
   "Create and find file for TIME."
@@ -59,18 +61,21 @@
 (defun org-roam-dailies-today ()
   "Create and find the daily note for today."
   (interactive)
+  (unless org-roam-mode (org-roam-mode))
   (org-roam-dailies--file-for-time (current-time)))
 
 (defun org-roam-dailies-tomorrow (n)
   "Create and find the daily note for tomorrow.
 With numeric argument N, use N days in the future."
   (interactive "p")
+  (unless org-roam-mode (org-roam-mode))
   (org-roam-dailies--file-for-time (time-add (* n 86400) (current-time))))
 
 (defun org-roam-dailies-yesterday (n)
   "Create and find the file for yesterday.
 With numeric argument N, use N days in the past."
   (interactive "p")
+  (unless org-roam-mode (org-roam-mode))
   (org-roam-dailies-tomorrow (- n)))
 
 (defun org-roam-dailies-date ()

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -53,8 +53,10 @@
 (declare-function org-roam--org-roam-file-p "org-roam")
 (declare-function org-roam--parse-tags "org-roam")
 (declare-function org-roam--parse-alias "org-roam")
+(declare-function org-roam-mode "org-roam")
 
 (defvar org-roam-verbose)
+(defvar org-roam-mode)
 
 (cl-defstruct (org-roam-doctor-checker (:copier nil))
   (name 'missing-checker-name)
@@ -280,6 +282,7 @@ CHECKER is a org-roam-doctor checker instance."
   "Perform a check on the current buffer to ensure cleanliness.
 If CHECKALL, run the check for all Org-roam files."
   (interactive "P")
+  (unless org-roam-mode (org-roam-mode))
   (let ((files (if checkall
                   (org-roam--list-all-files)
                 (unless (org-roam--org-roam-file-p)

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -37,8 +37,10 @@
 
 ;;;; Declarations
 (defvar org-roam-directory)
+(defvar org-roam-mode)
 (declare-function org-roam--org-roam-file-p  "org-roam")
 (declare-function org-roam--path-to-slug     "org-roam")
+(declare-function org-roam-mode              "org-roam")
 
 ;;;; Options
 (defcustom org-roam-graph-viewer (executable-find "firefox")
@@ -283,6 +285,7 @@ ARG may be any of the following values:
   - `\\[universal-argument]' -   build the graph for FILE.
   - `\\[universal-argument]' -N  build the graph for FILE limiting nodes to N steps."
   (interactive "P")
+  (unless org-roam-mode (org-roam-mode))
   (let ((file (or file (buffer-file-name (buffer-base-buffer)))))
     (unless (or (not arg) (equal arg '(16)))
       (unless file

--- a/org-roam.el
+++ b/org-roam.el
@@ -1051,6 +1051,7 @@ FILTER-FN is the name of a function to apply on the candidates
 which takes as its argument an alist of path-completions.  See
 `org-roam--get-title-path-completions' for details."
   (interactive)
+  (unless org-roam-mode (org-roam-mode))
   (when (org-roam-capture--in-process-p) (user-error "Org-roam capture in process"))
   (let* ((completions (funcall (or filter-fn #'identity)
                                (or completions (org-roam--get-title-path-completions))))
@@ -1086,6 +1087,7 @@ takes three arguments: the type, the ref, and the file of the
 current candidate.  It should return t if that candidate is to be
 included as a candidate."
   (interactive "p")
+  (unless org-roam-mode (org-roam-mode))
   (let* ((completions (org-roam--get-ref-path-completions arg filter))
          (ref (org-roam-completion--completing-read "Ref: "
                                                     completions
@@ -1105,6 +1107,7 @@ which takes as its argument an alist of path-completions.
 If DESCRIPTION is provided, use this as the link label.  See
 `org-roam--get-title-path-completions' for details."
   (interactive "P")
+  (unless org-roam-mode (org-roam-mode))
   (let* ((region (and (region-active-p)
                       ;; following may lose active region, so save it
                       (cons (region-beginning) (region-end))))
@@ -1151,6 +1154,7 @@ Otherwise, the function will look in your `org-roam-directory'
 for a note whose title is 'Index'.  If it does not exist, the
 command will offer you to create one."
   (interactive)
+  (unless org-roam-mode (org-roam-mode))
   (let ((index (org-roam--get-index-path)))
     (if (and index
              (file-exists-p index))


### PR DESCRIPTION
Users should not have to explicitly enable the minor mode before using
autoloaded commands.

###### Motivation for this change
see #446,  #116 and I'm sure others.
I have hit this issue myself on occasion.