### PR TITLE
(internal): fix expand-file usage in org-roam--expand-links

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -506,8 +506,7 @@ PATH should be the root from which to compute the relativity."
         (when (f-relative-p link)
           (delete-region (match-beginning 1)
                          (match-end 1))
-          (insert (expand-file-name
-                   (concat dir link)))))
+          (insert (expand-file-name link dir))))
       (buffer-string))))
 
 (defun org-roam--get-outline-path ()


### PR DESCRIPTION
###### Motivation for this change

This seemed to fix some link expansions for me.