### PR TITLE
(feat): Improve interactive format for ref completions

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -895,10 +895,10 @@ included as a candidate."
               (let ((k (if interactive
                            (concat
                             (when org-roam-include-type-in-ref-path-completions
-                              (format "[%s] " type))
+                              (format "{%s} " type))
                             (when tags
                               (format "(%s) " (s-join org-roam-tag-separator tags)))
-                            (format "%s {%s}" title ref))
+                            (format "%s (%s)" title ref))
                          ref))
                     (v (list :path file-path :type type :ref ref)))
                 (push (cons k v) completions)))))))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -859,16 +859,16 @@ whose title is 'Index'."
 ;;;; org-roam-find-ref
 (defun org-roam--get-ref-path-completions (&optional interactive filter)
   "Return an alist of refs to absolute path of Org-roam files.
-When `org-roam-include-type-in-ref-path-completions' and
-INTERACTIVE are non-nil, format the car of the
-completion-candidates as 'type:ref'.
-FILTER can either be a string or a function:
-- If it is a string, it should be the type of refs to include as
-candidates (e.g. \"cite\" ,\"website\" ,etc.)
-- If it is a function, it should be the name of a function that
-takes three arguments: the type, the ref, and the file of the
-current candidate.  It should return t if that candidate is to be
-included as a candidate."
+When called interactively (i.e. when INTERACTIVE is non-nil),
+format the car of the completion-candidates with extra
+information: title, tags, and type if
+`org-roam-include-type-in-ref-path-completions' is non-nil.
+FILTER can either be a string or a function: - If it is a string,
+it should be the type of refs to include as candidates (e.g.
+\"cite\" ,\"website\" ,etc.) - If it is a function, it should be
+the name of a function that takes three arguments: the type, the
+ref, and the file of the current candidate. It should return t if
+that candidate is to be included as a candidate."
   (let ((rows (org-roam-db-query
                [:select [refs:type refs:ref refs:file titles:titles tags:tags]
                 :from titles

--- a/org-roam.el
+++ b/org-roam.el
@@ -869,31 +869,39 @@ candidates (e.g. \"cite\" ,\"website\" ,etc.)
 takes three arguments: the type, the ref, and the file of the
 current candidate.  It should return t if that candidate is to be
 included as a candidate."
-  (let ((rows (org-roam-db-query [:select [refs:type refs:ref refs:file ] :from refs
-                                  :left :join files
-                                  :on (= refs:file files:file)]))
-        (include-type (and interactive
-                           org-roam-include-type-in-ref-path-completions))
+  (let ((rows (org-roam-db-query
+               [:select [refs:type refs:ref refs:file titles:titles tags:tags]
+                :from titles
+                :left :join tags
+                :on (= titles:file tags:file)
+                :left :join refs :on (= titles:file refs:file)
+                :where refs:file :is :not :null]))
         completions)
     (seq-sort-by (lambda (x)
                    (plist-get (nth 3 x) :mtime))
                  #'time-less-p
                  rows)
     (dolist (row rows completions)
-      (pcase-let ((`(,type ,ref ,file-path) row))
-        (when (pcase filter
-                ('nil t)
-                ((pred stringp) (string= type filter))
-                ((pred functionp) (funcall filter type ref file-path))
-                (wrong-type (signal 'wrong-type-argument
-                                    `((stringp functionp)
-                                      ,wrong-type))))
-          (let ((k (concat
-                    (when include-type
-                      (format "(%s) " type))
-                    ref))
-                (v (list :path file-path :type type :ref ref)))
-            (push (cons k v) completions)))))))
+      (pcase-let ((`(,type ,ref ,file-path ,titles ,tags) row))
+        (let ((titles (or titles (list (org-roam--path-to-slug file-path)))))
+          (when (pcase filter
+                  ('nil t)
+                  ((pred stringp) (string= type filter))
+                  ((pred functionp) (funcall filter type ref file-path))
+                  (wrong-type (signal 'wrong-type-argument
+                                      `((stringp functionp)
+                                        ,wrong-type))))
+            (dolist (title titles)
+              (let ((k (if interactive
+                           (concat
+                            (when org-roam-include-type-in-ref-path-completions
+                              (format "[%s] " type))
+                            (when tags
+                              (format "(%s) " (s-join org-roam-tag-separator tags)))
+                            (format "%s {%s}" title ref))
+                         ref))
+                    (v (list :path file-path :type type :ref ref)))
+                (push (cons k v) completions)))))))))
 
 (defun org-roam--find-file (file)
   "Open FILE using `org-roam-find-file-function' or `find-file'."


### PR DESCRIPTION
Adds titles and tags info for interactive calls to ‘org-roam-find-ref’.

I'm not entirely happy with the format of `org-roam--get-ref-path-completions`, and we could probably split the `interactive` behaviour into `org-roam--get-formatted-ref-path-completions`.  Since it's not the only function that would benefit from a clean-up, I'll keep this in mind for later.

Before:
![screenshot-K3zVpjW4fP](https://user-images.githubusercontent.com/12202828/87094533-57ccf700-c23f-11ea-98e5-98a76179329c.png)

After:
![screenshot-n6rOUz9cbI](https://user-images.githubusercontent.com/12202828/87094503-48e64480-c23f-11ea-95ee-451bc33a23cb.png)