### PR TITLE
(feat) Implements link types

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -340,11 +340,12 @@ the capture)."
              (when region
                (delete-region (car region) (cdr region)))
              (let ((path (org-roam-capture--get :file-path))
+                   (type (org-roam-capture--get :link-type))
                    (desc (org-roam-capture--get :link-description)))
                (if (eq (point) (marker-position mkr))
-                   (insert (org-roam--format-link path desc))
+                   (insert (org-roam--format-link path desc type))
                  (org-with-point-at mkr
-                   (insert (org-roam--format-link path desc))))))))))
+                   (insert (org-roam--format-link path desc type))))))))))
     (when region
       (set-marker beg nil)
       (set-marker end nil))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -321,7 +321,7 @@ If the file does not have any connections, nil is returned."
                    links_of(file, link) AS
                      (WITH filelinks AS (SELECT * FROM links WHERE \"type\" = '\"file\"'"
                           (-reduce-from (lambda (x y) (concat x " OR \"type\" = '\"" y "\"'"))
-                                        "" org-roam-link-types)
+                                        "" org-roam-extra-link-types)
                           "),
                            citelinks AS (SELECT * FROM links
                                                   JOIN refs ON links.\"to\" = refs.\"ref\"
@@ -346,7 +346,7 @@ connections, nil is returned."
                    links_of(file, link) AS
                      (WITH filelinks AS (SELECT * FROM links WHERE \"type\" = '\"file\"'"
                         (-reduce-from (lambda (x y) (concat x " OR \"type\" = '\"" y "\"'"))
-                                      "" org-roam-link-types)
+                                      "" org-roam-extra-link-types)
                         "),
                            citelinks AS (SELECT * FROM links
                                                   JOIN refs ON links.\"to\" = refs.\"ref\"

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -40,6 +40,7 @@
 (defvar org-roam-directory)
 (defvar org-roam-verbose)
 (defvar org-roam-file-name)
+(defvar org-roam-extra-link-types)
 
 (declare-function org-roam--org-roam-file-p                "org-roam")
 (declare-function org-roam--extract-titles                 "org-roam")

--- a/org-roam.el
+++ b/org-roam.el
@@ -1320,7 +1320,6 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)
       (org-link-set-parameters "file" :face 'org-roam--file-link-face :store #'org-roam-store-link)
-      ;; TOOO: make the same for link types?
       (org-link-set-parameters "id" :face 'org-roam---id-link-face))
     (org-roam-db-build-cache))
    (t
@@ -1331,7 +1330,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (advice-remove 'rename-file #'org-roam--rename-file-advice)
     (advice-remove 'delete-file #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)
-      (dolist (face '("file" "id")) ;TODO: add link types
+      (dolist (face '("file" "id")) 
         (org-link-set-parameters face :face 'org-link)))
     (org-roam-db--close-all)
     ;; Disable local hooks for all org-roam buffers

--- a/org-roam.el
+++ b/org-roam.el
@@ -803,10 +803,10 @@ Examples:
            (slug (-reduce-from #'cl-replace (strip-nonspacing-marks title) pairs)))
       (downcase slug))))
 
-(defun org-roam--format-link-title (title)
+(defun org-roam--format-link-title (title &optional type)
   "Return the link title, given the file TITLE."
   (if (functionp org-roam-link-title-format)
-      (funcall org-roam-link-title-format title)
+      (funcall org-roam-link-title-format title type)
     (format org-roam-link-title-format title)))
 
 (defun org-roam--format-link (target &optional description type)
@@ -1452,7 +1452,8 @@ If DESCRIPTION is provided, use this as the link label.  See
                (description (or description region-text title))
                (link-description (org-roam--format-link-title (if lowercase
                                                                   (downcase description)
-                                                                description))))
+                                                                description)
+                                                              type)))
           (cond ((and target-file-path
                       (file-exists-p target-file-path))
                  (when region-text

--- a/org-roam.el
+++ b/org-roam.el
@@ -250,8 +250,9 @@ space-delimited strings.
   :group 'org-roam)
 
 (defcustom org-roam-link-types nil
-  "List of link types registered for Org Roam in addition to always recognized \"file:\" link.
-Types themselves should be defined in Org. See `org-link-set-parameters'."
+  "List of link types registered for Org Roam.
+These types are added to always recognized \"file:\" and \"cite\" links.
+Types themselves should be previously defined in Org. See `org-link-set-parameters'."
   :type 'list
   :group 'org-roam)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -249,7 +249,7 @@ space-delimited strings.
   :type 'boolean
   :group 'org-roam)
 
-(defcustom org-roam-link-types nil
+(defcustom org-roam-extra-link-types nil
   "List of link types registered for Org Roam.
 These types are added to always recognized \"file:\" and \"cite\" links.
 Types themselves should be previously defined in Org. See `org-link-set-parameters'."
@@ -266,7 +266,7 @@ This is set by `org-roam--with-temp-buffer', to allow throwing of
 descriptive warnings when certain operations fail (e.g. parsing).")
 
 (defvar org-roam--org-link-file-bracket-re
-  (eval `(rx "[[" (or ,@org-roam-link-types "file") ":" (seq (group (one-or-more (or (not (any "]" "[" "\\"))
+  (eval `(rx "[[" (or ,@org-roam-extra-link-types "file") ":" (seq (group (one-or-more (or (not (any "]" "[" "\\"))
                                              (seq "\\"
                                                   (zero-or-more "\\\\")
                                                   (any "[" "]"))
@@ -592,7 +592,7 @@ it as FILE-PATH."
                                 (list path)
                               (list (file-truename (expand-file-name path (file-name-directory file-path))))))
                            ((pred (lambda (typ)
-                                    (member typ org-roam-link-types)))
+                                    (member typ org-roam-extra-link-types)))
                             (list (file-truename (expand-file-name path (file-name-directory file-path)))))
                            ("id"
                             (list (car (org-roam-id-find path))))
@@ -984,7 +984,7 @@ buffer or a marker."
         (pcase type
           ("file" dest)
           ((pred (lambda (typ)
-                   (member typ org-roam-link-types))
+                   (member typ org-roam-extra-link-types))
                  dest))
           ("id" (car (org-roam-id-find dest))))))))
 
@@ -1007,7 +1007,7 @@ This function hooks into `org-open-at-point' via `org-open-at-point-functions'."
            (path (org-element-property :path context)))
       (when (and (eq (org-element-type context) 'link)
                  (or (string= "file" type)
-                     (member type org-roam-link-types))
+                     (member type org-roam-extra-link-types))
                  (org-roam--org-roam-file-p (file-truename path)))
         (org-roam-buffer--find-file path)
         (org-show-context)
@@ -1188,7 +1188,7 @@ update with NEW-DESC."
                               (let ((type (org-element-property :type l))
                                     (path (org-element-property :path l)))
                                 (when (and (or (equal "file" type)
-                                               (member type org-roam-link-types))
+                                               (member type org-roam-extra-link-types))
                                            (string-equal (file-truename path)
                                                          old-path))
                                   (cons (set-marker (make-marker) (org-element-property :begin l))
@@ -1219,7 +1219,7 @@ replaced links are made relative to the current buffer."
                     (let ((type (org-element-property :type link))
                           (path (org-element-property :path link)))
                       (when (and (or (equal "file" type)
-                                     (member type org-roam-link-types))
+                                     (member type org-roam-extra-link-types))
                                  (f-relative-p path))
                         (cons (set-marker (make-marker)
                                           (org-element-property :begin link))
@@ -1262,7 +1262,7 @@ replaced links are made relative to the current buffer."
                                                   :from links
                                                   :where (= to $s1)
                                                   :and (or (= type "file")
-                                                           (member type org-roam-link-types))]
+                                                           (member type org-roam-extra-link-types))]
                                                  old-path)))
         ;; Remove database entries for old-file.org
         (org-roam-db--clear-file old-file)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1331,7 +1331,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (advice-remove 'rename-file #'org-roam--rename-file-advice)
     (advice-remove 'delete-file #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)
-      (dolist (face '("file" "id")) 
+      (dolist (face '("file" "id"))
         (org-link-set-parameters face :face 'org-link)))
     (org-roam-db--close-all)
     ;; Disable local hooks for all org-roam buffers

--- a/org-roam.el
+++ b/org-roam.el
@@ -1188,9 +1188,10 @@ update with NEW-DESC."
                                                (member type org-roam-link-types))
                                            (string-equal (file-truename path)
                                                          old-path))
-                                  (set-marker (make-marker) (org-element-property :begin l))))))))
+                                  (cons (set-marker (make-marker) (org-element-property :begin l))
+                                        type)))))))
         (dolist (m link-markers)
-          (goto-char m)
+          (goto-char (car m))
           (save-match-data
             (unless (org-in-regexp org-link-bracket-re 1)
               (user-error "No link at point"))
@@ -1199,11 +1200,10 @@ update with NEW-DESC."
                             (org-link-unescape (match-string-no-properties 1))))
                    (new-label (if (string-equal label old-desc)
                                   new-desc
-                                label))
-                   (element (org-element-at-point))
-                   (type (org-element-property :type elemen)))
+                                label)))
               (replace-match (org-link-make-string
-                              (concat type ":" (file-relative-name new-path (file-name-directory (buffer-file-name))))
+                              (concat (cdr m) ":"
+                                      (file-relative-name new-path (file-name-directory (buffer-file-name))))
                               new-label)))))))
     (save-buffer)))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -813,8 +813,8 @@ TYPE allows to format the link title according to the link type. See
     (format org-roam-link-title-format title)))
 
 (defun org-roam--format-link (target &optional description type)
-  "Formats an org link for a given file TARGET, link DESCRIPTION and
-link TYPE. When not given, TYPE defaults to \"file\"."
+  "Formats an org link for a given file TARGET, link DESCRIPTION and link TYPE.
+When not given, TYPE defaults to \"file\"."
   (let* ((here (ignore-errors
                  (-> (or (buffer-base-buffer)
                          (current-buffer))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1219,18 +1219,16 @@ replaced links are made relative to the current buffer."
                                  (f-relative-p path))
                         (cons (set-marker (make-marker)
                                           (org-element-property :begin link))
-                              path)))))))
+                              (cons path type))))))))
     (save-excursion
       (save-match-data
         (dolist (link links)
-          (pcase-let ((`(,marker . ,path) link))
+          (pcase-let ((`(,marker . (,path . ,type)) link))
             (goto-char marker)
             (unless (org-in-regexp org-link-bracket-re 1)
               (user-error "No link at point"))
             (let* ((file-path (expand-file-name path (file-name-directory old-path)))
-                   (new-path (file-relative-name file-path (file-name-directory (buffer-file-name))))
-                   (l (org-element-at-point)) ; should be link
-                   (type (org-element-property :type l)))
+                   (new-path (file-relative-name file-path (file-name-directory (buffer-file-name)))))
               (replace-match (concat type ":" new-path)
                              nil t nil 1))
             (set-marker marker nil)))))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1416,12 +1416,6 @@ included as a candidate."
   (find-file (seq-random-elt (org-roam--list-all-files))))
 
 ;;;###autoload
-;; (defun org-roam-insert-roam (&optional lowercase completions filter-fn description)
-;;   "Insert roam: link."
-;;   (interactive "P")
-;;   (org-roam-insert "roam" lowercase completions filter-fn description))
-
-;;;###autoload
 (defun org-roam-insert (&optional type lowercase completions filter-fn description)
   "Find an Org-roam file, and insert a relative org link to it at point.
 Return selected file if it exists.

--- a/org-roam.el
+++ b/org-roam.el
@@ -805,13 +805,16 @@ Examples:
       (downcase slug))))
 
 (defun org-roam--format-link-title (title &optional type)
-  "Return the link title, given the file TITLE."
+  "Return the link title, given the file TITLE.
+TYPE allows to format the link title according to the link type. See
+`org-roam-link-title-format title'."
   (if (functionp org-roam-link-title-format)
       (funcall org-roam-link-title-format title type)
     (format org-roam-link-title-format title)))
 
 (defun org-roam--format-link (target &optional description type)
-  "Formats an org link for a given file TARGET and link DESCRIPTION."
+  "Formats an org link for a given file TARGET, link DESCRIPTION and
+link TYPE. When not given, TYPE defaults to \"file\"."
   (let* ((here (ignore-errors
                  (-> (or (buffer-base-buffer)
                          (current-buffer))
@@ -1424,6 +1427,7 @@ included as a candidate."
 (defun org-roam-insert (&optional type lowercase completions filter-fn description)
   "Find an Org-roam file, and insert a relative org link to it at point.
 Return selected file if it exists.
+TYPE is the type of the created link. It defaults to \"file\".
 If LOWERCASE, downcase the title before insertion.
 COMPLETIONS is a list of completions to be used instead of
 `org-roam--get-title-path-completions`.


### PR DESCRIPTION
This implements link types in Org-roam. Types should be previously defined in Org, for example via `org-link-set-parameters`. Org-roam already recognizes `file:` and `cite:` link types, this code makes it possible to add more. Additional types should be declared in `org-roam-extra-link-types`. Link types are saved in the database and faces, the look of graph's edges etc. can be adjusted according to them. 