### PR TITLE
s/org-roam-show-graph/org-roam-graph-show/ README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Here's a sample configuration with using `use-package`:
       :bind (:map org-roam-mode-map
               (("C-c n l" . org-roam)
                ("C-c n f" . org-roam-find-file)
-               ("C-c n g" . org-roam-show-graph))
+               ("C-c n g" . org-roam-graph-show))
               :map org-mode-map
               (("C-c n i" . org-roam-insert))
               (("C-c n I" . org-roam-insert-immediate))))


### PR DESCRIPTION
###### Motivation for this change

I used the exsisting example from the README and was told:

> ‘org-roam-show-graph’ is an obsolete command (as of org-roam 1.0.0); use ‘org-roam-graph-show’ instead.

