### PR TITLE
At after-save-hook schedule file for idle update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ In this release we support fuzzy links of the form `[[Title]]`, `[[*Headline]]` 
 
 ### Features
 
+- [#1032](https://github.com/org-roam/org-roam/pull/1032) File changes are now propagated to the database on idle timer. This prevents large wait times during file saves.
 - [#974](https://github.com/org-roam/org-roam/pull/974) Protect region targeted by `org-roam-insert`
 - [#994](https://github.com/org-roam/org-roam/pull/994) Simplify org-roam-store-link
 - [#910](https://github.com/org-roam/org-roam/pull/910) Support fuzzy links of the form [[Title]], [[*Headline]] and [[Title*Headline]]

--- a/org-roam.el
+++ b/org-roam.el
@@ -273,7 +273,7 @@ descriptive warnings when certain operations fail (e.g. parsing).")
   "Matches a typed link in double brackets.")
 
 (defvar org-roam--updater-timer nil
-  "Keep binding to idle timer so we can cancel it when org-mode is shutdown.")
+  "Keep binding to idle timer so we can cancel it when `org-roam' is shutdown.")
 
 (defvar org-roam--file-update-queue '()
   "List of files that need to be save during next idle timer.")

--- a/org-roam.el
+++ b/org-roam.el
@@ -1420,8 +1420,8 @@ file."
 (defun org-roam--idle-updater ()
   (when org-roam--file-update-queue
     ;; if there are filenames queued up, process them all here
-    (message "updating org-roam db because idle")
     (mapc #'org-roam-db--update-file org-roam--file-update-queue)
+    (org-roam-message "org-roam updated files %s during idle." org-roam--file-update-queue)
     ;; and then reset the list
     (setq org-roam--file-update-queue '())))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1409,9 +1409,11 @@ file."
           (t
            'org-link))))
 
-;; light-weight function that is called during after-save-hook and only schedules the current
-;; orgmode file to be org-roam updated during the next idle slot
-(defun org-roam--update-db-when-idle (&optional file-path)
+(defun org-roam--queue-file-for-update (&optional file-path)
+  "Schedule file for org-roam database update during idle.
+This is a light-weight function that is called during after-save-hook
+and only schedules the current orgmode file to be org-roam updated
+during the next idle slot."
   (when (org-roam--org-roam-file-p file-path)
     (let ((fp (or file-path buffer-file-name)))
       ;; only add filename if not in the list already
@@ -1432,7 +1434,7 @@ file."
     (setq org-roam-last-window (get-buffer-window))
     (add-hook 'post-command-hook #'org-roam-buffer--update-maybe nil t)
     (add-hook 'before-save-hook #'org-roam--replace-fuzzy-link-on-save nil t)
-    (add-hook 'after-save-hook #'org-roam--update-db-when-idle nil t)
+    (add-hook 'after-save-hook #'org-roam--queue-file-for-update nil t)
     (add-hook 'completion-at-point-functions #'org-roam-complete-at-point nil t)
     (org-roam-buffer--update-maybe :redisplay t)))
 
@@ -1608,7 +1610,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
       (with-current-buffer buf
         (remove-hook 'post-command-hook #'org-roam-buffer--update-maybe t)
         (remove-hook 'before-save-hook #'org-roam--replace-fuzzy-link-on-save t)
-        (remove-hook 'after-save-hook #'org-roam--update-db-when-idle t))))))
+        (remove-hook 'after-save-hook #'org-roam--queue-file-for-update t))))))
 
 ;;; Interactive Commands
 ;;;###autoload

--- a/org-roam.el
+++ b/org-roam.el
@@ -1424,7 +1424,8 @@ during the next idle slot."
   (when org-roam--file-update-queue
     ;; if there are filenames queued up, process them all here
     (mapc #'org-roam-db--update-file org-roam--file-update-queue)
-    (org-roam-message "org-roam updated files %s during idle." org-roam--file-update-queue)
+    (org-roam-message "database updated during idle: %s."
+                      (mapconcat #'file-name-nondirectory org-roam--file-update-queue  ", ") )
     ;; and then reset the list
     (setq org-roam--file-update-queue '())))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1411,9 +1411,9 @@ file."
            'org-link))))
 
 (defun org-roam--queue-file-for-update (&optional file-path)
-  "Schedule file for org-roam database update during idle.
-This is a light-weight function that is called during after-save-hook
-and only schedules the current orgmode file to be org-roam updated
+  "Schedule FILE-PATH for `org-roam' database update during idle.
+This is a light-weight function that is called during `after-save-hook'
+and only schedules the current orgmode file to be `org-roam' updated
 during the next idle slot."
   (when (org-roam--org-roam-file-p file-path)
     (let ((fp (or file-path buffer-file-name)))
@@ -1421,6 +1421,7 @@ during the next idle slot."
       (add-to-list 'org-roam--file-update-queue fp))))
 
 (defun org-roam--idle-updater ()
+  "Update queued up files in `org-roam' db during idle."
   (when org-roam--file-update-queue
     ;; if there are filenames queued up, process them all here
     (mapc #'org-roam-db--update-file org-roam--file-update-queue)

--- a/org-roam.el
+++ b/org-roam.el
@@ -272,10 +272,11 @@ descriptive warnings when certain operations fail (e.g. parsing).")
            "]"))
   "Matches a typed link in double brackets.")
 
-;; store timer so we can cancel it when org-mode is shutdown
-(defvar org-roam--updater-timer nil)
-;; list of files that need to be save at next idle slot
-(defvar org-roam--file-update-queue '())
+(defvar org-roam--updater-timer nil
+  "Keep binding to idle timer so we can cancel it when org-mode is shutdown.")
+
+(defvar org-roam--file-update-queue '()
+  "List of files that need to be save during next idle timer.")
 
 ;;;; Utilities
 (defun org-roam--plist-to-alist (plist)

--- a/org-roam.el
+++ b/org-roam.el
@@ -273,9 +273,9 @@ descriptive warnings when certain operations fail (e.g. parsing).")
   "Matches a typed link in double brackets.")
 
 ;; store timer so we can cancel it when org-mode is shutdown
-(defvar-local org-roam--updater-timer nil)
+(defvar org-roam--updater-timer nil)
 ;; list of files that need to be save at next idle slot
-(defvar-local org-roam--files-to-be-updated-when-idle '())
+(defvar org-roam--file-update-queue '())
 
 ;;;; Utilities
 (defun org-roam--plist-to-alist (plist)
@@ -1415,15 +1415,15 @@ file."
   (when (org-roam--org-roam-file-p file-path)
     (let ((fp (or file-path buffer-file-name)))
       ;; only add filename if not in the list already
-      (add-to-list 'org-roam--files-to-be-updated-when-idle fp))))
+      (add-to-list 'org-roam--file-update-queue fp))))
 
 (defun org-roam--idle-updater ()
-  (when org-roam--files-to-be-updated-when-idle
+  (when org-roam--file-update-queue
     ;; if there are filenames queued up, process them all here
     (message "updating org-roam db because idle")
-    (mapc #'org-roam-db--update-file org-roam--files-to-be-updated-when-idle)
+    (mapc #'org-roam-db--update-file org-roam--file-update-queue)
     ;; and then reset the list
-    (setq org-roam--files-to-be-updated-when-idle '())))
+    (setq org-roam--file-update-queue '())))
 
 ;;;; Hooks and Advices
 (defun org-roam--find-file-hook-function ()


### PR DESCRIPTION
On my setup (Samsung 970 EVO Plus NVMe SSD, Core i7 8750H, emacs 26.3 on WSL1 of Windows 20H2 beta channel, so not too slow) I see on average about 0.5 seconds per 500 lines of orgmode spent in `org-roam-db--update-file` as measured with the Emacs Lisp Profiler (elp).

As you can imagine, this is quite noticeable when you have files of a thousand or two lines. Many of my org-roam files are small, but my monthly journal files are usually in that range. Also, I habitually save quite often as I work.

I know I'm not the only one.

This PR moves the actual save-hook org-roam db updating into an idle handler. Every time you invoke save, the filename is added to an idle-save-list if it's not already there. Whenever the idle handler runs (it should do this after 2s of idle time as measured by Emacs), it will run through the idle-save list and do all of the database updating.

In my workflow, this makes a major difference to the interactivity, as saving is now instantaneous again.