### PR TITLE
(internal): parse AST once

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -277,8 +277,8 @@ is used in place of the titles for completions.
 
 If you wish to add your own title extraction method, you may push a symbol
 ='foo= into =org-roam-title-sources=, and define a
-=org-roam--extract-titles-foo= which accepts no arguments. See
-=org-roam--extract-titles-title= for an example.
+=org-roam--extract-titles-foo= which accepts the AST of the current buffer as
+argument. See =org-roam--extract-titles-title= for an example.
 
 ** Tags
 
@@ -307,8 +307,8 @@ extraction methods, you may modify =org-roam-tag-sources=:
 
 If you wish to add your own tag extraction method, you may push a symbol ='foo=
 into =org-roam-tag-sources=, and define a =org-roam--extract-tags-foo= which
-accepts the absolute file path as its argument. See
-=org-roam--extract-tags-prop= for an example.
+accepts the absolute file path, and the AST of the current buffer as its
+argument. See =org-roam--extract-tags-prop= for an example.
 
 ** File Refs
 

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -23,7 +23,7 @@ General Public License for more details.
 @end quotation
 @end copying
 
-@dircategory emacs
+@dircategory Emacs
 @direntry
 * Org-roam: (org-roam). Rudimentary Roam Replica for Emacs.
 @end direntry
@@ -433,8 +433,8 @@ is used in place of the titles for completions.
 
 If you wish to add your own title extraction method, you may push a symbol
 @samp{'foo} into @samp{org-roam-title-sources}, and define a
-@samp{org-roam--extract-titles-foo} which accepts no arguments. See
-@samp{org-roam--extract-titles-title} for an example.
+@samp{org-roam--extract-titles-foo} which accepts the AST of the current buffer as
+argument. See @samp{org-roam--extract-titles-title} for an example.
 
 @node Tags
 @section Tags
@@ -469,8 +469,8 @@ extraction methods, you may modify @samp{org-roam-tag-sources}:
 
 If you wish to add your own tag extraction method, you may push a symbol @samp{'foo}
 into @samp{org-roam-tag-sources}, and define a @samp{org-roam--extract-tags-foo} which
-accepts the absolute file path as its argument. See
-@samp{org-roam--extract-tags-prop} for an example.
+accepts the absolute file path, and the AST of the current buffer as its
+argument. See @samp{org-roam--extract-tags-prop} for an example.
 
 @node File Refs
 @section File Refs


### PR DESCRIPTION
Parse the buffer once to obtain AST, to be used in downstream functions.

This makes Org-roam more performant, but the functions get ugly.

Another idea is to store the currently required AST in a global variable so they
don't have to be passed around as arguments, but this is another surface area
for bugs (maybe a macro `with-ast`, not sure)