### PR TITLE
(fix): Change symbol used for delta

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -511,7 +511,7 @@ If FORCE, force a rebuild of the cache from scratch."
         ;; These files are no longer around, remove from cache...
         (org-roam-db--clear-file file)
         (setq deleted-count (1+ deleted-count))))
-    (org-roam-message "files: 𝚫%s, headlines: 𝚫%s, links: 𝚫%s, tags: 𝚫%s, titles: 𝚫%s, refs: 𝚫%s, deleted: 𝚫%s"
+    (org-roam-message "files: Δ%s, headlines: Δ%s, links: Δ%s, tags: Δ%s, titles: Δ%s, refs: Δ%s, deleted: Δ%s"
                       file-count
                       headline-count
                       link-count


### PR DESCRIPTION
7f56df7f4d8b7da46096f084e906b7b0f64726ef introduced the delta symbol in the
db-rebuild message to make it clearer the the db was updated as opposed to
being completely rebuilt.

However, the unicode symbol used, U+1D6AB, which is the mathematical, bold
variant of the Greek letter is not present in many fonts.  Switching to
U+0394, the base Greek letter, is better for compatibility.

Example from before:
![screenshot-fNrxUuWsL6](https://user-images.githubusercontent.com/12202828/87230988-a8656100-c3b3-11ea-8642-d6adb4524d2d.png)
Note the large line-height that is a side-effect of Emacs's struggling to find a font with the appropriate symbol.