### PR TITLE
check if path is remote before using file-truename

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -584,7 +584,9 @@ it as FILE-PATH."
                                     :point begin))
                   (names (pcase type
                            ("file"
-                            (list (file-truename (expand-file-name path (file-name-directory file-path)))))
+                            (if (file-remote-p path)
+                                (list path)
+                              (list (file-truename (expand-file-name path (file-name-directory file-path))))))
                            ("id"
                             (list (car (org-roam-id-find path))))
                            ((pred (lambda (typ)


### PR DESCRIPTION
###### Motivation for this change

When `tramp-mode` is active, calling `file-truename` on a non-existing/non-reachable remote path makes tramp to attempt at opening the non-reachable remote connection, and thus prevents `org-roam` from updating the cache database.

This is a hotfix for #967, not tested properly. 

`file-truename` is used throughout `org-roam`, so there may be other issues. It would be nice to wrap it in a protecting function that would check if the file is remote and behave accordingly.