### PR TITLE
(bugfix): prevent file-exists-p opening tramp links

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -998,8 +998,8 @@ Applies `org-roam-link-current' if PATH corresponds to the
 currently opened Org-roam file in the backlink buffer, or
 `org-roam-link-face' if PATH corresponds to any other Org-roam
 file."
-  (cond ((or (file-remote-p path) ;; Prevent lockups opening Tramp links
-             (not (file-exists-p path)))
+  (cond ((and (not (file-remote-p path)) ;; Prevent lockups opening Tramp links
+              (not (file-exists-p path)))
          'org-roam-link-invalid)
         ((and (org-roam--in-buffer-p)
               (org-roam--backlink-to-current-p))

--- a/org-roam.el
+++ b/org-roam.el
@@ -998,7 +998,8 @@ Applies `org-roam-link-current' if PATH corresponds to the
 currently opened Org-roam file in the backlink buffer, or
 `org-roam-link-face' if PATH corresponds to any other Org-roam
 file."
-  (cond ((not (file-exists-p path))
+  (cond ((or (file-remote-p path) ;; Prevent lockups opening Tramp links
+             (not (file-exists-p path)))
          'org-roam-link-invalid)
         ((and (org-roam--in-buffer-p)
               (org-roam--backlink-to-current-p))


### PR DESCRIPTION
###### Motivation for this change

Links like `/ssh:me@host:/` cause emacs to lock up asking for the password repeatedly due to using `file-exists-p` in a function passed to font lock.