### PR TITLE
(feat): org-roam-find-file-function customization

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -49,6 +49,7 @@
 (declare-function org-roam--get-backlinks     "org-roam")
 (declare-function org-roam-backlinks-mode     "org-roam")
 (declare-function org-roam-mode               "org-roam")
+(declare-function org-roam--find-file         "org-roam")
 
 (defcustom org-roam-buffer-position 'right
   "Position of `org-roam' buffer.
@@ -96,6 +97,14 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
 
 (defvar org-roam-buffer--current nil
   "Currently displayed file in `org-roam' buffer.")
+
+(defun org-roam-buffer--find-file (file)
+  "Open FILE in the window `org-roam' was called from."
+  (if (and org-roam-last-window (window-valid-p org-roam-last-window))
+      (progn (with-selected-window org-roam-last-window
+               (org-roam--find-file file))
+             (select-window org-roam-last-window))
+    (org-roam--find-file file)))
 
 (defun org-roam-buffer--insert-title ()
   "Insert the org-roam-buffer title."

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -42,6 +42,7 @@
 (declare-function  org-roam--get-title-path-completions "org-roam")
 (declare-function  org-roam--get-ref-path-completions   "org-roam")
 (declare-function  org-roam--file-path-from-id          "org-roam")
+(declare-function  org-roam--find-file                  "org-roam")
 (declare-function  org-roam--format-link                "org-roam")
 (declare-function  org-roam--title-to-slug              "org-roam")
 (declare-function  org-roam-mode                        "org-roam")
@@ -305,7 +306,7 @@ This is added as a hook to `org-capture-after-finalize-hook'.
 Run the hooks defined in `org-roam-capture-after-find-file-hook'."
   (unless org-note-abort
     (when-let ((file-path (org-roam-capture--get :file-path)))
-      (find-file file-path))
+      (org-roam--find-file file-path))
     (run-hooks 'org-roam-capture-after-find-file-hook))
   (remove-hook 'org-capture-after-finalize-hook #'org-roam-capture--find-file-h))
 

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -78,7 +78,7 @@ It should contain the FILE key, pointing to the path of the file to open.
 org-protocol://roam-file?file=/path/to/file.org"
   (when-let ((file (plist-get info :file)))
     (raise-frame)
-    (find-file file))
+    (org-roam--find-file file))
   nil)
 
 (push '("org-roam-ref"  :protocol "roam-ref"   :function org-roam-protocol-open-ref)

--- a/org-roam.el
+++ b/org-roam.el
@@ -104,6 +104,12 @@ ensure that."
   :type '(repeat string)
   :group 'org-roam)
 
+(defcustom org-roam-find-file-function nil
+  "Function called when visiting files in Org-roam commands.
+If nil, `find-file' is used."
+  :type 'function
+  :group 'org-roam)
+
 (defcustom org-roam-include-type-in-ref-path-completions nil
   "When t, include the type in ref-path completions.
 Note that this only affects interactive calls.
@@ -838,6 +844,10 @@ included as a candidate."
                 (v (list :path file-path :type type :ref ref)))
             (push (cons k v) completions)))))))
 
+(defun org-roam--find-file (file)
+  "Open FILE using `org-roam-find-file-function' or `find-file'."
+  (funcall (or org-roam-find-file-function #'find-file) file))
+
 (defun org-roam--find-ref (ref)
   "Find and open and Org-roam file from REF if it exists.
 REF should be the value of '#+roam_key:' without any
@@ -845,7 +855,7 @@ type-information (e.g. 'cite:').
 Return nil if the file does not exist."
   (when-let* ((completions (org-roam--get-ref-path-completions))
               (file (plist-get (cdr (assoc ref completions)) :path)))
-    (find-file file)))
+    (org-roam--find-file file)))
 
 (defun org-roam--get-roam-buffers ()
   "Return a list of buffers that are Org-roam files."
@@ -969,26 +979,18 @@ This function hooks into `org-open-at-point' via `org-open-at-point-functions'."
       (when (and (eq (org-element-type context) 'link)
                  (string= "file" type)
                  (org-roam--org-roam-file-p (file-truename path)))
-        (org-roam--find-file path)
+        (org-roam-buffer--find-file path)
         (org-show-context)
         t)))
    ;; Org-roam preview text
    ((when-let ((file-from (get-text-property (point) 'file-from))
                (p (get-text-property (point) 'file-from-point)))
-      (org-roam--find-file file-from)
+      (org-roam-buffer--find-file file-from)
       (goto-char p)
       (org-show-context)
       t))
    ;; If called via `org-open-at-point', fall back to default behavior.
    (t nil)))
-
-(defun org-roam--find-file (file)
-  "Open FILE in the window `org-roam' was called from."
-  (if (and org-roam-last-window (window-valid-p org-roam-last-window))
-      (progn (with-selected-window org-roam-last-window
-               (find-file file))
-             (select-window org-roam-last-window))
-    (find-file file)))
 
 (defun org-roam--get-backlinks (target)
   "Return the backlinks for TARGET.
@@ -1292,7 +1294,7 @@ which takes as its argument an alist of path-completions.  See
          (res (cdr (assoc title-with-tags completions)))
          (file-path (plist-get res :path)))
     (if file-path
-        (find-file file-path)
+        (org-roam--find-file file-path)
       (let ((org-roam-capture--info `((title . ,title-with-tags)
                                       (slug  . ,(org-roam--title-to-slug title-with-tags))))
             (org-roam-capture--context 'title))
@@ -1304,7 +1306,7 @@ which takes as its argument an alist of path-completions.  See
 (defun org-roam-find-directory ()
   "Find and open `org-roam-directory'."
   (interactive)
-  (find-file org-roam-directory))
+  (org-roam--find-file org-roam-directory))
 
 ;;;###autoload
 (defun org-roam-find-ref (arg &optional filter)
@@ -1326,7 +1328,7 @@ included as a candidate."
                                                     :require-match t))
          (file (-> (cdr (assoc ref completions))
                    (plist-get :path))))
-    (find-file file)))
+    (org-roam--find-file file)))
 
 ;;;###autoload
 (defun org-roam-insert (&optional lowercase completions filter-fn description)
@@ -1390,7 +1392,7 @@ command will offer you to create one."
   (let ((index (org-roam--get-index-path)))
     (if (and index
              (file-exists-p index))
-        (find-file index)
+        (org-roam--find-file index)
       (when (y-or-n-p "Index file does not exist.  Would you like to create it? ")
         (org-roam-find-file "Index")))))
 


### PR DESCRIPTION
Allow users to specify a function for finding files in various commands.
Can be let-bound to define new commands that suit user preferences.

See: #790
