### PR TITLE
(internal): normalize titles in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.1 (TBD)
 
 ### Breaking Changes
+- [#908](https://github.com/org-roam/org-roam/pull/908) Normalized titles in database. May break external packages that rely on unnormalized titles.
 
 ### Features
 - [#814](https://github.com/org-roam/org-roam/pull/814) Implement `org-roam-insert-immediate`

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -48,6 +48,7 @@
 (declare-function org-roam--extract-headlines              "org-roam")
 (declare-function org-roam--extract-links                  "org-roam")
 (declare-function org-roam--list-all-files                 "org-roam")
+(declare-function org-roam--path-to-slug                   "org-roam")
 (declare-function org-roam-buffer--update-maybe            "org-roam-buffer")
 
 ;;;; Options

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -75,7 +75,7 @@ value like `most-positive-fixnum'."
   :type 'int
   :group 'org-roam)
 
-(defconst org-roam-db--version 6)
+(defconst org-roam-db--version 7)
 
 (defvar org-roam-db--connection (make-hash-table :test #'equal)
   "Database connection to Org-roam database.")
@@ -152,7 +152,7 @@ SQL can be either the emacsql vector representation, or a string."
 
     (titles
      [(file :not-null)
-      titles])
+      title])
 
     (refs
      [(ref :unique :not-null)
@@ -242,7 +242,8 @@ This is equivalent to removing the node from the graph."
   (org-roam-db-query
    [:insert :into titles
     :values $v1]
-   (list (vector file titles))))
+   (mapcar (lambda (title)
+             (vector file title)) titles)))
 
 (defun org-roam-db--insert-headlines (headlines)
   "Insert HEADLINES into the Org-roam cache.
@@ -306,10 +307,10 @@ Insertions can fail if the key is already in the database."
 
 (defun org-roam-db--get-titles (file)
   "Return the titles of FILE from the cache."
-  (caar (org-roam-db-query [:select [titles] :from titles
-                            :where (= file $s1)]
-                           file
-                           :limit 1)))
+  (caar (org-roam-db-query [:select [title] :from titles
+                            :where (= file $s1)
+                            :limit 1]
+                           file)))
 
 (defun org-roam-db--connected-component (file)
   "Return all files reachable from/connected to FILE, including the file itself.
@@ -381,11 +382,12 @@ connections, nil is returned."
 (defun org-roam-db--update-titles ()
   "Update the title of the current buffer into the cache."
   (let* ((file (file-truename (buffer-file-name)))
-         (title (org-roam--extract-titles)))
+         (titles (or (org-roam--extract-titles)
+                     (list (org-roam--path-to-slug file)))))
     (org-roam-db-query [:delete :from titles
                         :where (= file $s1)]
                        file)
-    (org-roam-db--insert-titles file title)))
+    (org-roam-db--insert-titles file titles)))
 
 (defun org-roam-db--update-tags ()
   "Update the tags of the current buffer into the cache."
@@ -496,12 +498,10 @@ If FORCE, force a rebuild of the cache from scratch."
                   :values $v1]
                  (vector file tags))
                 (setq tag-count (1+ tag-count)))
-              (let ((titles (org-roam--extract-titles)))
-                (org-roam-db-query
-                 [:insert :into titles
-                  :values $v1]
-                 (vector file titles))
-                (setq title-count (1+ title-count)))
+              (let ((titles (or (org-roam--extract-titles)
+                                (list (org-roam--path-to-slug file)))))
+                (org-roam-db--insert-titles file titles)
+                (setq title-count (+ title-count (length titles))))
               (when-let* ((ref (org-roam--extract-ref)))
                 (when (org-roam-db--insert-ref file ref)
                   (setq ref-count (1+ ref-count)))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -876,7 +876,7 @@ FILTER can either be a string or a function:
   current candidate. It should return t if that candidate is to
   be included as a candidate."
   (let ((rows (org-roam-db-query
-               [:select [refs:type refs:ref refs:file titles:titles tags:tags]
+               [:select [refs:type refs:ref refs:file titles:title tags:tags]
                 :from titles
                 :left :join tags
                 :on (= titles:file tags:file)
@@ -888,26 +888,24 @@ FILTER can either be a string or a function:
                  #'time-less-p
                  rows)
     (dolist (row rows completions)
-      (pcase-let ((`(,type ,ref ,file-path ,titles ,tags) row))
-        (let ((titles (or titles (list (org-roam--path-to-slug file-path)))))
-          (when (pcase filter
+      (pcase-let ((`(,type ,ref ,file-path ,title ,tags) row))
+        (when (pcase filter
                   ('nil t)
                   ((pred stringp) (string= type filter))
                   ((pred functionp) (funcall filter type ref file-path))
                   (wrong-type (signal 'wrong-type-argument
                                       `((stringp functionp)
                                         ,wrong-type))))
-            (dolist (title titles)
-              (let ((k (if (eq arg 1)
-                           (concat
-                            (when org-roam-include-type-in-ref-path-completions
-                              (format "{%s} " type))
-                            (when tags
-                              (format "(%s) " (s-join org-roam-tag-separator tags)))
-                            (format "%s (%s)" title ref))
-                         ref))
-                    (v (list :path file-path :type type :ref ref)))
-                (push (cons k v) completions)))))))))
+            (let ((k (if (eq arg 1)
+                         (concat
+                          (when org-roam-include-type-in-ref-path-completions
+                            (format "{%s} " type))
+                          (when tags
+                            (format "(%s) " (s-join org-roam-tag-separator tags)))
+                          (format "%s (%s)" title ref))
+                       ref))
+                  (v (list :path file-path :type type :ref ref)))
+              (push (cons k v) completions)))))))
 
 (defun org-roam--find-file (file)
   "Open FILE using `org-roam-find-file-function' or `find-file'."

--- a/org-roam.el
+++ b/org-roam.el
@@ -818,7 +818,7 @@ Examples:
   "Return an alist for completion.
 The car is the displayed title for completion, and the cdr is the
 to the file."
-  (let* ((rows (org-roam-db-query [:select [titles:file titles:titles tags:tags files:meta] :from titles
+  (let* ((rows (org-roam-db-query [:select [files:file titles:title tags:tags files:meta] :from titles
                                    :left :join tags
                                    :on (= titles:file tags:file)
                                    :left :join files
@@ -829,15 +829,13 @@ to the file."
                  #'time-less-p
                  rows)
     (dolist (row rows completions)
-      (pcase-let ((`(,file-path ,titles ,tags) row))
-        (let ((titles (or titles (list (org-roam--path-to-slug file-path)))))
-          (dolist (title titles)
-            (let ((k (concat
+      (pcase-let ((`(,file-path ,title ,tags) row))
+        (let ((k (concat
                       (when tags
                         (format "(%s) " (s-join org-roam-tag-separator tags)))
                       title))
                   (v (list :path file-path :title title)))
-              (push (cons k v) completions))))))))
+              (push (cons k v) completions))))))
 
 (defun org-roam--get-index-path ()
   "Return the path to the index in `org-roam-directory'.
@@ -1040,6 +1038,7 @@ When point is on the Org-roam preview text, open the link in the Org-roam
 window, and navigate to the point.
 This function hooks into `org-open-at-point' via `org-open-at-point-functions'."
   (cond
+   ;;
    ;; Org-roam link
    ((let* ((context (org-element-context))
            (type (org-element-property :type context))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1038,7 +1038,6 @@ When point is on the Org-roam preview text, open the link in the Org-roam
 window, and navigate to the point.
 This function hooks into `org-open-at-point' via `org-open-at-point-functions'."
   (cond
-   ;;
    ;; Org-roam link
    ((let* ((context (org-element-context))
            (type (org-element-property :type context))


### PR DESCRIPTION
Instead of storing titles as a list within in the Org-roam cache, e.g.
file, ("title1" "title2"). We normalize it and store it as:

file, "title1"
file, "title2"

###### Motivation for this change

We need to be able to find a file given a title. This is in preparation for resolving fuzzy links such as `[[Title]]`.

In the old format, we need to do some elisp post-processing, but once we normalize, we can find all files that have that given title.