### PR TITLE
(fix): enable org-mode in temp buffers

### DIFF
--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -45,7 +45,9 @@ If FILE, set `org-roam-temp-file-name' to file and insert its contents."
   (let ((current-org-roam-directory (make-symbol "current-org-roam-directory")))
     `(let ((,current-org-roam-directory org-roam-directory))
        (with-temp-buffer
-         (let ((org-roam-directory ,current-org-roam-directory))
+         (let ((org-roam-directory ,current-org-roam-directory)
+               (org-mode-hook nil))
+           (org-mode)
            (when ,file
              (insert-file-contents ,file)
              (setq-local org-roam-file-name ,file))


### PR DESCRIPTION
###### Motivation for this change

Fixes #956.

The extraction of links rely on appropriate regexp being set for
outline-mode, to determine the outline information. Because the
information were extracted in a temporary buffer, the outline regexp was
not set. This corrects for that, but probably adds significant
extraction time.