### PR TITLE
(fix): Adapt get-title-or-slug to new schemata

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -775,7 +775,7 @@ Examples:
 
 (defun org-roam--get-title-or-slug (path)
   "Convert `PATH' to the file title, if it exists.  Else, return the path."
-  (or (car (org-roam-db--get-titles path))
+  (or (org-roam-db--get-titles path)
       (org-roam--path-to-slug path)))
 
 (defun org-roam--title-to-slug (title)


### PR DESCRIPTION
Follow-up to #908.

I've grepped `org-roam--get-title-or-slug` in the repo, and we don't see to be expecting a list anywhere else.