### PR TITLE
Improve roam-ref docs

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -777,7 +777,7 @@ This protocol finds or creates a new note with a given ~roam_key~ (see [[*Anatom
 
 [[file:images/roam-ref.gif]]
 
-To use this, create a Firefox bookmarklet as follows:
+To use this, create the following [[https://en.wikipedia.org/wiki/Bookmarklet][bookmarklet]] in your browser:
 
 #+BEGIN_SRC javascript
 javascript:location.href =

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1068,7 +1068,7 @@ This protocol finds or creates a new note with a given @code{roam_key} (see @ref
 
 @image{images/roam-ref,,,,gif}
 
-To use this, create a Firefox bookmarklet as follows:
+To use this, create the following @uref{https://en.wikipedia.org/wiki/Bookmarklet, bookmarklet} in your browser:
 
 @example
 javascript:location.href =


### PR DESCRIPTION
The current documentation made me think that bookmarklet feature was
limited to Firefox. This patch slightly improves it.
