### PR TITLE
(fix): Fix syntax for calling compiled versions of functions

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -858,9 +858,9 @@ This face is used for links without a destination."
              map)
   (if org-roam-backlinks-mode
       (add-hook 'org-open-at-point-functions
-                'org-roam-open-at-point nil 'local)
+                #'org-roam-open-at-point nil 'local)
     (remove-hook 'org-open-at-point-functions
-                 'org-roam-open-at-point 'local)))
+                 #'org-roam-open-at-point 'local)))
 
 (defun org-roam--in-buffer-p ()
   "Return t if in the Org-roam buffer."


### PR DESCRIPTION
I'm not one to `git blame`, which is why I won't say that eae97487dcbea2b09249455a390fa501154aec79 introduced it. 🤡