### PR TITLE
(internal): add delta symbol in org-roam message

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -510,7 +510,7 @@ If FORCE, force a rebuild of the cache from scratch."
         ;; These files are no longer around, remove from cache...
         (org-roam-db--clear-file file)
         (setq deleted-count (1+ deleted-count))))
-    (org-roam-message "files: %s, headlines: %s, links: %s, tags: %s, titles: %s, refs: %s, deleted: %s"
+    (org-roam-message "files: 𝚫%s, headlines: 𝚫%s, links: 𝚫%s, tags: 𝚫%s, titles: 𝚫%s, refs: 𝚫%s, deleted: 𝚫%s"
                       file-count
                       headline-count
                       link-count


### PR DESCRIPTION
###### Motivation for this change

This makes it clearer that the message shows the changes in the
database, and not the total number.

Ref: https://github.com/org-roam/org-roam/issues/881#issuecomment-653732953