### PR TITLE
Add -other-window versions of org-roam-{find-file,switch-to-buffer,jump-to-index}

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Here's a sample configuration with using `use-package`:
       :bind (:map org-roam-mode-map
               (("C-c n l" . org-roam)
                ("C-c n f" . org-roam-find-file)
+               ("C-x 4 C-c n f" . org-roam-find-file-other-window)
                ("C-c n g" . org-roam-show-graph))
               :map org-mode-map
               (("C-c n i" . org-roam-insert))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1305,6 +1305,18 @@ If OTHER-WINDOW is non-nil, open the buffer in another window similarly to
           (org-roam-capture--capture))))))
 
 ;;;###autoload
+(defun org-roam-find-file-other-window (&optional initial-prompt completions filter-fn)
+  "Find and open an Org-roam file in another window.
+INITIAL-PROMPT is the initial title prompt.
+COMPLETIONS is a list of completions to be used instead of
+`org-roam--get-title-path-completions`.
+FILTER-FN is the name of a function to apply on the candidates
+which takes as its argument an alist of path-completions.  See
+`org-roam--get-title-path-completions' for details."
+  (interactive)
+  (org-roam-find-file initial-prompt completions filter-fn t))
+
+;;;###autoload
 (defun org-roam-find-directory ()
   "Find and open `org-roam-directory'."
   (interactive)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1524,6 +1524,12 @@ linked, lest the network graph get too crowded."
 
 
 ;;;###autoload
+(defun org-roam-switch-to-buffer-other-window ()
+  "Switch to an existing Org-roam buffer in another window."
+  (interactive)
+  (org-roam-switch-to-buffer t))
+
+;;;###autoload
 (defun org-roam-version (&optional message)
   "Return `org-roam' version.
 Interactively, or when MESSAGE is non-nil, show in the echo area."

--- a/org-roam.el
+++ b/org-roam.el
@@ -1395,20 +1395,22 @@ If DESCRIPTION is provided, use this as the link label.  See
           (org-roam-capture--capture))))))
 
 ;;;###autoload
-(defun org-roam-jump-to-index ()
+(defun org-roam-jump-to-index (&optional other-window)
   "Find the index file in `org-roam-directory'.
 The path to the index can be defined in `org-roam-index-file'.
 Otherwise, the function will look in your `org-roam-directory'
 for a note whose title is 'Index'.  If it does not exist, the
-command will offer you to create one."
+command will offer you to create one.
+If OTHER-WINDOW is non-nil, open the buffer in another window similarly to
+`find-file-other-window`"
   (interactive)
   (unless org-roam-mode (org-roam-mode))
   (let ((index (org-roam--get-index-path)))
     (if (and index
              (file-exists-p index))
-        (find-file index)
+        (if other-window (find-file-other-window index) (find-file index))
       (when (y-or-n-p "Index file does not exist.  Would you like to create it? ")
-        (org-roam-find-file "Index")))))
+        (org-roam-find-file "Index" nil nil other-window)))))
 
 ;;;###autoload
 (defun org-roam-switch-to-buffer ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -1274,14 +1274,16 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (insert (format "- Org-roam: %s" (org-roam-version)))))
 
 ;;;###autoload
-(defun org-roam-find-file (&optional initial-prompt completions filter-fn)
+(defun org-roam-find-file (&optional initial-prompt completions filter-fn other-window)
   "Find and open an Org-roam file.
 INITIAL-PROMPT is the initial title prompt.
 COMPLETIONS is a list of completions to be used instead of
 `org-roam--get-title-path-completions`.
 FILTER-FN is the name of a function to apply on the candidates
 which takes as its argument an alist of path-completions.  See
-`org-roam--get-title-path-completions' for details."
+`org-roam--get-title-path-completions' for details.
+If OTHER-WINDOW is non-nil, open the buffer in another window similarly to
+`find-file-other-window`"
   (interactive)
   (unless org-roam-mode (org-roam-mode))
   (when (org-roam-capture--in-process-p) (user-error "Org-roam capture in process"))
@@ -1292,7 +1294,9 @@ which takes as its argument an alist of path-completions.  See
          (res (cdr (assoc title-with-tags completions)))
          (file-path (plist-get res :path)))
     (if file-path
-        (find-file file-path)
+        (if other-window
+            (find-file-other-window file-path)
+          (find-file file-path))
       (let ((org-roam-capture--info `((title . ,title-with-tags)
                                       (slug  . ,(org-roam--title-to-slug title-with-tags))))
             (org-roam-capture--context 'title))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1420,8 +1420,10 @@ See `org-roam-jump-to-index`"
   (org-roam-jump-to-index t))
 
 ;;;###autoload
-(defun org-roam-switch-to-buffer ()
-  "Switch to an existing Org-roam buffer."
+(defun org-roam-switch-to-buffer (&optional other-window)
+  "Switch to an existing Org-roam buffer.
+If OTHER-WINDOW is non-nil, open it in another window similarly to
+`find-file-other-window`"
   (interactive)
   (let* ((roam-buffers (org-roam--get-roam-buffers))
          (names-and-buffers (mapcar (lambda (buffer)
@@ -1434,7 +1436,10 @@ See `org-roam-jump-to-index`"
       (user-error "No roam buffers"))
     (when-let ((name (org-roam-completion--completing-read "Buffer: " names-and-buffers
                                                            :require-match t)))
-      (switch-to-buffer (cdr (assoc name names-and-buffers))))))
+      (let  ((buffer (cdr (assoc name names-and-buffers))))
+        (if other-window
+            (switch-to-buffer-other-window buffer)
+          (switch-to-buffer buffer))))))
 
 (defun org-roam--execute-file-row-col (s)
   "Move to row:col if S match the row:col syntax. To be used with `org-execute-file-search-functions'."

--- a/org-roam.el
+++ b/org-roam.el
@@ -1413,6 +1413,13 @@ If OTHER-WINDOW is non-nil, open the buffer in another window similarly to
         (org-roam-find-file "Index" nil nil other-window)))))
 
 ;;;###autoload
+(defun org-roam-jump-to-index-other-window ()
+  "Find the index file in `org-roam-directory' and open it in another window.
+See `org-roam-jump-to-index`"
+  (interactive)
+  (org-roam-jump-to-index t))
+
+;;;###autoload
 (defun org-roam-switch-to-buffer ()
   "Switch to an existing Org-roam buffer."
   (interactive)


### PR DESCRIPTION
###### Motivation for this change

Emacs has some [nice keybindings for manipulating buffers in another window](https://www.gnu.org/software/emacs/manual/html_node/emacs/Pop-Up-Window.html). These keybindings start with `C-x 4`, e.g.
* `C-x 4 b` opens an existing buffer in another window.
* `C-x 4 f` opens a file in another window.

I wanted to have similar keybindings for org-roam functions: `org-roam-find-file`, `org-roam-switch-to-buffer`, `org-roam-jump-to-index`. So I added `other-window` optional argument to these functions and created `org-roam-find-file-other-window`, `org-roam-switch-to-buffer-other-window`, `org-roam-jump-to-index-other-window`. Now we can have org-roam related keybindings which start with `C-x 4`. This is how I use it:

```
(define-key org-roam-mode-map (kbd "C-x 4 C-c n f") #'org-roam-find-file-other-window)
(define-key org-roam-mode-map (kbd "C-x 4 C-c n j") #'org-roam-jump-to-index-other-window)
(define-key org-roam-mode-map (kbd "C-x 4 C-c n b") #'org-roam-switch-to-buffer-other-window)
```