### PR TITLE
Properties in org-mode are case insensitive

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -369,7 +369,8 @@ The search terminates when the first property is encountered."
     (dolist (prop props)
       (let ((p (org-element-map buf 'keyword
                  (lambda (kw)
-                   (when (string= (org-element-property :key kw) prop)
+                   (when (string-collate-equalp
+                          (org-element-property :key kw) prop nil t)
                      (org-element-property :value kw)))
                  :first-match t)))
         (push (cons prop p) res)))


### PR DESCRIPTION

###### Motivation for this change

This change allows lowercase properties such as "#+title:" and "#+roam_ref:" for those of us who think it looks better.

If this change warrants an update to the changelog please let me know and I'll do that.