### PR TITLE
(fix): fix emacsql-sqlite3-executable possibly unbound

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1234,7 +1234,8 @@ Otherwise, behave as if called interactively."
   :global t
   (cond
    (org-roam-mode
-    (unless (or (file-executable-p emacsql-sqlite3-executable)
+    (unless (or (and (fboundp 'emacsql-sqlite3-executable)
+                     (file-executable-p emacsql-sqlite3-executable))
                 (executable-find "sqlite3"))
       (lwarn '(org-roam) :error "Cannot find executable 'sqlite3'. \
 Ensure it is installed and can be found within `exec-path'. \


### PR DESCRIPTION
###### Motivation for this change

On old versions of emacsql-sqlite3, this will catastrophically fail. Ref #838 