### PR TITLE
(internal): Exclude org-roam-compat.el from linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,11 @@ jobs:
     # The "all" rule is not used, because it treats compilation warnings
     # as failures, so linting and testing are run as separate steps.
 
+    # org-roam-compat is excluded from linting because it contains
+    # symbols/aliases from other packages
     - name: Lint
       continue-on-error: false
-      run: ./makem.sh -vv --sandbox $SANDBOX_DIR lint
+      run: ./makem.sh -vv --sandbox $SANDBOX_DIR --exclude org-roam-compat.el lint
 
     - name: Test
       if: always()  # Run test even if linting fails.


### PR DESCRIPTION
org-roam-compat.el may contain symbols that belong to other packages.
e.g. functions backported to older versions of Org mode.

###### Motivation for this change
see #711