### PR TITLE
(fix): fix get-backlinks failing for unescaped strings

### DIFF
--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -37,6 +37,15 @@
 
 (defvar org-roam-verbose)
 
+;;;; Utility Functions
+(defun org-roam--list-interleave (lst separator)
+  "Interleaves elements in LST with SEPARATOR."
+  (when lst
+    (let ((new-lst (list (pop lst))))
+      (dolist (it lst)
+        (nconc new-lst (list separator it)))
+      new-lst)))
+
 (defmacro org-roam--with-temp-buffer (file &rest body)
   "Execute BODY within a temp buffer.
 Like `with-temp-buffer', but propagates `org-roam-directory'.

--- a/org-roam.el
+++ b/org-roam.el
@@ -1013,11 +1013,12 @@ Org-roam cache. It may be a file, for Org-roam file links, or a
 citation key, for Org-ref cite links."
   (unless (listp targets)
     (setq targets (list targets)))
-  (org-roam-db-query
-   (concat "SELECT \"from\", \"to\", \"properties\" FROM links WHERE "
-           (string-join (mapcar (lambda (target)
-                                  (concat "\"to\" = '\"" target "\"'"))
-                                targets) " OR "))))
+  (let ((conditions (--> targets
+                         (mapcar (lambda (i) (list '= 'to i)) it)
+                         (org-roam--list-interleave it :or))))
+    (org-roam-db-query `[:select [from to properties] :from links
+                         :where ,@conditions
+                         :order-by (asc from)])))
 
 (defun org-roam-store-link ()
   "Store a link to an Org-roam file or heading."


### PR DESCRIPTION
Revert to emacsql vector format to retain escaping. Fixes #1007.
