### PR TITLE
return selected file from org-roam-insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Features
 - [#814] Implement `org-roam-insert-immediate`
 - [#833](https://github.com/org-roam/org-roam/pull/833) Add customization of file titles with `org-roam-title-to-slug-function`. 
+- [#839](https://github.com/org-roam/org-roam/pull/839) Return selected file from `org-roam-insert`
+
 ### Bugfixes
 
 ## 1.2.0 (12-06-2020)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1339,6 +1339,7 @@ included as a candidate."
 ;;;###autoload
 (defun org-roam-insert (&optional lowercase completions filter-fn description)
   "Find an Org-roam file, and insert a relative org link to it at point.
+Return selected file if it exists.
 If LOWERCASE, downcase the title before insertion.
 COMPLETIONS is a list of completions to be used instead of
 `org-roam--get-title-path-completions`.
@@ -1384,7 +1385,8 @@ If DESCRIPTION is provided, use this as the link label.  See
                                                                :link-description link-description
                                                                :capture-fn 'org-roam-insert))
         (org-roam--with-template-error 'org-roam-capture-templates
-          (org-roam-capture--capture))))))
+          (org-roam-capture--capture))))
+    res))
 
 ;;;###autoload
 (defun org-roam-insert-immediate (arg &rest args)


### PR DESCRIPTION
###### Motivation for this change

This is useful in scenarios when you want to automatically do something with the
context where the link was inserted. For example, if you are linking someone in
the task, you can add a special tag for this person.

```emacs-lisp
(defun +org-notes-insert ()
  "Insert a link to the note."
  (interactive)
  (when-let* ((res (org-roam-insert))
              (path (plist-get res :path))
              (title (plist-get res :title))
              (roam-tags (+seq-flatten
                          (+seq-flatten
                           (org-roam-db-query [:select tags
                                               :from tags
                                               :where (= file $s1)]
                                              path)))))
    (when (seq-contains-p roam-tags "People")
      (save-excursion
        (ignore-errors
          (org-back-to-heading)
          (let ((tags (org-get-tags)))
            (org-set-tags (seq-uniq (cons (+org-notes--title-to-tag title) tags)))))))))

(defun +org-notes--title-to-tag (title)
  "Convert TITLE to tag."
  (concat "@" (s-replace " " "" title)))
```
