### PR TITLE
(fix): Stop resolving symlinks to their destinations

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -471,7 +471,7 @@ Use external shell commands if defined in `org-roam-list-files-commands'."
 
 (defun org-roam--list-all-files ()
   "Return a list of all Org-roam files within `org-roam-directory'."
-  (org-roam--list-files (file-truename org-roam-directory)))
+  (org-roam--list-files org-roam-directory))
 
 ;;;; Org extraction functions
 (defun org-roam--extract-global-props (props)


### PR DESCRIPTION
Affects both `org-roam-find-file' and the db.

Fixes #919.

-----

This might cause problem with libs.