### PR TITLE
Skip unreadable files while building the cache

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -492,7 +492,7 @@ If FORCE, force a rebuild of the cache from scratch."
           (let ((contents-hash (org-roam-db--file-hash file)))
             (unless (string= (gethash file current-files)
                              contents-hash)
-              (condition-case err-mesg
+              (condition-case nil
                   (org-roam--with-temp-buffer file
                     (org-roam-db--clear-file file)
                     (org-roam-db-query

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -506,7 +506,8 @@ If FORCE, force a rebuild of the cache from scratch."
                 (file-error
                  (setq org-roam-files (remove file org-roam-files))
                  (org-roam-db--clear-file file)
-                 (message "org-roam-db-build-cache: Skipping unreadable file: %s" file)))))))
+                 (lwarn '(org-roam) :warning
+                        "Skipping unreadable file while building cache: %s" file)))))))
       ;; Second step: Rebuild the rest
       (dolist (file org-roam-files)
         (let ((contents-hash (org-roam-db--file-hash file)))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -492,16 +492,21 @@ If FORCE, force a rebuild of the cache from scratch."
           (let ((contents-hash (org-roam-db--file-hash file)))
             (unless (string= (gethash file current-files)
                              contents-hash)
-              (org-roam--with-temp-buffer file
-               (org-roam-db--clear-file file)
-               (org-roam-db-query
-                [:insert :into files
-                 :values $v1]
-                (vector file contents-hash (list :atime atime :mtime mtime)))
-               (setq file-count (1+ file-count))
-               (when-let ((headlines (org-roam--extract-headlines file)))
-                 (when (org-roam-db--insert-headlines headlines)
-                   (setq headline-count (1+ headline-count)))))))))
+              (condition-case err-mesg
+                  (org-roam--with-temp-buffer file
+                    (org-roam-db--clear-file file)
+                    (org-roam-db-query
+                     [:insert :into files
+                      :values $v1]
+                     (vector file contents-hash (list :atime atime :mtime mtime)))
+                    (setq file-count (1+ file-count))
+                    (when-let ((headlines (org-roam--extract-headlines file)))
+                      (when (org-roam-db--insert-headlines headlines)
+                        (setq headline-count (1+ headline-count)))))
+                (file-error
+                 (setq org-roam-files (remove file org-roam-files))
+                 (org-roam-db--clear-file file)
+                 (message "org-roam-db-build-cache: Skipping unreadable file: %s" file)))))))
       ;; Second step: Rebuild the rest
       (dolist (file org-roam-files)
         (let ((contents-hash (org-roam-db--file-hash file)))


### PR DESCRIPTION
When using gpg encrypted files it might happen (intended) that on a
certain machine there is no key to decrypt that file.  Currently an
error of type 'file-error' will be raised and the cache building
process will be aborted.  So in a certain sense org-roam will not
be functional in that case.  Furthermore, when the the cache building
process is run from the emacs initialisation it will come to a halt as
well and the user will be left with a half working emacs instance.

This patch changes the behaviour to just skipping over offending files
while removing them from the db at the same time.  Here an offending
file is any file that cannot be read for indexing.  As it stands this
case only works reliably for the case of missing gpg keys.

An error buffer will still show up and be prominently displayed,
besides a log to the message buffer.

Implementation note: This io error will only be caught during the
first part of the cache rebuilding ("files and headlines").  If such
an error would occur during the second part ("rebuild the rest")
another (more severe) cause might be the problem and the user better
be informed the hard way (i.e. the same behaviour as before).