### PR TITLE
(feat): add org-roam-random-note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - [#847](https://github.com/org-roam/org-roam/pull/847) Add GC threshold `org-roam-db-gc-threshold` to temporarily change the threshold on expensive operations.
 - [#847](https://github.com/org-roam/org-roam/pull/847) Use sqlite3 transactions instead of storing the values to be inserted.
 - [#851](https://github.com/org-roam/org-roam/pull/851) Add `'first-directory'` option for `org-roam-tag-sources`
-- [#863](https://github.com/org-roam/org-roam/pull/863) Display outline hierarchy in backlinks buffer 
+- [#863](https://github.com/org-roam/org-roam/pull/863) Display outline hierarchy in backlinks buffer
+- [#898](https://github.com/org-roam/org-roam/pull/898) Add `org-roam-random-note` to browse a random note.
 
 ### Bugfixes
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1394,6 +1394,12 @@ included as a candidate."
     (org-roam--find-file file)))
 
 ;;;###autoload
+(defun org-roam-random-note ()
+  "Find a random Org-roam file."
+  (interactive)
+  (find-file (seq-random-elt (org-roam--list-all-files))))
+
+;;;###autoload
 (defun org-roam-insert (&optional lowercase completions filter-fn description)
   "Find an Org-roam file, and insert a relative org link to it at point.
 Return selected file if it exists.


### PR DESCRIPTION
###### Motivation for this change

Adds an interactive function that browses to a random note. Closes #856.