### PR TITLE
 (fix): Check sqlite3’s executability using boundp

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1297,7 +1297,7 @@ Otherwise, behave as if called interactively."
   :global t
   (cond
    (org-roam-mode
-    (unless (or (and (fboundp 'emacsql-sqlite3-executable)
+    (unless (or (and (boundp 'emacsql-sqlite3-executable)
                      (file-executable-p emacsql-sqlite3-executable))
                 (executable-find "sqlite3"))
       (lwarn '(org-roam) :error "Cannot find executable 'sqlite3'. \


### PR DESCRIPTION
Fixes #837.

###### Motivation for this change

The existing merged fixes do not actually work, because `fboundp` tests for a function.