### PR TITLE
(docs): Add link to Roam-migration

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1023,6 +1023,10 @@ All files within that directory will be treated as their own separate
 set of Org-roam files. Remember to run =org-roam-db-build-cache= from a
 file within that directory, at least once.
 
+** How do I migrate from Roam Research?
+
+Fabio has produced a command-line tool that converts markdown files exported from Roam Research into Org-roam compatible markdown. More instructions are provided [[https://github.com/fabioberger/roam-migration][in the repository]].
+
 # Local Variables:
 # eval: (require 'ol-info)
 # before-save-hook: org-make-toc

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -23,7 +23,7 @@ General Public License for more details.
 @end quotation
 @end copying
 
-@dircategory emacs
+@dircategory Emacs
 @direntry
 * Org-roam: (org-roam). Rudimentary Roam Replica for Emacs.
 @end direntry
@@ -139,6 +139,7 @@ Ecosystem
 FAQ
 
 * How do I have more than one Org-roam directory?::
+* How do I migrate from Roam Research?::
 
 @end detailmenu
 @end menu
@@ -1317,6 +1318,7 @@ files. Other alternatives include @uref{https://orgmode.org/worg/org-contrib/org
 
 @menu
 * How do I have more than one Org-roam directory?::
+* How do I migrate from Roam Research?::
 @end menu
 
 @node How do I have more than one Org-roam directory?
@@ -1337,6 +1339,11 @@ contain:
 All files within that directory will be treated as their own separate
 set of Org-roam files. Remember to run @samp{org-roam-db-build-cache} from a
 file within that directory, at least once.
+
+@node How do I migrate from Roam Research?
+@section How do I migrate from Roam Research?
+
+Fabio has produced a command-line tool that converts markdown files exported from Roam Research into Org-roam compatible markdown. More instructions are provided @uref{https://github.com/fabioberger/roam-migration, in the repository}.
 
 Emacs 28.0.50 (Org mode 9.4)
 @bye


### PR DESCRIPTION
###### Motivation for this change

Add link to [Roam-migration](https://github.com/fabioberger/roam-migration) in manual.

Closes #411 