### PR TITLE
Wrap updates in a sql transaction

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -427,12 +427,13 @@ connections, nil is returned."
                    (current-buffer))))
       (with-current-buffer buf
         (save-excursion
-          (org-roam-db--update-meta)
-          (org-roam-db--update-tags)
-          (org-roam-db--update-titles)
-          (org-roam-db--update-refs)
-          (org-roam-db--update-headlines)
-          (org-roam-db--update-links)
+          (emacsql-with-transaction (org-roam-db--get-connection)
+            (org-roam-db--update-meta)
+            (org-roam-db--update-tags)
+            (org-roam-db--update-titles)
+            (org-roam-db--update-refs)
+            (org-roam-db--update-headlines)
+            (org-roam-db--update-links))
           (org-roam-buffer--update-maybe :redisplay t))))))
 
 (defun org-roam-db-build-cache (&optional force)


### PR DESCRIPTION
This will ensure atomicity with updates and should stop any partial
updates that may occur.


----

###### Motivation for this change

Possible future errors arising from database partial updates. I'm not aware of any bugs due to this currently