### PR TITLE
(fix): Update rename-file-advice to new schemata

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1236,7 +1236,7 @@ replaced links are made relative to the current buffer."
              (new-path (file-truename new-file))
              (old-slug (org-roam--get-title-or-slug old-file))
              (old-desc (org-roam--format-link-title old-slug))
-             (new-slug (or (car (org-roam-db--get-titles old-path))
+             (new-slug (or (org-roam-db--get-titles old-path)
                            (org-roam--path-to-slug new-path)))
              (new-desc (org-roam--format-link-title new-slug))
              (new-buffer (or (find-buffer-visiting new-path)


### PR DESCRIPTION
Caused by #908.

Again, I've grepped the directory for similar patterns, and this was the only one.