### PR TITLE
Update url of org-fc

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1136,7 +1136,7 @@ tight integration between
     :CUSTOM_ID: spaced-repetition
     :END:
 
-[[https://github.com/l3kn/org-fc/][Org-fc]] is a spaced repetition system that scales well with a large number of
+[[https://www.leonrische.me/fc/index.html][Org-fc]] is a spaced repetition system that scales well with a large number of
 files. Other alternatives include [[https://orgmode.org/worg/org-contrib/org-drill.html][org-drill]], and [[https://github.com/abo-abo/pamparam][pamparam]].
 
 * FAQ

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1475,7 +1475,7 @@ tight integration between
 @node Spaced Repetition
 @unnumberedsubsubsec Spaced Repetition
 
-@uref{https://github.com/l3kn/org-fc/, Org-fc} is a spaced repetition system that scales well with a large number of
+@uref{https://www.leonrische.me/fc/index.html, Org-fc} is a spaced repetition system that scales well with a large number of
 files. Other alternatives include @uref{https://orgmode.org/worg/org-contrib/org-drill.html, org-drill}, and @uref{https://github.com/abo-abo/pamparam, pamparam}.
 
 @node FAQ


### PR DESCRIPTION
Org-fc now has it's own website, I've updated the link in the documentation accordingly.

Should I add an entry to the changelog even if this is just a minor change to the docs?

###### Motivation for this change

The main repository of org-fc is moving to sourcehut,
I prefer hosting the documentation on my own website instead of using a github readme for it.