### PR TITLE
Make the db caching more efficient for gpg encrypted files 

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -49,6 +49,7 @@
 (declare-function org-roam--extract-links                  "org-roam")
 (declare-function org-roam--list-all-files                 "org-roam")
 (declare-function org-roam--path-to-slug                   "org-roam")
+(declare-function org-roam--file-name-extension            "org-roam")
 (declare-function org-roam-buffer--update-maybe            "org-roam-buffer")
 
 ;;;; Options

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -369,14 +369,7 @@ connections, nil is returned."
     files))
 
 (defun org-roam-db--file-hash (&optional file-path)
-  "Compute the hash of the file (or current buffer).
-
-For encrypted files the on-disk representation (i.e. the encoded bytes)
-will be used.  This means, we cannot create a hash for a buffer which
-is about to be encoded.
-
-For non-encrypted files we compute the hash over the buffer representation,
-as usual."
+  "Compute the hash of the file or current buffer."
   (let* ((file-p (and file-path))
          (file-path (or file-path
                         (buffer-file-name (current-buffer))))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -373,20 +373,20 @@ connections, nil is returned."
   (let* ((file-p (and file-path))
          (file-path (or file-path
                         (buffer-file-name (current-buffer))))
-         (orig-buffer (current-buffer))
          (encrypted-p (and file-path
                            (string= (org-roam--file-name-extension file-path)
                                     "gpg"))))
-    (if (and encrypted-p file-p)
-        (with-temp-buffer
-          (set-buffer-multibyte nil)
-          (insert-file-contents-literally file-path)
-          (secure-hash 'sha1 (current-buffer)))
-      (with-temp-buffer
-        (if file-p
-            (insert-file-contents file-path)
-          (insert-buffer-substring orig-buffer))
-        (secure-hash 'sha1 (current-buffer))))))
+    (cond ((and encrypted-p file-p)
+           (with-temp-buffer
+             (set-buffer-multibyte nil)
+             (insert-file-contents-literally file-path)
+             (secure-hash 'sha1 (current-buffer))))
+          (file-p
+           (with-temp-buffer
+             (insert-file-contents file-path)
+             (secure-hash 'sha1 (current-buffer))))
+          (t
+           (secure-hash 'sha1 (current-buffer))))))
 
 ;;;;; Updating
 (defun org-roam-db--update-meta ()

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -369,8 +369,7 @@ connections, nil is returned."
 
 (defun org-roam-db--file-hash (&optional file-path)
   "Compute the hash of the file (or current buffer) as it would
-be encoded on disk.  In any case there must be a filename associated
-(which might e.g. indicate encryption).
+be encoded on disk.
 
 For encrypted files the on-disk representation (i.e. the encoded bytes)
 will be used.  This means, we cannot create a hash for a buffer which
@@ -393,7 +392,7 @@ as usual."
       (with-temp-buffer
         (if file-p
             (insert-file-contents file-path)
-          (insert-buffer orig-buffer))
+          (insert-buffer-substring orig-buffer))
         (secure-hash 'sha1 (current-buffer))))))
 
 ;;;;; Updating

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -369,7 +369,7 @@ connections, nil is returned."
     files))
 
 (defun org-roam-db--file-hash (&optional file-path)
-  "Compute the hash of the file or current buffer."
+  "Compute the hash of FILE-PATH, a file or current buffer."
   (let* ((file-p (and file-path))
          (file-path (or file-path
                         (buffer-file-name (current-buffer))))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -369,8 +369,7 @@ connections, nil is returned."
     files))
 
 (defun org-roam-db--file-hash (&optional file-path)
-  "Compute the hash of the file (or current buffer) as it would
-be encoded on disk.
+  "Compute the hash of the file (or current buffer).
 
 For encrypted files the on-disk representation (i.e. the encoded bytes)
 will be used.  This means, we cannot create a hash for a buffer which


### PR DESCRIPTION
Before this patch all hash-sums were computed over the files or
buffers content.  For encrypted files this means that we first have
decrypt the file before we can compute the hash-sum.  So when the
cache gets updated all gpg files need to be decrypted which is a very
expensive operation and nearly defeats the purpose of having a cache
in the first place (for gpg files).

This changes the computation of hash-sums for gpg encrypted files.
Instead of the content the raw files on disk will be read.

This shouldn't interfere with the current use of hashes.

There is one ugly (but otherwise inconsequential) ward, though.
For open buffers of to be gpg encrypted files we need to compute the
hash sum over the contents as well.  This is because there is
no (easy) way to get the encrypted version.  The consequence is that
that buffers file will be rehashed again (then using the bytes on
disk).  But all other non changed gpg files will only be hashed once,
as desired.

Note: Git chose an unfortunate way of building the diff part regarding
the `org-roam-db-build-cache`.  All what happened there is, that we use
the newly introduced `org-roam-db--file-hash` function instead of
secure-hash and that we moved the computation of the hash-sum outside
of the `org-roam--with-temp-buffer`.