### PR TITLE
(fix): rename links as long as old file is Org-roam file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - [#854](https://github.com/org-roam/org-roam/pull/854) Warn instead of fail when duplicate refs and IDs exist.
 - [#857](https://github.com/org-roam/org-roam/pull/857) Fix tag extraction for symlinked directories.
+- [#894](https://github.com/org-roam/org-roam/pull/894) Perform link fixes on all Org-roam files
 
 ## 1.2.0 (12-06-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1226,7 +1226,7 @@ replaced links are made relative to the current buffer."
                     new-file-or-dir)))
     (when (and (not (auto-save-file-name-p old-file))
                (not (auto-save-file-name-p new-file))
-               (org-roam--org-roam-file-p new-file))
+               (org-roam--org-roam-file-p old-file))
       (org-roam-db--ensure-built)
       (let* ((old-path (file-truename old-file))
              (new-path (file-truename new-file))
@@ -1263,7 +1263,8 @@ replaced links are made relative to the current buffer."
           (with-current-buffer new-buffer
             (org-roam--fix-relative-links old-path)
             (save-buffer)))
-        (org-roam-db--update-file new-path)))))
+        (when (org-roam--org-roam-file-p new-file)
+          (org-roam-db--update-file new-path))))))
 
 ;;;###autoload
 (define-minor-mode org-roam-mode


### PR DESCRIPTION
###### Motivation for this change


Previously, if the new file is no longer an Org-roam file, links will
not be fixed. The current behaviour is now to perform the link fixes as
long as the old file as an Org-roam file.

Closes #893