### PR TITLE
(perf): use sqlite transactions, and GC less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Breaking Changes
 
 ### Features
-- [#814] Implement `org-roam-insert-immediate`
+- [#814](https://github.com/org-roam/org-roam/pull/814) Implement `org-roam-insert-immediate`
 - [#833](https://github.com/org-roam/org-roam/pull/833) Add customization of file titles with `org-roam-title-to-slug-function`. 
 - [#839](https://github.com/org-roam/org-roam/pull/839) Return selected file from `org-roam-insert`
+- [#847](https://github.com/org-roam/org-roam/pull/847) Add GC threshold `org-roam-db-gc-threshold` to temporarily change the threshold on expensive operations.
+- [#847](https://github.com/org-roam/org-roam/pull/847) Use sqlite3 transactions instead of storing the values to be inserted.
 
 ### Bugfixes
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -60,6 +60,10 @@ when used with multiple Org-roam instances."
   :type 'string
   :group 'org-roam)
 
+(defcustom org-roam-db-gc-threshold most-positive-fixnum
+  "The value to set the `gc-cons-threshold' threshold to, during
+  large, heavy operations like `org-roam-db-build-cache'.")
+
 (defconst org-roam-db--version 6)
 
 (defvar org-roam-db--connection (make-hash-table :test #'equal)
@@ -403,7 +407,8 @@ If FORCE, force a rebuild of the cache from scratch."
   (when force (delete-file (org-roam-db--get)))
   (org-roam-db--close) ;; Force a reconnect
   (org-roam-db) ;; To initialize the database, no-op if already initialized
-  (let* ((org-roam-files (org-roam--list-all-files))
+  (let* ((gc-cons-threshold org-roam-db-gc-threshold)
+         (org-roam-files (org-roam--list-all-files))
          (current-files (org-roam-db--get-current-files))
          (file-count 0)
          (headline-count 0)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -61,8 +61,12 @@ when used with multiple Org-roam instances."
   :group 'org-roam)
 
 (defcustom org-roam-db-gc-threshold most-positive-fixnum
-  "The value to set the `gc-cons-threshold' threshold to, during
-large, heavy operations like `org-roam-db-build-cache'."
+  "The value to temporarily set the `gc-cons-threshold' threshold to.
+During large, heavy operations like `org-roam-db-build-cache',
+many GC operations happen because of the large number of
+temporary structures generated (e.g. parsed ASTs). Temporarily
+increasing `gc-cons-threshold' will help reduce the number of GC
+operations, at the cost of temporary memory usage."
   :type 'int
   :group 'org-roam)
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -411,12 +411,7 @@ If FORCE, force a rebuild of the cache from scratch."
          (tag-count 0)
          (title-count 0)
          (ref-count 0)
-         (deleted-count 0)
-         (temp-buffer (generate-new-buffer " *temp*"))
-         (current-org-roam-directory (make-symbol "current-org-roam-directory"))
-         (current-org-roam-directory org-roam-directory))
-    (with-current-buffer temp-buffer
-      (setq org-roam-directory current-org-roam-directory))
+         (deleted-count 0))
     (emacsql-with-transaction (org-roam-db--get-connection)
       ;; Two-step building
       ;; First step: Rebuild files and headlines
@@ -424,10 +419,7 @@ If FORCE, force a rebuild of the cache from scratch."
         (let* ((attr (file-attributes file))
                (atime (file-attribute-access-time attr))
                (mtime (file-attribute-modification-time attr)))
-          (with-current-buffer temp-buffer
-            (setq-local org-roam-file-name file)
-            (erase-buffer)
-            (insert-file-contents file)
+          (org-roam--with-temp-buffer file
             (let ((contents-hash (secure-hash 'sha1 (current-buffer))))
               (unless (string= (gethash file current-files)
                                contents-hash)
@@ -445,10 +437,7 @@ If FORCE, force a rebuild of the cache from scratch."
                   (setq headline-count (1+ headline-count))))))))
       ;; Second step: Rebuild the rest
       (dolist (file org-roam-files)
-        (with-current-buffer temp-buffer
-          (setq-local org-roam-file-name file)
-          (erase-buffer)
-          (insert-file-contents file)
+        (org-roam--with-temp-buffer file
           (let ((contents-hash (secure-hash 'sha1 (current-buffer))))
             (unless (string= (gethash file current-files)
                              contents-hash)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -62,7 +62,9 @@ when used with multiple Org-roam instances."
 
 (defcustom org-roam-db-gc-threshold most-positive-fixnum
   "The value to set the `gc-cons-threshold' threshold to, during
-  large, heavy operations like `org-roam-db-build-cache'.")
+large, heavy operations like `org-roam-db-build-cache'."
+  :type 'int
+  :group 'org-roam)
 
 (defconst org-roam-db--version 6)
 

--- a/tests/test-org-roam-perf.el
+++ b/tests/test-org-roam-perf.el
@@ -45,7 +45,7 @@
     (pcase (benchmark-run 1 (org-roam-db-build-cache t))
       (`(,time ,gcs ,time-in-gc)
        (message "Elapsed time: %fs (%fs in %d GCs)" time time-in-gc gcs)
-       (expect time :to-be-less-than 100))))
+       (expect time :to-be-less-than 60))))
   (it "builds quickly without change"
     (pcase (benchmark-run 1 (org-roam-db-build-cache))
       (`(,time ,gcs ,time-in-gc)


### PR DESCRIPTION
###### Motivation for this change

We use sqlite transactions to commit changes into the database, rather than storing all the data in a list before running one big insert. Hopefully this gives a noticeable perf boost.

Also add `org-roam-db-gc-threshold`, which defaults to a large number. This allows expensive operations like `org-roam-db-build-cache` to execute faster (on 1000 files, cuts execution time from 70s to 50s).

Ref #834