### PR TITLE
(internal): fix CI for compat functions

### DIFF
--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -82,8 +82,20 @@
 (define-obsolete-function-alias 'org-roam-db--clear 'org-roam-db-clear
   "org-roam 1.2.0")
 
-(when (version< (org-version) "9.3")
-  (defalias 'org-link-make-string 'org-make-link-string))
+(defalias 'org-roam-link-make-string
+  (if (fboundp 'org-link-make-string)
+      'org-link-make-string
+    'org-make-link-string))
+
+(defalias 'org-roam-link-store-props
+  (if (fboundp 'org-link-store-props)
+      'org-link-store-props
+    'org-store-link-props))
+
+(defalias 'org-roam-link-decode
+  (if (fboundp 'org-link-decode)
+      'org-link-decode
+    'org-link-escape))
 
 ;;;; Variables
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -83,7 +83,7 @@ If DESC, also replace the desc"
     (let ((desc (or desc (match-string-no-properties 1)))
           (remove (list (match-beginning 0) (match-end 0))))
       (apply #'delete-region remove)
-      (insert (org-link-make-string new-loc desc)))
+      (insert (org-roam-link-make-string new-loc desc)))
     (sit-for 0)))
 
 ;;; Shielding regions

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -52,7 +52,7 @@ It opens or creates a note with the given ref.
               (decoded-alist (mapcar (lambda (k.v)
                                        (let ((key (car k.v))
                                              (val (cdr k.v)))
-                                         (cons key (org-link-decode val)))) alist)))
+                                         (cons key (org-roam-link-decode val)))) alist)))
     (unless (assoc 'ref decoded-alist)
       (error "No ref key provided"))
     (when-let ((title (cdr (assoc 'title decoded-alist))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -417,10 +417,11 @@ recursion."
                              (funcall predicate full-file)))
                 (let ((sub-files
                        (if (eq predicate t)
-                           (ignore-error file-error
-                             (org-roam--directory-files-recursively
+                           (condition-case nil
+                               (org-roam--directory-files-recursively
                               full-file regexp include-directories
-                              predicate follow-symlinks))
+                              predicate follow-symlinks)
+                             (file-error nil))
                          (org-roam--directory-files-recursively
                           full-file regexp include-directories
                           predicate follow-symlinks))))
@@ -813,7 +814,7 @@ TYPE defaults to \"file\"."
                      (buffer-file-name)
                      (file-truename)
                      (file-name-directory)))))
-    (org-link-make-string
+    (org-roam-link-make-string
      (concat (or type "file") ":" (if here
                                     (file-relative-name target here)
                                   target))
@@ -1028,7 +1029,7 @@ citation key, for Org-ref cite links."
              (org-roam--org-roam-file-p))
     (if (org-before-first-heading-p)
         (when-let ((titles (org-roam--extract-titles)))
-          (org-link-store-props
+          (org-roam-link-store-props
            :type        "file"
            :link        (format "file:%s" (abbreviate-file-name buffer-file-name))
            :description (car titles)))
@@ -1448,7 +1449,7 @@ update with NEW-DESC."
                    (new-label (if (string-equal label old-desc)
                                   new-desc
                                 label)))
-              (replace-match (org-link-make-string
+              (replace-match (org-roam-link-make-string
                               (concat (cdr m) ":"
                                       (file-relative-name new-path (file-name-directory (buffer-file-name))))
                               new-label)))))))
@@ -1851,7 +1852,7 @@ linked, lest the network graph get too crowded."
                                            file-loc)))
                   (let ((rowcol (concat row ":" col)))
                     (insert "- "
-                            (org-link-make-string (concat "file:" file "::" rowcol)
+                            (org-roam-link-make-string (concat "file:" file "::" rowcol)
                                                   (format "[%s] %s" rowcol (org-roam--get-title-or-slug file))))
                     (when (executable-find "sed") ; insert line contents when sed is available
                       (insert " :: "


### PR DESCRIPTION
Following the advice from the coding conventions from the Emacs manual,
we preface the compatibility functions with the org-roam namespace.