### PR TITLE
(fix): org-roam--list-files: canonicalize filenames

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -380,7 +380,7 @@ If FORCE, force a rebuild of the cache from scratch."
   (when force (delete-file (org-roam-db--get)))
   (org-roam-db--close) ;; Force a reconnect
   (org-roam-db) ;; To initialize the database, no-op if already initialized
-  (let* ((org-roam-files (seq-filter #'org-roam--org-roam-file-p (org-roam--list-all-files)))
+  (let* ((org-roam-files (org-roam--list-all-files))
          (current-files (org-roam-db--get-current-files))
          all-files all-links all-titles all-refs all-tags)
     (dolist (file org-roam-files)


### PR DESCRIPTION
###### Motivation for this change

Paths with double slashes are causing trouble for some users. We canonicalize the file-names using elisp so it's more robust (at the risk of being slightly slower).

Fixes #724 , #732 