### PR TITLE
(fix): Simplify org-roam-store-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Features
 
--[#974](https://github.com/org-roam/org-roam/pull/974) Protect region targeted by `org-roam-insert`
+- [#974](https://github.com/org-roam/org-roam/pull/974) Protect region targeted by `org-roam-insert`
+- [#994](https://github.com/org-roam/org-roam/pull/994) Simplify org-roam-store-link
 
 ### Bugfixes
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1015,7 +1015,7 @@ for Org-ref cite links."
                      target))
 
 (defun org-roam-store-link ()
-  "Store a link to an Org-roam file."
+  "Store a link to an Org-roam file or heading."
   (when (and (bound-and-true-p org-roam-mode)
              (org-roam--org-roam-file-p))
     (if (org-before-first-heading-p)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1014,36 +1014,21 @@ for Org-ref cite links."
                       :order-by (asc from)]
                      target))
 
-(defun org-roam-store-link-file ()
+(defun org-roam-store-link ()
   "Store a link to an Org-roam file."
   (when (and (bound-and-true-p org-roam-mode)
-             (org-roam--org-roam-file-p)
-             (org-before-first-heading-p))
-    (when-let ((titles (org-roam--extract-titles)))
-      (org-link-store-props
-       :type        "file"
-       :link        (format "file:%s" (abbreviate-file-name buffer-file-name))
-       :description (car titles)))))
-
-(defun org-roam--store-link (arg &optional interactive?)
-  "Store a link to the current location within Org-roam.
-See `org-roam-store-link' for details on ARG and INTERACTIVE?."
-  (let ((org-id-link-to-org-use-id t)
-        (id (org-id-get)))
-    (org-store-link arg interactive?)
-    ;; If :ID: was created, update the cache
-    (unless id
-      (org-roam-db--update-headlines))))
-
-(defun org-roam-store-link (arg &optional interactive?)
-  "Store a link to the current location.
-This commands is a wrapper for `org-store-link' which forces the
-automatic creation of :ID: properties.
-See `org-roam-store-link' for details on ARG and INTERACTIVE?."
-  (interactive "P\np")
-  (if (org-roam--org-roam-file-p)
-      (org-roam--store-link arg interactive?)
-    (org-store-link arg interactive?)))
+             (org-roam--org-roam-file-p))
+    (if (org-before-first-heading-p)
+        (when-let ((titles (org-roam--extract-titles)))
+          (org-link-store-props
+           :type        "file"
+           :link        (format "file:%s" (abbreviate-file-name buffer-file-name))
+           :description (car titles)))
+      (let ((id (org-id-get)))
+          (org-id-store-link)
+          ;; If :ID: was created, update the cache
+          (unless id
+            (org-roam-db--update-headlines))))))
 
 (defun org-roam-id-find (id &optional markerp strict)
   "Return the location of the entry with the id ID.
@@ -1275,7 +1260,6 @@ nil, or positive. If ARG is `toggle', toggle `org-roam-mode'.
 Otherwise, behave as if called interactively."
   :lighter " Org-roam"
   :keymap  (let ((map (make-sparse-keymap)))
-             (define-key map [remap org-store-link] 'org-roam-store-link)
              map)
   :group 'org-roam
   :require 'org-roam
@@ -1295,7 +1279,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)
-      (org-link-set-parameters "file" :face 'org-roam--file-link-face :store #'org-roam-store-link-file)
+      (org-link-set-parameters "file" :face 'org-roam--file-link-face :store #'org-roam-store-link)
       (org-link-set-parameters "id" :face 'org-roam---id-link-face))
     (org-roam-db-build-cache))
    (t


### PR DESCRIPTION
Drop the wrapper, and refactor as an org-store-link function.

Fixes #853, #982.

Right now, as long as you're in an Org-roam file, it'll create an ID when you're capturing on a heading.  I think it's going to be hard to make it cleaner, i.e., only creating the ID when necessary.  Right now, if you cancel the capture, the ID remains, which leads to ID rot.  I'm investigating.
