### PR TITLE
(feat): add org-roam-buffer-window-parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 - [#701](https://github.com/org-roam/org-roam/pull/701) Use `emacsql-sqlite3` instead of `emacsql-sqlite` for better Windows compatibility. This requires the presence of the standard `sqlite3` binary on your machine.
+- [#750](https://github.com/org-roam/org-roam/pull/750) Deprecate `org-roam-buffer-no-delete-other-windows` in favour of `org-roam-buffer-window-parameters`.
 
 ## 1.1.1 (18-05-2020)
 

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -88,10 +88,10 @@ Has an effect if and only if `org-roam-buffer-position' is `top' or `bottom'."
   :type 'hook
   :group 'org-roam)
 
-(defcustom org-roam-buffer-no-delete-other-windows nil
-  "The `no-delete-other-windows' parameter of the `org-roam-buffer' window.
-When non-nil, the window will not be closed when deleting other windows."
-  :type 'boolean
+(defcustom org-roam-buffer-window-parameters nil
+  "Additional window parameters for the `org-roam-buffer' side window.
+For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
+  :type '(alist)
   :group 'org-roam)
 
 (defvar org-roam-buffer--current nil
@@ -251,17 +251,12 @@ Valid states are 'visible, 'exists and 'none."
              (lwarn '(org-roam) :error
                     "Invalid org-roam-buffer-position: %s. Defaulting to \\='right"
                     org-roam-buffer-position))
-           'right))
-        (params
-         (list
-          (cons 'no-other-window org-roam-buffer-no-delete-other-windows)
-          (cons 'no-delete-other-windows org-roam-buffer-no-delete-other-windows))))
+           'right)))
     (save-selected-window
       (-> (get-buffer-create org-roam-buffer)
           (display-buffer-in-side-window
-           (list
-            (cons 'side position)
-            (cons 'window-parameters params)))
+           `((side . ,position)
+             (window-parameters . org-roam-buffer-window-parameters)))
           (select-window))
       (pcase position
         ((or 'right 'left)

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -84,6 +84,8 @@
   (defalias 'org-link-make-string 'org-make-link-string))
 
 ;;;; Variables
+(define-obsolete-variable-alias 'org-roam-buffer-no-delete-other-windows
+  'org-roam-buffer-window-parameters "org-roam 1.1.1")
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options
   'org-roam-graph-extra-config "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam-grapher-extra-options


### PR DESCRIPTION
###### Motivation for this change

The variable `org-roam-buffer-window-parameters` gives one more
flexibility in customizing the org-roam-buffer window parameters.
`org-roam-buffer-no-delete-other-windows` is deprecated in favour of
this.