### PR TITLE
(feat): add 'first-directory option for org-roam-tag-sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#814] Implement `org-roam-insert-immediate`
 - [#833](https://github.com/org-roam/org-roam/pull/833) Add customization of file titles with `org-roam-title-to-slug-function`. 
 - [#839](https://github.com/org-roam/org-roam/pull/839) Return selected file from `org-roam-insert`
+- [#851](https://github.com/org-roam/org-roam/pull/851) Add `'first-directory'` option for `org-roam-tag-sources`
 
 ### Bugfixes
 

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -306,6 +306,9 @@ extraction methods supported are:
 3. ='last-directory=: Extracts the last directory relative to
    =org-roam-directory= as the tag. That is, if a file is located at relative
    path =foo/bar/file.org=, the file will have tag =bar=.
+4. ='first-directory=: Extracts the first directory relative to
+   =org-roam-directory= as the tag. That is, if a file is located at relative
+   path =foo/bar/file.org=, the file will have tag =foo=.
 
 By default, only the ='prop= extraction method is enabled. To enable the other
 extraction methods, you may modify =org-roam-tag-sources=:

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -468,6 +468,10 @@ extracted as tags. That is, if a file is located at relative path
 @samp{'last-directory}: Extracts the last directory relative to
 @samp{org-roam-directory} as the tag. That is, if a file is located at relative
 path @samp{foo/bar/file.org}, the file will have tag @samp{bar}.
+@item
+@samp{'first-directory}: Extracts the first directory relative to
+@samp{org-roam-directory} as the tag. That is, if a file is located at relative
+path @samp{foo/bar/file.org}, the file will have tag @samp{foo}.
 @end enumerate
 
 By default, only the @samp{'prop} extraction method is enabled. To enable the other

--- a/org-roam.el
+++ b/org-roam.el
@@ -202,10 +202,16 @@ extraction methods:
   `last-directory'
     Extract the last directory relative to `org-roam-directory'.
     That is, if a file is located at relative path foo/bar/file.org,
-    the file will have tag \"bar\"."
+    the file will have tag \"bar\".
+
+  `first-directory'
+    Extract the first directory relative to `org-roam-directory'.
+    That is, if a file is located at relative path foo/bar/file.org,
+    the file will have tag \"foo\"."
   :type '(set (const :tag "#+roam_tags" prop)
               (const :tag "sub-directories" all-directories)
-              (const :tag "parent directory" last-directory)))
+              (const :tag "parent directory" last-directory)
+              (const :tag "first sub-directory" first-directory)))
 
 (defcustom org-roam-title-to-slug-function #'org-roam--title-to-slug
   "Function to be used in converting a title to the filename slug.
@@ -641,6 +647,14 @@ The final directory component is used as a tag."
   (when-let ((dir-relative (file-name-directory
                             (file-relative-name file org-roam-directory))))
     (last (f-split dir-relative))))
+
+(defun org-roam--extract-tags-first-directory (file)
+  "Extract tags from path FILE.
+The first directory component after `org-roam-directory' is used as a
+tag."
+  (when-let ((dir-relative (file-name-directory
+                            (file-relative-name file org-roam-directory))))
+    (list (car (f-split dir-relative)))))
 
 (defun org-roam--extract-tags-prop (_file)
   "Extract tags from the current buffer's \"#roam_tags\" global property."

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -211,6 +211,20 @@
               :to-equal
               '("deeply")))
 
+    (it "extracts from first directory"
+      (expect (test #'org-roam--extract-tags-first-directory
+                    "base.org")
+              :to-equal
+              nil)
+      (expect (test #'org-roam--extract-tags-first-directory
+                    "tags/tag.org")
+              :to-equal
+              '("tags"))
+      (expect (test #'org-roam--extract-tags-first-directory
+                    "nested/deeply/deeply_nested_file.org")
+              :to-equal
+              '("nested")))
+
     (describe "uses org-roam-tag-sources correctly"
       (it "'(prop)"
         (expect (let ((org-roam-tag-sources '(prop)))


### PR DESCRIPTION
###### Motivation for this change

I use a directory structure where each subdirectory of `org-roam-directory` is a separate slip-box (e.g., literature notes, work notes, etc).

I believe that's a common enough setup to add built-in support.
