### PR TITLE
Require org-macs in org-roam-db to fix undefined org-with-wide-buffer macro.

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -35,6 +35,7 @@
 (require 'emacsql)
 (require 'emacsql-sqlite3)
 (require 'seq)
+(require 'org-macs)
 (require 'org-roam-macs)
 
 (defvar org-roam-directory)


### PR DESCRIPTION
###### Motivation for this change
Fixes #1026 when compiling asynchronously. Basically org-roam-db.el references `org-with-wide-buffer` without it imported.