### PR TITLE
(tests): increase perf test threshold

### DIFF
--- a/tests/test-org-roam-perf.el
+++ b/tests/test-org-roam-perf.el
@@ -45,7 +45,7 @@
     (pcase (benchmark-run 1 (org-roam-db-build-cache t))
       (`(,time ,gcs ,time-in-gc)
        (message "Elapsed time: %fs (%fs in %d GCs)" time time-in-gc gcs)
-       (expect time :to-be-less-than 90))))
+       (expect time :to-be-less-than 100))))
   (it "builds quickly without change"
     (pcase (benchmark-run 1 (org-roam-db-build-cache))
       (`(,time ,gcs ,time-in-gc)


### PR DESCRIPTION
###### Motivation for this change

Things take more time to run now that we are also caching headline hierarchies.