### PR TITLE
Fixes caar into caadr for PRAGMA "user_version"

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -92,7 +92,7 @@ Performs a database upgrade when required."
                  org-roam-db--connection)
         (when init-db
           (org-roam-db--init conn))
-        (let* ((version (caar (emacsql conn "PRAGMA user_version")))
+        (let* ((version (caadr (emacsql conn "PRAGMA user_version")))
                (version (org-roam-db--update-maybe conn version)))
           (cond
            ((> version org-roam-db--version)


### PR DESCRIPTION
###### Motivation for this change
When evaluating this code
```emacs-lisp
(let ((conn (emacsql-sqlite3 "~/path/to/org-roam.db")))
  (emacsql conn "PRAGMA user_version"))
;;; => ((user_version) (3) (Run Time: real 0.0 user 4.8e-05 sys 0.0))
```
if we use `caar` it returns `"user_version"` instead of `3` which is what we want.
Switching to `caadr` fixes this.
