### PR TITLE
(ux): update the error message for org-roam-unlinked-references

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1438,7 +1438,7 @@ linked, lest the network graph get too crowded."
   (unless (org-roam--org-roam-file-p)
     (user-error "Not in org-roam file"))
   (if (not (executable-find "rg"))
-      (user-error "Cannot find the rigrep executable \"rg\". Check that it is installed and available on `exec-path'")
+      (error "Cannot find the rigrep executable \"rg\". Check that it is installed and available on `exec-path'")
     (let* ((titles (org-roam--extract-titles))
            (rg-command (concat "rg -o --vimgrep -P -i "
                                (string-join (mapcar (lambda (glob) (concat "-g " glob))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1438,7 +1438,7 @@ linked, lest the network graph get too crowded."
   (unless (org-roam--org-roam-file-p)
     (user-error "Not in org-roam file"))
   (if (not (executable-find "rg"))
-      (user-error "Cannot find the \"rg\" executable, aborting")
+      (user-error "Cannot find the rigrep executable \"rg\". Check that it is installed and available on `exec-path'")
     (let* ((titles (org-roam--extract-titles))
            (rg-command (concat "rg -o --vimgrep -P -i "
                                (string-join (mapcar (lambda (glob) (concat "-g " glob))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1438,7 +1438,7 @@ linked, lest the network graph get too crowded."
   (unless (org-roam--org-roam-file-p)
     (user-error "Not in org-roam file"))
   (if (not (executable-find "rg"))
-      (error "Cannot find the rigrep executable \"rg\". Check that it is installed and available on `exec-path'")
+      (error "Cannot find the ripgrep executable \"rg\". Check that it is installed and available on `exec-path'")
     (let* ((titles (org-roam--extract-titles))
            (rg-command (concat "rg -o --vimgrep -P -i "
                                (string-join (mapcar (lambda (glob) (concat "-g " glob))


### PR DESCRIPTION
###### Motivation for this change

`rg` might be unfamiliar to some, so let's mention the name of the full
executable name.