### PR TITLE
(bugfix): fix tag extraction for symlinked directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugfixes
 
 - [#854](https://github.com/org-roam/org-roam/pull/854) Warn instead of fail when duplicate refs and IDs exist.
+- [#857](https://github.com/org-roam/org-roam/pull/857) Fix tag extraction for symlinked directories.
 
 ## 1.2.0 (12-06-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -638,14 +638,14 @@ If NESTED, return the first successful result from SOURCES."
   "Extract tags from using the directory path FILE.
 All sub-directories relative to `org-roam-directory' are used as tags."
   (when-let ((dir-relative (file-name-directory
-                            (file-relative-name file org-roam-directory))))
+                            (file-relative-name file (file-truename org-roam-directory)))))
     (f-split dir-relative)))
 
 (defun org-roam--extract-tags-last-directory (file)
   "Extract tags from using the directory path FILE.
 The final directory component is used as a tag."
   (when-let ((dir-relative (file-name-directory
-                            (file-relative-name file org-roam-directory))))
+                            (file-relative-name file (file-truename org-roam-directory)))))
     (last (f-split dir-relative))))
 
 (defun org-roam--extract-tags-first-directory (file)
@@ -653,7 +653,7 @@ The final directory component is used as a tag."
 The first directory component after `org-roam-directory' is used as a
 tag."
   (when-let ((dir-relative (file-name-directory
-                            (file-relative-name file org-roam-directory))))
+                            (file-relative-name file (file-truename org-roam-directory)))))
     (list (car (f-split dir-relative)))))
 
 (defun org-roam--extract-tags-prop (_file)


### PR DESCRIPTION
###### Motivation for this change

Resolves symlinks before computing relative paths. Fixes #855.