### PR TITLE
(fix): remove save-buffer on id creation

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1225,9 +1225,7 @@ If there is no corresponding headline, return nil."
           (goto-char marker)
           (cons marker
                 (when org-roam-auto-replace-fuzzy-links
-                  (let ((id (org-id-get-create)))
-                    (save-buffer)
-                    id))))))))
+                  (org-id-get-create))))))))
 
 (defun org-roam--get-fuzzy-link-location (link)
   "Return the location of Org-roam fuzzy LINK.


### PR DESCRIPTION
This can trigger a lot of hooks, which may not be desirable.