### PR TITLE
(fix): Check if link-description is empty prior to inserting

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -594,11 +594,12 @@ it as FILE-PATH."
                               (org-ref-split-and-strip-string path))
                              (_ (list (org-element-property :raw-link link))))))
                 (seq-do (lambda (name)
-                          (push (vector file-path
-                                        name
-                                        type
-                                        properties)
-                                links))
+                          (when name
+                            (push (vector file-path
+                                          name
+                                          type
+                                          properties)
+                                  links)))
                         names))))))
     links))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -563,7 +563,6 @@ it as FILE-PATH."
     (org-element-map (org-element-parse-buffer) 'link
       (lambda (link)
         (let* ((type (org-element-property :type link))
-               (format (org-element-property :format link))
                (path (org-element-property :path link))
                (start (org-element-property :begin link)))
           (goto-char start)

--- a/org-roam.el
+++ b/org-roam.el
@@ -563,6 +563,7 @@ it as FILE-PATH."
     (org-element-map (org-element-parse-buffer) 'link
       (lambda (link)
         (let* ((type (org-element-property :type link))
+               (format (org-element-property :format link))
                (path (org-element-property :path link))
                (start (org-element-property :begin link)))
           (goto-char start)

--- a/org-roam.el
+++ b/org-roam.el
@@ -567,40 +567,40 @@ it as FILE-PATH."
                (start (org-element-property :begin link)))
           (goto-char start)
           (let* ((element (org-element-at-point))
-                   (begin (or (org-element-property :content-begin element)
-                              (org-element-property :begin element)))
-                   (content (or (org-element-property :raw-value element)
-                                (buffer-substring-no-properties
-                                 begin
-                                 (or (org-element-property :content-end element)
-                                     (org-element-property :end element)))))
-                   (content (string-trim content))
-                   ;; Expand all relative links to absolute links
-                   (content (org-roam--expand-links content file-path)))
-              (let ((properties (list :outline (mapcar (lambda (path)
-                                                         (org-roam--expand-links path file-path))
-                                                       (org-roam--get-outline-path))
-                                      :content content
-                                      :point begin))
-                    (names (pcase type
-                             ("file"
-                              (list (file-truename (expand-file-name path (file-name-directory file-path)))))
-                             ("id"
-                              (list (car (org-roam-id-find path))))
-                             ((pred (lambda (typ)
-                                      (and (boundp 'org-ref-cite-types)
-                                           (-contains? org-ref-cite-types typ))))
-                              (setq type "cite")
-                              (org-ref-split-and-strip-string path))
-                             (_ (list (org-element-property :raw-link link))))))
-                (seq-do (lambda (name)
-                          (when name
-                            (push (vector file-path
-                                          name
-                                          type
-                                          properties)
-                                  links)))
-                        names))))))
+                 (begin (or (org-element-property :content-begin element)
+                            (org-element-property :begin element)))
+                 (content (or (org-element-property :raw-value element)
+                              (buffer-substring-no-properties
+                               begin
+                               (or (org-element-property :content-end element)
+                                   (org-element-property :end element)))))
+                 (content (string-trim content))
+                 ;; Expand all relative links to absolute links
+                 (content (org-roam--expand-links content file-path)))
+            (let ((properties (list :outline (mapcar (lambda (path)
+                                                       (org-roam--expand-links path file-path))
+                                                     (org-roam--get-outline-path))
+                                    :content content
+                                    :point begin))
+                  (names (pcase type
+                           ("file"
+                            (list (file-truename (expand-file-name path (file-name-directory file-path)))))
+                           ("id"
+                            (list (car (org-roam-id-find path))))
+                           ((pred (lambda (typ)
+                                    (and (boundp 'org-ref-cite-types)
+                                         (-contains? org-ref-cite-types typ))))
+                            (setq type "cite")
+                            (org-ref-split-and-strip-string path))
+                           (_ (list (org-element-property :raw-link link))))))
+              (seq-do (lambda (name)
+                        (when name
+                          (push (vector file-path
+                                        name
+                                        type
+                                        properties)
+                                links)))
+                      names))))))
     links))
 
 (defun org-roam--extract-headlines (&optional file-path)


### PR DESCRIPTION
Caused problems with plain links, i.e., those not framed by
brackets (e.g. `file:foo.org` or `id:$uuid`).

Fixes #926.