### PR TITLE
(feat): make roam properties case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - [#701](https://github.com/org-roam/org-roam/pull/701) Use `emacsql-sqlite3` instead of `emacsql-sqlite` for better Windows compatibility. This requires the presence of the standard `sqlite3` binary on your machine.
 - [#750](https://github.com/org-roam/org-roam/pull/750) Deprecate `org-roam-buffer-no-delete-other-windows` in favour of `org-roam-buffer-window-parameters`.
 
+### Features
+
+- [#757](https://github.com/org-roam/org-roam/pull/757) Roam global properties are now case-insensitive
+
 ## 1.1.1 (18-05-2020)
 
 In this release, we added two new features:

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -94,7 +94,7 @@ AST is the org-element parse tree."
     (org-element-map ast 'keyword
       (lambda (kw)
         (let ((key (org-element-property :key kw)))
-          (when (and (string-prefix-p "ROAM_" key)
+          (when (and (string-prefix-p "ROAM_" key t)
                      (not (member key org-roam-doctor--supported-roam-properties)))
             (push
              `(,(org-element-property :begin kw)

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -111,7 +111,7 @@ AST is the org-element parse tree."
   (let (reports)
     (org-element-map ast 'keyword
       (lambda (kw)
-        (when (string= (org-element-property :key kw) "ROAM_TAGS")
+        (when (string-collate-equalp (org-element-property :key kw) "ROAM_TAGS" nil t)
           (let* ((s (org-element-property :value kw))
                      (tags (org-roam--parse-tags s))
                      (bad-tags (-remove #'stringp tags)))
@@ -131,7 +131,7 @@ AST is the org-element parse tree."
   (let (reports)
     (org-element-map ast 'keyword
       (lambda (kw)
-        (when (string= (org-element-property :key kw) "ROAM_ALIAS")
+        (when (string-collate-equalp (org-element-property :key kw) "ROAM_ALIAS" nil t)
           (let* ((s (org-element-property :value kw))
                      (aliases (org-roam--parse-alias s))
                      (bad-aliases (-remove #'stringp aliases)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -441,7 +441,7 @@ The search terminates when the first property is encountered."
     (dolist (prop props)
       (let ((p (org-element-map buf 'keyword
                  (lambda (kw)
-                   (when (string= (org-element-property :key kw) prop)
+                   (when (string-collate-equalp (org-element-property :key kw) prop nil t)
                      (org-element-property :value kw)))
                  :first-match t)))
         (push (cons prop p) res)))


### PR DESCRIPTION
###### Motivation for this change

Roam properties such as `ROAM_KEY` are now case-sensitive. This change makes it
case-insensitive, for people who prefer it that way. Supercedes #730.