### PR TITLE
(feat): warn on duplicate IDs rather than fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Bugfixes
 
+- [#854](https://github.com/org-roam/org-roam/pull/854) Warn instead of fail when duplicate refs and IDs exist.
+
 ## 1.2.0 (12-06-2020)
 
 In this release, we improved the linking process by achieving feature parity between links to files and links to headlines. Before, we used the `file:foo::*bar` format to link to the headline `bar` in file `foo`, but this was prone to breakage upon renaming the file or modifying the headline. This is not the case anymore. Now, we use `org-id` to create IDs for those headlines, which are then stored in our database to compute the relationships and jump around. Note that this will work even if you’re not using `org-id` in your global configuration for Org-mode.


### PR DESCRIPTION
###### Motivation for this change

Closes #816. Warn on duplicate IDs and refs, rather than fail catastrophically. Attempt is made to show a useful error message:

![image](https://user-images.githubusercontent.com/1667473/85220175-0b2e9280-b3dc-11ea-8d89-5d292fdf4323.png)

![image](https://user-images.githubusercontent.com/1667473/85220194-2f8a6f00-b3dc-11ea-8782-30b41960fef9.png)

