### PR TITLE
(fix): fix bad behaviour on malformed properties

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -39,6 +39,7 @@
 
 (defvar org-roam-directory)
 (defvar org-roam-verbose)
+(defvar org-roam-file-name)
 
 (declare-function org-roam--org-roam-file-p                "org-roam")
 (declare-function org-roam--extract-titles                 "org-roam")
@@ -387,8 +388,7 @@ If FORCE, force a rebuild of the cache from scratch."
       (let* ((attr (file-attributes file))
              (atime (file-attribute-access-time attr))
              (mtime (file-attribute-modification-time attr)))
-        (org-roam--with-temp-buffer
-          (insert-file-contents file)
+        (org-roam--with-temp-buffer file
           (let ((contents-hash (secure-hash 'sha1 (current-buffer))))
             (unless (string= (gethash file current-files)
                              contents-hash)

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -165,7 +165,7 @@ The Org-roam database titles table is read, to obtain the list of titles.
 The links table is then read to obtain all directed links, and formatted
 into a digraph."
   (org-roam-db--ensure-built)
-  (org-roam--with-temp-buffer
+  (org-roam--with-temp-buffer nil
     (let* ((nodes (org-roam-db-query node-query))
            (edges-query
             `[:with selected :as [:select [file] :from ,node-query]

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -36,14 +36,18 @@
 
 (defvar org-roam-verbose)
 
-(defmacro org-roam--with-temp-buffer (&rest body)
+(defmacro org-roam--with-temp-buffer (file &rest body)
   "Execute BODY within a temp buffer.
-Like `with-temp-buffer', but propagates `org-roam-directory'."
-  (declare (indent 0) (debug t))
+Like `with-temp-buffer', but propagates `org-roam-directory'.
+If FILE, set `org-roam-temp-file-name' to file and insert its contents."
+  (declare (indent 1) (debug t))
   (let ((current-org-roam-directory (make-symbol "current-org-roam-directory")))
     `(let ((,current-org-roam-directory org-roam-directory))
        (with-temp-buffer
          (let ((org-roam-directory ,current-org-roam-directory))
+           (when ,file
+             (insert-file-contents ,file)
+             (setq-local org-roam-file-name ,file))
            ,@body)))))
 
 (defmacro org-roam--with-template-error (templates &rest body)


### PR DESCRIPTION
Org-roam now skips over bad properties and throws a warning for the
given file that contains a malformed property. This allows most of the
database rebuild to complete, and for the user to fix the offending
file.

![image](https://user-images.githubusercontent.com/1667473/83939550-7854fc00-a810-11ea-8d04-956ebaf9de9f.png)

Fixes #728.
