### PR TITLE
(fix): fix unlinked-references for older Emacs

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1451,7 +1451,7 @@ linked, lest the network graph get too crowded."
            (file-loc (buffer-file-name))
            (buf (get-buffer-create "*org-roam unlinked references*"))
            (results (split-string (shell-command-to-string rg-command) "\n"))
-           (result-regex (rx (group (one-or-more anychar))
+           (result-regex (rx (group (one-or-more anything))
                              ":"
                              (group (one-or-more digit))
                              ":"


### PR DESCRIPTION
###### Motivation for this change

Emacs' in-built rx.el was rewritten in Emacs 27, and the form `anychar`
only exists in later versions. We use the older form `anything` that has
support even in Emacs 26.

Emacs 26: https://github.com/emacs-mirror/emacs/blob/emacs-26/lisp/emacs-lisp/rx.el#L889


