### PR TITLE
Add support for headlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.2 (TBD)
 
-In this release, we improved the linking process by making links to headline much more robust.  Before, we used the `file:foo::*bar` format to link to the headline `bar` in file `foo`, but this was prone to breakage upon renaming the file or modifying the headline.  Now, we use `org-id` to create IDs for those headlines, which are then stored in our database to compute the relationships and jump around.  Note that this will work even if you’re not using `org-id` in your global configuration for Org-mode.
+In this release, we improved the linking process by achieving feature parity between links to files and links to headlines.  Before, we used the `file:foo::*bar` format to link to the headline `bar` in file `foo`, but this was prone to breakage upon renaming the file or modifying the headline.  This is not the case anymore.  Now, we use `org-id` to create IDs for those headlines, which are then stored in our database to compute the relationships and jump around.  Note that this will work even if you’re not using `org-id` in your global configuration for Org-mode.
+
+This is a major step forward.  Supporting the in-file structure of Org-mode files means that we can interface with many of its core-features like TODOs, properties, priorities, etc.  UX will have to be figured out, but this release ushers in a new age in terms of functionalities.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 1.2 (TBD)
 
-In this release, we improved the linking process by achieving feature parity between links to files and links to headlines.  Before, we used the `file:foo::*bar` format to link to the headline `bar` in file `foo`, but this was prone to breakage upon renaming the file or modifying the headline.  This is not the case anymore.  Now, we use `org-id` to create IDs for those headlines, which are then stored in our database to compute the relationships and jump around.  Note that this will work even if you’re not using `org-id` in your global configuration for Org-mode.
+In this release, we improved the linking process by achieving feature parity between links to files and links to headlines. Before, we used the `file:foo::*bar` format to link to the headline `bar` in file `foo`, but this was prone to breakage upon renaming the file or modifying the headline. This is not the case anymore. Now, we use `org-id` to create IDs for those headlines, which are then stored in our database to compute the relationships and jump around. Note that this will work even if you’re not using `org-id` in your global configuration for Org-mode.
 
-This is a major step forward.  Supporting the in-file structure of Org-mode files means that we can interface with many of its core-features like TODOs, properties, priorities, etc.  UX will have to be figured out, but this release ushers in a new age in terms of functionalities.
+This is a major step forward. Supporting the in-file structure of Org-mode files means that we can interface with many of its core-features like TODOs, properties, priorities, etc. UX will have to be figured out, but this release ushers in a new age in terms of functionalities.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 1.1.2 (TBD)
+## 1.2 (TBD)
+
+In this release, we improved the linking process by making links to headline much more robust.  Before, we used the `file:foo::*bar` format to link to the headline `bar` in file `foo`, but this was prone to breakage upon renaming the file or modifying the headline.  Now, we use `org-id` to create IDs for those headlines, which are then stored in our database to compute the relationships and jump around.  Note that this will work even if you’re not using `org-id` in your global configuration for Org-mode.
 
 ### Breaking Changes
 
@@ -9,6 +11,7 @@
 
 ### Features
 
+- [#783](https://github.com/org-roam/org-roam/pull/783) Add support for headlines
 - [#757](https://github.com/org-roam/org-roam/pull/757) Roam global properties are now case-insensitive
 - [#680](https://github.com/org-roam/org-roam/pull/680) , [#703](https://github.com/org-roam/org-roam/pull/703), [#708](https://github.com/org-roam/org-roam/pull/708) Add `org-roam-doctor` checkers for `ROAM_*` properties
 - [#664](https://github.com/org-roam/org-roam/pull/664) Add support for shelling out to `rg` and `find` in `org-roam--list-files`

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -372,8 +372,7 @@ connections, nil is returned."
 
 (defun org-roam-db--update-cache-headlines ()
   "Update the file headlines of the current buffer into the cache."
-  (let* ((file (file-truename (buffer-file-name)))
-         (headlines (org-roam--extract-headlines)))
+  (let* ((file (file-truename (buffer-file-name))))
     (org-roam-db-query [:delete :from headlines
                         :where (= file $s1)]
                        file)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -392,8 +392,8 @@ connections, nil is returned."
           (org-roam-db--update-tags)
           (org-roam-db--update-titles)
           (org-roam-db--update-refs)
-          (org-roam-db--update-cache-links)
           (org-roam-db--update-cache-headlines)
+          (org-roam-db--update-cache-links)
           (org-roam-buffer--update-maybe :redisplay t))))))
 
 (defun org-roam-db-build-cache (&optional force)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -45,6 +45,7 @@
 (declare-function org-roam--extract-titles                 "org-roam")
 (declare-function org-roam--extract-ref                    "org-roam")
 (declare-function org-roam--extract-tags                   "org-roam")
+(declare-function org-roam--extract-headlines              "org-roam")
 (declare-function org-roam--extract-links                  "org-roam")
 (declare-function org-roam--list-all-files                 "org-roam")
 (declare-function org-roam-buffer--update-maybe            "org-roam-buffer")

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -465,13 +465,15 @@ If FORCE, force a rebuild of the cache from scratch."
         :values $v1]
        all-refs))
     (let ((stats (list :files (length all-files)
+                       :headlines (length all-headlines)
                        :links (length all-links)
                        :tags (length all-tags)
                        :titles (length all-titles)
                        :refs (length all-refs)
                        :deleted (length (hash-table-keys current-files)))))
-      (org-roam-message "files: %s, links: %s, tags: %s, titles: %s, refs: %s, deleted: %s"
+      (org-roam-message "files: %s, headlines: %s, links: %s, tags: %s, titles: %s, refs: %s, deleted: %s"
                         (plist-get stats :files)
+                        (plist-get stats :headlines)
                         (plist-get stats :links)
                         (plist-get stats :tags)
                         (plist-get stats :titles)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -60,7 +60,7 @@ when used with multiple Org-roam instances."
   :type 'string
   :group 'org-roam)
 
-(defconst org-roam-db--version 5)
+(defconst org-roam-db--version 6)
 
 (defvar org-roam-db--connection (make-hash-table :test #'equal)
   "Database connection to Org-roam database.")

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -371,13 +371,12 @@ connections, nil is returned."
     (when-let ((links (org-roam--extract-links)))
       (org-roam-db--insert-links links))))
 
-(defun org-roam-db--update-headlines (&optional file)
-  "Update the file headlines of FILE into the cache.
-If FILE is nil, use the file for the current buffer."
-  (let* ((file (or file (buffer-file-name))))
+(defun org-roam-db--update-headlines ()
+  "Update the file headlines of the current buffer into the cache."
+  (let* ((file (file-truename (buffer-file-name))))
     (org-roam-db-query [:delete :from headlines
                         :where (= file $s1)]
-                       (file-truename file))
+                       file)
     (when-let ((headlines (org-roam--extract-headlines)))
       (org-roam-db--insert-headlines headlines))))
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -371,14 +371,17 @@ connections, nil is returned."
     (when-let ((links (org-roam--extract-links)))
       (org-roam-db--insert-links links))))
 
-(defun org-roam-db--update-cache-headlines ()
-  "Update the file headlines of the current buffer into the cache."
-  (let* ((file (file-truename (buffer-file-name))))
+(defun org-roam-db--update-cache-headlines (&optional alt-file)
+  "Update the file headlines of the current buffer into the cache.
+ALT-FILE can be used to specify a different file to be used for
+wiping the previous row, such as when the file has been rename."
+  (let* ((file (buffer-file-name)))
     (org-roam-db-query [:delete :from headlines
                         :where (= file $s1)]
-                       file)
+                       (file-truename (or alt-file
+                                          file)))
     (when-let ((headlines (org-roam--extract-headlines)))
-        (org-roam-db--insert-headlines headlines))))
+      (org-roam-db--insert-headlines headlines))))
 
 (defun org-roam-db--update-file (&optional file-path)
   "Update Org-roam cache for FILE-PATH."

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -229,7 +229,7 @@ This is equivalent to removing the node from the graph."
    (list (vector file titles))))
 
 (defun org-roam-db--insert-headlines (headlines)
-  "Insert TITLES for a FILE into the Org-roam cache."
+  "Insert HEADLINES for a FILE into the Org-roam cache."
   (org-roam-db-query
    [:insert :into headlines
     :values $v1]

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -374,7 +374,7 @@ connections, nil is returned."
 (defun org-roam-db--update-headlines (&optional alt-file)
   "Update the file headlines of the current buffer into the cache.
 ALT-FILE can be used to specify a different file to be used for
-wiping the previous row, such as when the file has been rename."
+wiping the previous row, such as when the file has been renamed."
   (let* ((file (buffer-file-name)))
     (org-roam-db-query [:delete :from headlines
                         :where (= file $s1)]

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -272,12 +272,12 @@ This is equivalent to removing the node from the graph."
 If the file does not have any connections, nil is returned."
   (let* ((query "WITH RECURSIVE
                    links_of(file, link) AS
-                     (WITH roamlinks AS (SELECT * FROM links WHERE \"type\" = '\"roam\"'),
+                     (WITH filelinks AS (SELECT * FROM links WHERE \"type\" = '\"file\"'),
                            citelinks AS (SELECT * FROM links
                                                   JOIN refs ON links.\"to\" = refs.\"ref\"
                                                             AND links.\"type\" = '\"cite\"')
-                      SELECT \"from\", \"to\" FROM roamlinks UNION
-                      SELECT \"to\", \"from\" FROM roamlinks UNION
+                      SELECT \"from\", \"to\" FROM filelinks UNION
+                      SELECT \"to\", \"from\" FROM filelinks UNION
                       SELECT \"file\", \"from\" FROM citelinks UNION
                       SELECT \"from\", \"file\" FROM citelinks),
                    connected_component(file) AS
@@ -294,12 +294,12 @@ This includes the file itself.  If the file does not have any
 connections, nil is returned."
   (let* ((query "WITH RECURSIVE
                    links_of(file, link) AS
-                     (WITH roamlinks AS (SELECT * FROM links WHERE \"type\" = '\"roam\"'),
+                     (WITH filelinks AS (SELECT * FROM links WHERE \"type\" = '\"file\"'),
                            citelinks AS (SELECT * FROM links
                                                   JOIN refs ON links.\"to\" = refs.\"ref\"
                                                             AND links.\"type\" = '\"cite\"')
-                      SELECT \"from\", \"to\" FROM roamlinks UNION
-                      SELECT \"to\", \"from\" FROM roamlinks UNION
+                      SELECT \"from\", \"to\" FROM filelinks UNION
+                      SELECT \"to\", \"from\" FROM filelinks UNION
                       SELECT \"file\", \"from\" FROM citelinks UNION
                       SELECT \"from\", \"file\" FROM citelinks),
                    -- Links are traversed in a breadth-first search.  In order to calculate the

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -362,7 +362,7 @@ connections, nil is returned."
     (when-let ((ref (org-roam--extract-ref)))
       (org-roam-db--insert-ref file ref))))
 
-(defun org-roam-db--update-cache-links ()
+(defun org-roam-db--update-links ()
   "Update the file links of the current buffer in the cache."
   (let ((file (file-truename (buffer-file-name))))
     (org-roam-db-query [:delete :from links
@@ -371,7 +371,7 @@ connections, nil is returned."
     (when-let ((links (org-roam--extract-links)))
       (org-roam-db--insert-links links))))
 
-(defun org-roam-db--update-cache-headlines (&optional alt-file)
+(defun org-roam-db--update-headlines (&optional alt-file)
   "Update the file headlines of the current buffer into the cache.
 ALT-FILE can be used to specify a different file to be used for
 wiping the previous row, such as when the file has been rename."
@@ -395,8 +395,8 @@ wiping the previous row, such as when the file has been rename."
           (org-roam-db--update-tags)
           (org-roam-db--update-titles)
           (org-roam-db--update-refs)
-          (org-roam-db--update-cache-headlines)
-          (org-roam-db--update-cache-links)
+          (org-roam-db--update-headlines)
+          (org-roam-db--update-links)
           (org-roam-buffer--update-maybe :redisplay t))))))
 
 (defun org-roam-db-build-cache (&optional force)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -229,7 +229,7 @@ This is equivalent to removing the node from the graph."
    (list (vector file titles))))
 
 (defun org-roam-db--insert-headlines (headlines)
-  "Insert HEADLINES for a FILE into the Org-roam cache."
+  "Insert HEADLINES into the Org-roam cache."
   (org-roam-db-query
    [:insert :into headlines
     :values $v1]

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -290,7 +290,7 @@ If the file does not have any connections, nil is returned."
 
 (defun org-roam-db--links-with-max-distance (file max-distance)
   "Return all files connected to FILE in at most MAX-DISTANCE steps.
-This includes the file itself. If the file does not have any
+This includes the file itself.  If the file does not have any
 connections, nil is returned."
   (let* ((query "WITH RECURSIVE
                    links_of(file, link) AS

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -371,15 +371,13 @@ connections, nil is returned."
     (when-let ((links (org-roam--extract-links)))
       (org-roam-db--insert-links links))))
 
-(defun org-roam-db--update-headlines (&optional alt-file)
-  "Update the file headlines of the current buffer into the cache.
-ALT-FILE can be used to specify a different file to be used for
-wiping the previous row, such as when the file has been renamed."
-  (let* ((file (buffer-file-name)))
+(defun org-roam-db--update-headlines (&optional file)
+  "Update the file headlines of FILE into the cache.
+If FILE is nil, use the file for the current buffer."
+  (let* ((file (or file (buffer-file-name))))
     (org-roam-db-query [:delete :from headlines
                         :where (= file $s1)]
-                       (file-truename (or alt-file
-                                          file)))
+                       (file-truename file))
     (when-let ((headlines (org-roam--extract-headlines)))
       (org-roam-db--insert-headlines headlines))))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -952,13 +952,7 @@ for Org-ref cite links."
 
 (defun org-roam-store-link (arg)
   (interactive "p")
-  (cl-letf* (((symbol-function 'org-id-add-location)
-              (lambda (&rest args)
-                (if org-id-track-globally
-                    (apply #'org-id-add-location args)
-                  (message "Successfully nuked"))))
-             (org-id-track-globally t)
-             (org-id-link-to-org-use-id t))
+  (let ((org-id-link-to-org-use-id t))
     (org-store-link arg)))
 
 ;;; The global minor org-roam-mode

--- a/org-roam.el
+++ b/org-roam.el
@@ -36,6 +36,7 @@
 ;;;; Dependencies
 (require 'org)
 (require 'org-element)
+(require 'org-id)
 (require 'ob-core) ;for org-babel-parse-header-arguments
 (require 'ansi-color) ; org-roam--list-files strip ANSI color codes
 (require 'cl-lib)

--- a/org-roam.el
+++ b/org-roam.el
@@ -557,7 +557,6 @@ If FILE-PATH is nil, use the current file."
               (value (org-element-property :value node-property)))
           (when (string= key "ID")
             (let* ((id value)
-                   (mtime (current-time))
                    (data (vector id
                                  file-path)))
               data)))))))
@@ -1006,7 +1005,6 @@ for Org-ref cite links."
   "Store a link to the current location within Org-roam.
 See `org-roam-store-link' for details on ARG and INTERACTIVE?."
   (let ((org-id-link-to-org-use-id t)
-        (file (buffer-file-name (buffer-base-buffer)))
         (id (org-id-get)))
     (org-store-link arg interactive?)
     ;; If :ID: was created, update the cache

--- a/org-roam.el
+++ b/org-roam.el
@@ -1210,8 +1210,8 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (remove-hook 'kill-emacs-hook #'org-roam-db--close-all)
     (advice-remove 'rename-file #'org-roam--rename-file-advice)
     (advice-remove 'delete-file #'org-roam--delete-file-advice)
-    (define-key org-roam-mode-map [remap org-store-link] 'org-roam-store-link)
-    (define-key org-roam-mode-map [remap org-open-at-point] 'org-roam-open-at-point)
+    (define-key org-roam-mode-map [remap org-store-link] nil)
+    (define-key org-roam-mode-map [remap org-open-at-point] nil)
     (org-roam-db--close-all)
     ;; Disable local hooks for all org-roam buffers
     (dolist (buf (org-roam--get-roam-buffers))

--- a/org-roam.el
+++ b/org-roam.el
@@ -975,9 +975,6 @@ for Org-ref cite links."
       (let* ((id (org-id-get))
              (data (vector id
                            file)))
-        ;; (org-roam-db-query [:delete :from headlines
-        ;;                     :where (= id $s1)]
-        ;;                    id)
         (org-roam-db-query [:insert :into headlines
                             :values $v1]
                            data)))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -991,22 +991,25 @@ for Org-ref cite links."
        :link        (format "file:%s" (abbreviate-file-name buffer-file-name))
        :description title))))
 
+(defun org-roam--store-link (arg &optional interactive?)
+  "Store a link to the current location within Org-roam.
+See `org-roam-store-link' for details."
+  (let ((org-id-link-to-org-use-id t)
+        (file (buffer-file-name (buffer-base-buffer)))
+        (id (org-id-get)))
+    (org-store-link arg interactive?)
+    ;; If :ID: was created, update the cache
+    (unless id
+      (org-roam-db--update-cache-headlines))))
+
 (defun org-roam-store-link (arg &optional interactive?)
   "Store a link to the current location.
 This commands is a wrapper for `org-store-link' which forces the
 automatic creation of :ID: properties."
   (interactive "P\np")
-  (let ((fun (lambda ()
-               (org-store-link arg interactive?))))
-    (if (org-roam--org-roam-file-p)
-        (let ((org-id-link-to-org-use-id t)
-              (file (buffer-file-name (buffer-base-buffer)))
-              (id (org-id-get)))
-          (funcall fun)
-          ;; If :ID: was created, update the cache
-          (unless id
-            (org-roam-db--update-cache-headlines)))
-      (funcall fun))))
+  (if (org-roam--org-roam-file-p)
+      (org-roam--store-link arg interactive?)
+    (org-store-link arg interactive?)))
 
 (defun org-roam-id-find (id &optional markerp)
   "Find ID in Org-roam's database.

--- a/org-roam.el
+++ b/org-roam.el
@@ -966,6 +966,9 @@ for Org-ref cite links."
        :description title))))
 
 (defun org-roam-store-link (arg)
+  "Store a link to the current location.
+This commands is a wrapper for `org-store-link' which forces the
+automatic creation of :ID: properties."
   (interactive "p")
   (let ((org-id-link-to-org-use-id t)
         (file (buffer-file-name (buffer-base-buffer)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -906,7 +906,7 @@ buffer or a marker."
         (backlink-dest (org-roam--retrieve-link-path)))
     (string= current backlink-dest)))
 
-(defun org-roam--roam-link-face (path)
+(defun org-roam--roam-link-face-file (path)
   "Conditional face for org file links.
 Applies `org-roam-link-current' if PATH corresponds to the
 currently opened Org-roam file in the backlink buffer, or
@@ -921,6 +921,22 @@ file."
          'org-roam-link)
         (t
          'org-link)))
+
+(defun org-roam--roam-link-face-id (id)
+  "Conditional face for org file links.
+Applies `org-roam-link-current' if PATH corresponds to the
+currently opened Org-roam file in the backlink buffer, or
+`org-roam-link-face' if PATH corresponds to any other Org-roam
+file."
+  (let ((table org-id-locations))
+    (cond ((org-roam--org-roam-headline-p id)
+           'org-roam-link)
+          ((and org-id-track-globally
+                table
+                (not (gethash id table)))
+           'org-roam-link-invalid)
+          (t
+           'org-link))))
 
 (defun org-roam-open-at-point ()
   "Open an Org-roam link or visit the text previewed at point.
@@ -1038,7 +1054,8 @@ behaviour to work with Org-roam."
     (setq org-roam-last-window (get-buffer-window))
     (add-hook 'post-command-hook #'org-roam-buffer--update-maybe nil t)
     (add-hook 'after-save-hook #'org-roam-db--update-file nil t)
-    (org-link-set-parameters "file" :face 'org-roam--roam-link-face :store #'org-roam-store-file-link)
+    (org-link-set-parameters "file" :face 'org-roam--roam-link-face-file :store #'org-roam-store-file-link)
+    (org-link-set-parameters "id" :face 'org-roam--roam-link-face-id)
     (org-roam-buffer--update-maybe :redisplay t)))
 
 (defun org-roam--delete-file-advice (file &optional _trash)

--- a/org-roam.el
+++ b/org-roam.el
@@ -314,7 +314,7 @@ If FILE is not specified, use the current buffer's file-path."
                             (file-truename org-roam-directory))))))
 
 (defun org-roam--org-roam-headline-p (&optional id)
-  "Return t if ID is part of Org-rroam system, nil otherwise.
+  "Return t if ID is part of Org-roam system, nil otherwise.
 If ID is not specified, use the ID of the entry at point."
   (if-let ((id (or id
                    (org-id-get))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -974,7 +974,7 @@ automatic creation of :ID: properties."
         (file (buffer-file-name (buffer-base-buffer)))
         (id (org-id-get)))
     (org-store-link arg)
-    (unless id
+    (when id
       (let* ((id (org-id-get))
              (data (vector id
                            file)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1049,7 +1049,7 @@ behaviour to work with Org-roam."
                 (unless (and (org-roam-id-open id)
                              org-id-track-globally)
                   (when (y-or-n-p (concat "ID was not found in `org-roam-directory' nor in `org-id-locations'.\n"
-                                          "Search externally with `org-id-goto'? "))
+                                          "Search in `org-id-files'? "))
                     (funcall orig-fun id))))))
     (org-open-at-point arg)))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -504,9 +504,13 @@ it as FILE-PATH."
         (let* ((type (org-element-property :type link))
                (path (org-element-property :path link))
                (start (org-element-property :begin link))
+               (id-data (org-roam-id-find path))
                (link-type (cond ((and (string= type "file")
                                       (org-roam--org-file-p path))
                                  "roam")
+                                ((and (string= type "id")
+                                      id-data)
+                                 "roam-id")
                                 ((and
                                   (require 'org-ref nil t)
                                   (-contains? org-ref-cite-types type))
@@ -529,6 +533,8 @@ it as FILE-PATH."
                     (names (pcase link-type
                              ("roam"
                               (list (file-truename (expand-file-name path (file-name-directory file-path)))))
+                             ("roam-id"
+                              (list (car id-data)))
                              ("cite"
                               (org-ref-split-and-strip-string path)))))
                 (seq-do (lambda (name)

--- a/org-roam.el
+++ b/org-roam.el
@@ -313,6 +313,15 @@ If FILE is not specified, use the current buffer's file-path."
          (f-descendant-of-p (file-truename path)
                             (file-truename org-roam-directory))))))
 
+(defun org-roam--org-roam-headline-p (&optional id)
+  "Return t if ID is part of Org-rroam system, nil otherwise.
+If ID is not specified, use the ID of the entry at point."
+  (if-let ((id (or id
+                   (org-id-get))))
+      (org-roam-db-query [:select [file] :from headlines
+                          :where (= id $s1)]
+                         id)))
+
 (defun org-roam--shell-command-files (cmd)
   "Run CMD in the shell and return a list of files. If no files are found, an empty list is returned."
   (--> cmd

--- a/org-roam.el
+++ b/org-roam.el
@@ -975,6 +975,7 @@ automatic creation of :ID: properties."
         (file (buffer-file-name (buffer-base-buffer)))
         (id (org-id-get)))
     (org-store-link arg interactive?)
+    ;; If :ID: was created, update the cache
     (unless id
       (org-roam-db--update-cache-headlines))))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -965,15 +965,15 @@ for Org-ref cite links."
        :link        (format "file:%s" (abbreviate-file-name buffer-file-name))
        :description title))))
 
-(defun org-roam-store-link (arg)
+(defun org-roam-store-link (arg &optional interactive?)
   "Store a link to the current location.
 This commands is a wrapper for `org-store-link' which forces the
 automatic creation of :ID: properties."
-  (interactive "p")
+  (interactive "P\np")
   (let ((org-id-link-to-org-use-id t)
         (file (buffer-file-name (buffer-base-buffer)))
         (id (org-id-get)))
-    (org-store-link arg)
+    (org-store-link arg interactive?)
     (when id
       (let* ((id (org-id-get))
              (data (vector id

--- a/org-roam.el
+++ b/org-roam.el
@@ -547,7 +547,7 @@ it as FILE-PATH."
     links))
 
 (defun org-roam--extract-headlines (&optional file-path)
-  "Extract all headlines with IDs within the current-buffer.
+  "Extract all headlines with IDs within the current buffer.
 If FILE-PATH is nil, use the current file."
   (let ((file-path (or file-path
                        (file-truename (buffer-file-name)))))
@@ -1004,7 +1004,7 @@ for Org-ref cite links."
 
 (defun org-roam--store-link (arg &optional interactive?)
   "Store a link to the current location within Org-roam.
-See `org-roam-store-link' for details."
+See `org-roam-store-link' for details on ARG and INTERACTIVE?."
   (let ((org-id-link-to-org-use-id t)
         (file (buffer-file-name (buffer-base-buffer)))
         (id (org-id-get)))
@@ -1016,7 +1016,8 @@ See `org-roam-store-link' for details."
 (defun org-roam-store-link (arg &optional interactive?)
   "Store a link to the current location.
 This commands is a wrapper for `org-store-link' which forces the
-automatic creation of :ID: properties."
+automatic creation of :ID: properties.
+See `org-roam-store-link' for details on ARG and INTERACTIVE?."
   (interactive "P\np")
   (if (org-roam--org-roam-file-p)
       (org-roam--store-link arg interactive?)
@@ -1043,7 +1044,8 @@ Org-roam's database.
 ID-OR-MARKER can either be the ID of the entry or the marker
 pointing to it if it has already been computed by
 `org-roam-id-find'. If the ID-OR-MARKER is not found, it reverts
-to the default behaviour of `org-id-open'."
+to the default behaviour of `org-id-open'.
+When STRICT is non-nil, only consider Org-roam’s database."
   (when-let ((marker (if (markerp id-or-marker)
                          id-or-marker
                        (org-roam-id-find id-or-marker t strict))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -982,7 +982,7 @@ for Org-ref cite links."
                       :order-by (asc from)]
                      target))
 
-(defun org-roam-store-file-link ()
+(defun org-roam-store-link-file ()
   "Store a link to an `org-roam' file."
   (when (org-before-first-heading-p)
     (when-let ((title (cdr (assoc "TITLE" (org-roam--extract-global-props '("TITLE"))))))
@@ -1054,7 +1054,7 @@ behaviour to work with Org-roam."
     (setq org-roam-last-window (get-buffer-window))
     (add-hook 'post-command-hook #'org-roam-buffer--update-maybe nil t)
     (add-hook 'after-save-hook #'org-roam-db--update-file nil t)
-    (org-link-set-parameters "file" :face 'org-roam--roam-link-face-file :store #'org-roam-store-file-link)
+    (org-link-set-parameters "file" :face 'org-roam--roam-link-face-file :store #'org-roam-store-link-file)
     (org-link-set-parameters "id" :face 'org-roam--roam-link-face-id)
     (org-roam-buffer--update-maybe :redisplay t)))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -976,10 +976,7 @@ automatic creation of :ID: properties."
         (id (org-id-get)))
     (org-store-link arg interactive?)
     (unless id
-      (let* ((id (org-id-get))
-             (data (vector id
-                           file)))
-        (org-roam-db--insert-headlines data)))))
+      (org-roam-db--update-cache-headlines))))
 
 ;;; The global minor org-roam-mode
 (defun org-roam--find-file-hook-function ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -1214,7 +1214,9 @@ When called from Lisp, enable `org-roam-mode' if ARG is omitted,
 nil, or positive. If ARG is `toggle', toggle `org-roam-mode'.
 Otherwise, behave as if called interactively."
   :lighter " Org-roam"
-  :keymap  (let ((map (make-sparse-keymap))) map)
+  :keymap  (let ((map (make-sparse-keymap)))
+             (define-key map [remap org-store-link] 'org-roam-store-link)
+             map)
   :group 'org-roam
   :require 'org-roam
   :global t
@@ -1229,7 +1231,6 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (add-hook 'org-open-at-point-functions #'org-roam-open-id-at-point)
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
-    (define-key org-roam-mode-map [remap org-store-link] 'org-roam-store-link)
     (org-roam-db-build-cache))
    (t
     (remove-hook 'find-file-hook #'org-roam--find-file-hook-function)
@@ -1237,7 +1238,6 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (remove-hook 'org-open-at-point-functions #'org-roam-open-id-at-point)
     (advice-remove 'rename-file #'org-roam--rename-file-advice)
     (advice-remove 'delete-file #'org-roam--delete-file-advice)
-    (define-key org-roam-mode-map [remap org-store-link] nil)
     (org-roam-db--close-all)
     ;; Disable local hooks for all org-roam buffers
     (dolist (buf (org-roam--get-roam-buffers))

--- a/org-roam.el
+++ b/org-roam.el
@@ -61,8 +61,13 @@
 (require 'org-roam-graph)
 
 ;;;; Declarations
-(defvar org-ref-cite-types) ;; from org-ref-core.el
+;; From org-ref-core.el
+(defvar org-ref-cite-types)
 (declare-function org-ref-split-and-strip-string "ext:org-ref-utils" (string))
+;; From org-id.el
+(defvar org-id-link-to-org-use-id)
+(declare-function org-id-find-id-in-file "ext:org-id" (id file &optional markerp))
+
 
 ;;;; Customizable variables
 (defgroup org-roam nil

--- a/org-roam.el
+++ b/org-roam.el
@@ -1015,7 +1015,7 @@ See `org-roam-store-link' for details on ARG and INTERACTIVE?."
     (org-store-link arg interactive?)
     ;; If :ID: was created, update the cache
     (unless id
-      (org-roam-db--update-cache-headlines))))
+      (org-roam-db--update-headlines))))
 
 (defun org-roam-store-link (arg &optional interactive?)
   "Store a link to the current location.
@@ -1182,7 +1182,7 @@ replaced links are made relative to the current buffer."
                                                  "file")))
         ;; Update headlines in new-file.org after removing the previous IDs
         (with-current-buffer new-buffer
-          (org-roam-db--update-cache-headlines old-file))
+          (org-roam-db--update-headlines old-file))
         ;; Replace links from old-file.org -> new-file.org in all Org-roam files with these links
         (mapc (lambda (file)
                 (setq file (if (string-equal (file-truename (car file)) old-path)

--- a/org-roam.el
+++ b/org-roam.el
@@ -532,7 +532,8 @@ it as FILE-PATH."
     links))
 
 (defun org-roam--extract-headlines (&optional file-path)
-  "Extract all headlines with IDs within the current-buffer."
+  "Extract all headlines with IDs within the current-buffer.
+If FILE-PATH is nil, use the current file."
   (let ((file-path (or file-path
                        (file-truename (buffer-file-name)))))
     (org-element-map (org-element-parse-buffer) 'node-property

--- a/org-roam.el
+++ b/org-roam.el
@@ -952,8 +952,11 @@ for Org-ref cite links."
 
 (defun org-roam-store-link (arg)
   (interactive "p")
-  (let ((org-id-link-to-org-use-id t)
-        (org-id-track-globally t))
+  (cl-letf* (((symbol-function 'org-id-add-location)
+              (lambda (&rest args)
+                (message "Successfully nuked")))
+             (org-id-link-to-org-use-id t)
+             (org-id-track-globally t))
     (org-store-link arg)))
 
 ;;; The global minor org-roam-mode

--- a/org-roam.el
+++ b/org-roam.el
@@ -975,7 +975,7 @@ automatic creation of :ID: properties."
         (file (buffer-file-name (buffer-base-buffer)))
         (id (org-id-get)))
     (org-store-link arg interactive?)
-    (when id
+    (unless id
       (let* ((id (org-id-get))
              (data (vector id
                            file)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1046,10 +1046,10 @@ behaviour to work with Org-roam."
   (cl-letf* ((orig-fun (symbol-function 'org-id-open))
              ((symbol-function 'org-id-open)
               (lambda (id)
-                (unless (and (org-roam-id-open id)
-                             org-id-track-globally)
-                  (when (y-or-n-p (concat "ID was not found in `org-roam-directory' nor in `org-id-locations'.\n"
-                                          "Search in `org-id-files'? "))
+                (unless (org-roam-id-open id)
+                  (when (and org-id-track-globally
+                             (y-or-n-p (concat "ID was not found in `org-roam-directory' nor in `org-id-locations'.\n"
+                                               "Search in `org-id-files'? ")))
                     (funcall orig-fun id))))))
     (org-open-at-point arg)))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1013,7 +1013,9 @@ behaviour to work with Org-roam."
               (lambda (id)
                 (if-let ((marker (org-roam-id-find id t)))
                     (org-roam-id-open marker)
-                  (org-id-find id)))))
+                  (when (y-or-n-p (concat "ID was not found in `org-roam-directory'.\n"
+                                          "Search externally with `org-id-goto'? "))
+                      (org-id-find id))))))
     (org-open-at-point arg)))
 
 ;;; The global minor org-roam-mode

--- a/org-roam.el
+++ b/org-roam.el
@@ -953,12 +953,17 @@ for Org-ref cite links."
 ;;; The global minor org-roam-mode
 (defun org-roam--find-file-hook-function ()
   "Called by `find-file-hook' when mode symbol `org-roam-mode' is on."
-  (when (org-roam--org-roam-file-p)
-    (setq org-roam-last-window (get-buffer-window))
-    (add-hook 'post-command-hook #'org-roam-buffer--update-maybe nil t)
-    (add-hook 'after-save-hook #'org-roam-db--update-file nil t)
-    (org-link-set-parameters "file" :face 'org-roam--roam-link-face :store #'org-roam-store-link)
-    (org-roam-buffer--update-maybe :redisplay t)))
+  (let ((org-id-loc (concat (file-name-as-directory org-roam-directory)
+                            ".org-id-locations")))
+    (when (org-roam--org-roam-file-p)
+      (setq org-roam-last-window (get-buffer-window))
+      (setq-local org-id-link-to-org-use-id t
+                  org-id-track-globally t
+                  org-id-locations-file org-id-loc)
+      (add-hook 'post-command-hook #'org-roam-buffer--update-maybe nil t)
+      (add-hook 'after-save-hook #'org-roam-db--update-file nil t)
+      (org-link-set-parameters "file" :face 'org-roam--roam-link-face :store #'org-roam-store-link)
+      (org-roam-buffer--update-maybe :redisplay t))))
 
 (defun org-roam--delete-file-advice (file &optional _trash)
   "Advice for maintaining cache consistency when FILE is deleted."

--- a/org-roam.el
+++ b/org-roam.el
@@ -999,7 +999,7 @@ pointing to it if it has already been computed by
 to the default behaviour of `org-id-open'."
   (when-let ((marker (if (markerp id-or-marker)
                          id-or-marker
-                       (org-roam-id-find id t))))
+                       (org-roam-id-find id-or-marker t))))
     (org-goto-marker-or-bmk marker)
     (set-marker marker nil)))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1180,9 +1180,11 @@ replaced links are made relative to the current buffer."
                                                   :and (= type $s2)]
                                                  old-path
                                                  "file")))
-        ;; Update headlines in new-file.org after removing the previous IDs
+        ;; Remove database entries for old-file.org
+        (org-roam-db--clear-file old-file)
+        ;; Insert new headlines locations in new-file.org after removing the previous IDs
         (with-current-buffer new-buffer
-          (org-roam-db--update-headlines old-file))
+          (org-roam-db--update-headlines))
         ;; Replace links from old-file.org -> new-file.org in all Org-roam files with these links
         (mapc (lambda (file)
                 (setq file (if (string-equal (file-truename (car file)) old-path)
@@ -1191,8 +1193,6 @@ replaced links are made relative to the current buffer."
                 (org-roam--replace-link file old-path new-path old-desc new-desc)
                 (org-roam-db--update-file file))
               files-to-rename)
-        ;; Remove database entries for old-file.org
-        (org-roam-db--clear-file old-file)
         ;; If the new path is in a different directory, relative links
         ;; will break. Fix all file-relative links:
         (unless (string= (file-name-directory old-path)

--- a/org-roam.el
+++ b/org-roam.el
@@ -513,10 +513,10 @@ it as FILE-PATH."
                (id-data (org-roam-id-find path))
                (link-type (cond ((and (string= type "file")
                                       (org-roam--org-file-p path))
-                                 "roam")
+                                 "file")
                                 ((and (string= type "id")
                                       id-data)
-                                 "roam-id")
+                                 "id")
                                 ((and
                                   (require 'org-ref nil t)
                                   (-contains? org-ref-cite-types type))
@@ -537,9 +537,9 @@ it as FILE-PATH."
                    (content (org-roam--expand-links content file-path)))
               (let ((context (list :content content :point begin))
                     (names (pcase link-type
-                             ("roam"
+                             ("file"
                               (list (file-truename (expand-file-name path (file-name-directory file-path)))))
-                             ("roam-id"
+                             ("id"
                               (list (car id-data)))
                              ("cite"
                               (org-ref-split-and-strip-string path)))))
@@ -686,7 +686,7 @@ Examples:
                       '("http" "https")))
          (type (cond (cite-prefix "cite")
                      (is-website "website")
-                     (t "roam"))))
+                     (t "file"))))
     type))
 
 (defun org-roam--extract-ref ()
@@ -1179,7 +1179,7 @@ replaced links are made relative to the current buffer."
                                                   :where (= to $s1)
                                                   :and (= type $s2)]
                                                  old-path
-                                                 "roam")))
+                                                 "file")))
         ;; Update headlines in new-file.org after removing the previous IDs
         (with-current-buffer new-buffer
           (org-roam-db--update-cache-headlines old-file))

--- a/org-roam.el
+++ b/org-roam.el
@@ -954,9 +954,11 @@ for Org-ref cite links."
   (interactive "p")
   (cl-letf* (((symbol-function 'org-id-add-location)
               (lambda (&rest args)
-                (message "Successfully nuked")))
-             (org-id-link-to-org-use-id t)
-             (org-id-track-globally t))
+                (if org-id-track-globally
+                    (apply #'org-id-add-location args)
+                  (message "Successfully nuked"))))
+             (org-id-track-globally t)
+             (org-id-link-to-org-use-id t))
     (org-store-link arg)))
 
 ;;; The global minor org-roam-mode

--- a/org-roam.el
+++ b/org-roam.el
@@ -979,9 +979,7 @@ automatic creation of :ID: properties."
       (let* ((id (org-id-get))
              (data (vector id
                            file)))
-        (org-roam-db-query [:insert :into headlines
-                            :values $v1]
-                           data)))))
+        (org-roam-db--insert-headlines data)))))
 
 ;;; The global minor org-roam-mode
 (defun org-roam--find-file-hook-function ()


### PR DESCRIPTION
Fixes #548.

This is the long-heralded PR to add support for headlines into Org-roam.  The goal is to support all the features that are currently supported for files.

I've been prototyping for couple of days to get a feel for the roadmap, and it's going to take me a couple more days to get it to a reviewable level.  I'll ping when it's ready to be reviewed, but in the meantime, you can check where I'm heading.