### PR TITLE
Make a regexp more intelligible

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -234,8 +234,17 @@ space-delimited strings.
   "Last window `org-roam' was called from.")
 
 (defvar org-roam--org-link-file-bracket-re
-  "\\[\\[file:\\(\\(?:[^][\\]\\|\\\\\\(?:\\\\\\\\\\)*[][]\\|\\\\+[^][]\\)+\\)]\\(?:\\[\\(\\(?:.\\|
-\\)+?\\)]\\)?]"
+  (rx "[[file:" (seq (group (one-or-more (or (not (any "]" "[" "\\"))
+                                             (seq "\\"
+                                                  (zero-or-more "\\\\")
+                                                  (any "[" "]"))
+                                             (seq (one-or-more "\\")
+                                                  (not (any "]" "["))))))
+                     "]"
+                     (zero-or-one (seq "["
+                                       (group (+? anything))
+                                       "]"))
+                     "]"))
   "Matches a 'file:' link in double brackets.")
 
 ;;;; Utilities


### PR DESCRIPTION
###### Motivation for this change
I found a regex very hard to read, so I translated it to rx form.

The only test I have done on this code is evaluating:

```
(equal "\\[\\[file:\\(\\(?:[^][\\]\\|\\\\\\(?:\\\\\\\\\\)*[][]\\|\\\\+[^][]\\)+\\)]\\(?:\\[\\(\\(?:.\\|
\\)+?\\)]\\)?]"
       (rx "[[file:" (seq (group (one-or-more (or (not (any "]" "[" "\\"))
                                             (seq "\\"
                                                  (zero-or-more "\\\\")
                                                  (any "[" "]"))
                                             (seq (one-or-more "\\")
                                                  (not (any "]" "["))))))
                     "]"
                     (zero-or-one (seq "["
                                       (group (+? anything))
                                       "]"))
                     "]")))

```

But I think that should be sufficient.
