### PR TITLE
Fixed org-protocol link in graph

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -202,7 +202,7 @@ into a digraph."
                (title (org-roam-string-quote title))
                (node-properties
                 `(("label"   . ,shortened-title)
-                  ("URL"     . ,(concat "org-protocol://roam-file?file=" (url-hexify-string file)))
+                  ("URL"     . ,(concat "org-protocol:////roam-file?file=" (url-hexify-string file)))
                   ("tooltip" . ,(xml-escape-string title)))))
           (insert
            (format "  \"%s\" [%s];\n" file


### PR DESCRIPTION
I'm not sure this is correct, but I had to do this on Windows to get it working. Perhaps `org-roam-protocol.el` should also be adjusted.