### PR TITLE
(fix): remove alias for org-roam-buffer-no-delete-other-windows

### DIFF
--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -84,8 +84,6 @@
   (defalias 'org-link-make-string 'org-make-link-string))
 
 ;;;; Variables
-(define-obsolete-variable-alias 'org-roam-buffer-no-delete-other-windows
-  'org-roam-buffer-window-parameters "org-roam 1.1.1")
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options
   'org-roam-graph-extra-config "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam-grapher-extra-options
@@ -100,6 +98,8 @@
   'org-roam-dailies-capture-templates "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam-date-filename-format
   'org-roam-dailies-capture-templates "org-roam 1.0.0")
+(make-obsolete-variable 'org-roam-buffer-no-delete-other-windows
+  'org-roam-buffer-window-parameters "org-roam 1.1.1")
 
 (provide 'org-roam-compat)
 


### PR DESCRIPTION
###### Motivation for this change
This variable is made obsolete, and replaced with
`org-roam-buffer-window-parameters`, but their shape are different and
cannot be used interchangeably.