### PR TITLE
(docs): remove readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,0 @@
-version: 2
-mkdocs:
- configuration: mkdocs.yml
-formats: all
-python:
-  version: 3.7
-  install:
-    - requirements: doc/requirements.txt


### PR DESCRIPTION
This has long been superceded by the internal and published online manual.