### PR TITLE
(doc): Add :ensure to use-package declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Here's a sample configuration with using `use-package`:
 
 ```emacs-lisp
 (use-package org-roam
+      :ensure t
       :hook
       (after-init . org-roam-mode)
       :custom


### PR DESCRIPTION
Ensure use-package installs org-roam.

See: #803
