### PR TITLE
Add custom var to disable headline linking

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -512,9 +512,10 @@ If FORCE, force a rebuild of the cache from scratch."
                       :values $v1]
                      (vector file contents-hash (list :atime atime :mtime mtime)))
                     (setq file-count (1+ file-count))
-                    (when-let ((headlines (org-roam--extract-headlines file)))
-                      (when (org-roam-db--insert-headlines headlines)
-                        (setq headline-count (1+ headline-count)))))
+                    (when org-roam-enable-headline-linking
+                      (when-let ((headlines (org-roam--extract-headlines file)))
+                        (when (org-roam-db--insert-headlines headlines)
+                          (setq headline-count (1+ headline-count))))))
                 (file-error
                  (setq org-roam-files (remove file org-roam-files))
                  (org-roam-db--clear-file file)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -38,7 +38,7 @@
 (require 'org-roam-macs)
 
 (defvar org-roam-directory)
-(defvar org-roam-disable-headline-linking)
+(defvar org-roam-enable-headline-linking)
 (defvar org-roam-verbose)
 (defvar org-roam-file-name)
 
@@ -472,7 +472,7 @@ connections, nil is returned."
            (org-roam-db--update-tags)
            (org-roam-db--update-titles)
            (org-roam-db--update-refs)
-           (when (not org-roam-disable-headline-linking)
+           (when org-roam-enable-headline-linking
              (org-roam-db--update-headlines))
            (org-roam-db--update-links)))
         (org-roam-buffer--update-maybe :redisplay t)))))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -38,6 +38,7 @@
 (require 'org-roam-macs)
 
 (defvar org-roam-directory)
+(defvar org-roam-disable-headline-linking)
 (defvar org-roam-verbose)
 (defvar org-roam-file-name)
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -471,7 +471,8 @@ connections, nil is returned."
            (org-roam-db--update-tags)
            (org-roam-db--update-titles)
            (org-roam-db--update-refs)
-           (org-roam-db--update-headlines)
+           (when (not org-roam-disable-headline-linking)
+             (org-roam-db--update-headlines))
            (org-roam-db--update-links)))
         (org-roam-buffer--update-maybe :redisplay t)))))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -244,8 +244,8 @@ space-delimited strings.
            (symbol)))
   :group 'org-roam)
 
-(defcustom org-roam-disable-headline-linking nil
-  "Disable linking to headlines, that is, no automatic :ID: creation and no scanning of :ID:s for org-roam database."
+(defcustom org-roam-enable-headline-linking t
+  "Enable linking to headlines, which includes automatic :ID: creation and scanning of :ID:s for org-roam database."
   :type 'boolean
   :group 'org-roam)
 
@@ -1569,7 +1569,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)
-      (when (not org-roam-disable-headline-linking)
+      (when org-roam-enable-headline-linking
         (org-link-set-parameters "file" :face 'org-roam--file-link-face :store #'org-roam-store-link))
       (org-link-set-parameters "id" :face 'org-roam--id-link-face))
     (org-roam-db-build-cache))

--- a/org-roam.el
+++ b/org-roam.el
@@ -244,6 +244,11 @@ space-delimited strings.
            (symbol)))
   :group 'org-roam)
 
+(defcustom org-roam-disable-headline-linking nil
+  "Disable linking to headlines, that is, no automatic :ID: creation and no scanning of :ID:s for org-roam database."
+  :type 'boolean
+  :group 'org-roam)
+
 (defcustom org-roam-verbose t
   "Echo messages that are not errors."
   :type 'boolean
@@ -1564,7 +1569,8 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)
-      (org-link-set-parameters "file" :face 'org-roam--file-link-face :store #'org-roam-store-link)
+      (when (not org-roam-disable-headline-linking)
+        (org-link-set-parameters "file" :face 'org-roam--file-link-face :store #'org-roam-store-link))
       (org-link-set-parameters "id" :face 'org-roam--id-link-face))
     (org-roam-db-build-cache))
    (t


### PR DESCRIPTION
This small PR adds a customization variable with which org-roam's new headline linking functionality can be disabled.

This  means that:

- org-roam will not assign an auto-id when you use `org-store-link`
- org-roam will not scan the headlines of each org file for IDs to save into its database.

# Motivation

I would prefer not to have an org-id automatically assigned whenever I do `org-store-link`.  This is especially troublesome when I have already assigned a `CUSTOM_ID` as I often do for normal orgmode use, and then this code assigns an automatic ID and links to that instead.

Furthermore, I don't make use of org-roam's headline linking functionality, preferring its initial approach of supporting exclusively compact, single-thought files, a la zettelkasten, and so having org-roam extract the IDs of all of the headlines in the file I'm working on and saving that to the database further increases the delay I see when saving org files.


