### PR TITLE
(fix): Make org-roam-graph work with new schemata

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -232,7 +232,7 @@ CALLBACK is passed the graph file as its sole argument."
                         "Please adjust `org-roam-graph-executable'")
                 org-roam-graph-executable))
   (let* ((node-query (or node-query
-                         `[:select [file titles] :from titles
+                         `[:select [file title] :from titles
                            ,@(org-roam-graph--expand-matcher 'file t)]))
          (graph      (org-roam-graph--dot node-query))
          (temp-dot   (make-temp-file "graph." nil ".dot" graph))
@@ -269,7 +269,7 @@ CALLBACK is passed to `org-roam-graph--build'."
                         (org-roam-db--links-with-max-distance file max-distance)
                       (org-roam-db--connected-component file))
                     (list file)))
-         (query `[:select [file titles]
+         (query `[:select [file title]
                   :from titles
                   :where (in file [,@files])]))
     (org-roam-graph--build query callback)))


### PR DESCRIPTION
Caused by #908.

Fixes #912.

----

I haven’t looked at it too deeply, but 1fe704cf716608d3859faa6084a36b715c492da4 is not enough to address the issue.  I’ve hardly worked on the graph, so I’m not the best person to address it in a timely fashion.