### PR TITLE
(internal): remove redundant org-ref require

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -37,7 +37,6 @@
 (require 'org)
 (require 'org-element)
 (require 'ob-core) ;for org-babel-parse-header-arguments
-(require 'org-ref nil t) ; To detect cite: links
 (require 'ansi-color) ; org-roam--list-files strip ANSI color codes
 (require 'cl-lib)
 (require 'dash)


### PR DESCRIPTION
###### Motivation for this change

Remove redundant 'org-ref require. Now `org-roam` can load without loading org-ref, but as soon as `org-roam` needs to extract links (e.g. cache build, file save), `org-ref` will be loaded.