### PR TITLE
(UX): Add more meaningful error message for sqlite3 

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -164,6 +164,15 @@ operating system. You can verify that this is the case by executing:
   (executable-find "sqlite3")
 #+END_SRC
 
+If you have ~sqlite3~ installed, and ~executable-find~ still reports ~nil~, then
+it is likely that the path to the executable is not a member of the Emacs
+variable ~exec-path~. You may rectify this by manually adding the path within
+your Emacs configuration:
+
+#+BEGIN_SRC emacs-lisp
+  (add-to-list 'exec-path "path/to/sqlite3")
+#+END_SRC
+
 * Getting Started
 
 This short tutorial describes the essential commands used in Org-roam, to help

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -119,6 +119,7 @@ Graphing
 
 Roam Protocol
 
+* _::
 * Installation: Installation (1). 
 * The @samp{roam-file} protocol::
 * The @samp{roam-ref} Protocol::
@@ -180,7 +181,7 @@ Emacs is also a fantastic interface for editing text, and we can inherit many of
 @chapter A Brief Introduction to the Zettelkasten Method
 
 Org-roam provides utilities for maintaining a digital slip-box. This section
-aims to provide a brief introduction to the "slip-box", or "Zettelkasten"
+aims to provide a brief introduction to the ``slip-box'', or ``Zettelkasten''
 method. By providing some background on the method, we hope that the design
 decisions of Org-roam will become clear, and that will aid in using Org-roam
 appropriately. In this section we will also introduce terms commonly used within
@@ -301,6 +302,15 @@ operating system. You can verify that this is the case by executing:
 (executable-find "sqlite3")
 @end lisp
 
+If you have @code{sqlite3} installed, and @code{executable-find} still reports @code{nil}, then
+it is likely that the path to the executable is not a member of the Emacs
+variable @code{exec-path}. You may rectify this by manually adding the path within
+your Emacs configuration:
+
+@lisp
+(add-to-list 'exec-path "path/to/sqlite3")
+@end lisp
+
 @node Getting Started
 @chapter Getting Started
 
@@ -389,8 +399,8 @@ to effective use of Org-roam.
 To easily find a note, a title needs to be prescribed to a note. A note can have
 many titles: this allows a note to be referred to by different names, which is
 especially useful for topics or concepts with acronyms. For example, for a note
-like "World War 2", it may be desirable to also refer to it using the acronym
-"WWII".
+like ``World War 2'', it may be desirable to also refer to it using the acronym
+``WWII''.
 
 Org-roam calls @samp{org-roam--extract-titles} to extract titles. It uses the
 variable @samp{org-roam-title-sources}, to control how the titles are extracted. The
@@ -419,11 +429,11 @@ Take for example the following org file:
 @headitem Method
 @tab Titles
 @item @samp{'title}
-@tab '("World War 2")
+@tab '(``World War 2'')
 @item @samp{'headline}
-@tab '("Headline")
+@tab '(``Headline'')
 @item @samp{'alias}
-@tab '("WWII" "World War II")
+@tab '(``WWII'' ``World War II'')
 @end multitable
 
 One can freely control which extraction methods to use by customizing
@@ -837,19 +847,19 @@ Graphviz provides many options for customizing the graph output, and Org-roam su
 @item
 User Option: org-roam-graph-extra-config
 
-Extra options passed to graphviz for the digraph (The "G" attributes).
+Extra options passed to graphviz for the digraph (The ``G'' attributes).
 Example: @samp{'=(("rankdir" . "LR"))}
 
 @item
 User Option: org-roam-graph-node-extra-config
 
-Extra options for nodes in the graphviz output (The "N" attributes).
+Extra options for nodes in the graphviz output (The ``N'' attributes).
 Example: @samp{'(("color" . "skyblue"))}
 
 @item
 User Option: org-roam-graph-edge-extra-config
 
-Extra options for edges in the graphviz output (The "E" attributes).
+Extra options for edges in the graphviz output (The ``E'' attributes).
 Example: @samp{'(("dir" . "back"))}
 
 @item
@@ -881,7 +891,7 @@ are excluded.
 (setq org-roam-graph-exclude-matcher '("private" "dailies"))
 @end example
 
-This setting excludes all files whose path contain "private" or "dailies".
+This setting excludes all files whose path contain ``private'' or ``dailies''.
 
 @node Org-roam Completion System
 @chapter Org-roam Completion System
@@ -905,14 +915,18 @@ Other options include @samp{'ido}, and @samp{'ivy}.
 @node Roam Protocol
 @chapter Roam Protocol
 
-Org-roam extending @samp{org-protocol} with 2 protocols: the @samp{roam-file}
-and @samp{roam-ref} protocol.
-
 @menu
+* _::
 * Installation: Installation (1). 
 * The @samp{roam-file} protocol::
 * The @samp{roam-ref} Protocol::
 @end menu
+
+@node _
+@section _ :ignore:
+
+Org-roam extending @samp{org-protocol} with 2 protocols: the @samp{roam-file}
+and @samp{roam-ref} protocol.
 
 @node Installation (1)
 @section Installation
@@ -947,7 +961,7 @@ running in your shell:
 xdg-mime default org-protocol.desktop x-scheme-handler/org-protocol
 @end example
 
-To disable the "confirm" prompt in Chrome, you can also make Chrome
+To disable the ``confirm'' prompt in Chrome, you can also make Chrome
 show a checkbox to tick, so that the @samp{Org-Protocol Client} app will be used
 without confirmation. To do this, run in a shell:
 
@@ -1016,7 +1030,7 @@ Inside @samp{Settings}:
 | Protocol                       | "org-protocol" |
 @end example
 
-To disable the "confirm" prompt in Chrome, you can also make Chrome
+To disable the ``confirm'' prompt in Chrome, you can also make Chrome
 show a checkbox to tick, so that the @samp{OrgProtocol} app will be used
 without confirmation. To do this, run in a shell:
 
@@ -1342,5 +1356,5 @@ file within that directory, at least once.
 
 Fabio has produced a command-line tool that converts markdown files exported from Roam Research into Org-roam compatible markdown. More instructions are provided @uref{https://github.com/fabioberger/roam-migration, in the repository}.
 
-Emacs 28.0.50 (Org mode 9.3.7)
+Emacs 28.0.50 (Org mode 9.4)
 @bye

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -79,10 +79,6 @@ when used with multiple Org-roam instances."
   "Entrypoint to the Org-roam sqlite database.
 Initializes and stores the database, and the database connection.
 Performs a database upgrade when required."
-  (unless (executable-find "sqlite3")
-    (user-error "Cannot find executable “sqlite3”. \
-Ensure it is installed and the path is set. \
-Refer to https://org-roam.github.io/org-roam/manual/Installation.html"))
   (unless (and (org-roam-db--get-connection)
                (emacsql-live-p (org-roam-db--get-connection)))
     (let* ((db-file (org-roam-db--get))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -80,8 +80,9 @@ when used with multiple Org-roam instances."
 Initializes and stores the database, and the database connection.
 Performs a database upgrade when required."
   (unless (executable-find "sqlite3")
-    (user-error "Please ensure `sqlite3' is installed and the path is set; refer to \
-https://org-roam.github.io/org-roam/manual/"))
+    (user-error "Cannot find executable “sqlite3”. \
+Ensure `sqlite3' is installed and the path is set. \
+Refer to https://org-roam.github.io/org-roam/manual/Installation.html"))
   (unless (and (org-roam-db--get-connection)
                (emacsql-live-p (org-roam-db--get-connection)))
     (let* ((db-file (org-roam-db--get))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -81,7 +81,7 @@ Initializes and stores the database, and the database connection.
 Performs a database upgrade when required."
   (unless (executable-find "sqlite3")
     (user-error "Cannot find executable “sqlite3”. \
-Ensure `sqlite3' is installed and the path is set. \
+Ensure it is installed and the path is set. \
 Refer to https://org-roam.github.io/org-roam/manual/Installation.html"))
   (unless (and (org-roam-db--get-connection)
                (emacsql-live-p (org-roam-db--get-connection)))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -79,6 +79,9 @@ when used with multiple Org-roam instances."
   "Entrypoint to the Org-roam sqlite database.
 Initializes and stores the database, and the database connection.
 Performs a database upgrade when required."
+  (unless (executable-find "sqlite3")
+    (user-error "Please ensure `sqlite3' is installed and the path is set; refer to \
+https://org-roam.github.io/org-roam/manual/"))
   (unless (and (org-roam-db--get-connection)
                (emacsql-live-p (org-roam-db--get-connection)))
     (let* ((db-file (org-roam-db--get))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1090,6 +1090,10 @@ Otherwise, behave as if called interactively."
   :global t
   (cond
    (org-roam-mode
+    (unless (executable-find "sqlite3")
+      (lwarn '(org-roam) :error "Cannot find executable 'sqlite3'. \
+Ensure it is installed and can be found within `exec-path'. \
+M-x info for more information at Org-roam > Installation > Post-Installation Tasks."))
     (add-hook 'find-file-hook #'org-roam--find-file-hook-function)
     (add-hook 'kill-emacs-hook #'org-roam-db--close-all)
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)


### PR DESCRIPTION
###### Motivation for this change
Context is [discussion in Discourse](https://org-roam.discourse.group/t/error-apply-cannot-find-executable-sqlite3/316).

When the computer is missing sqlite3 or the path is not correctly
set, you get an error message like this:

  `Error: apply: Cannot find executable “sqlite3”!`

The motivation of this simple change is to see whether a simple
change to the error message might not change UX, and better
guide end-users who may not be familiar with dealing with
these terse error messages.