### PR TITLE
Allow ignoring files with a regular expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ In this release we support fuzzy links of the form `[[Title]]`, `[[*Headline]]` 
 
 ### Features
 
+- [#1046](https://github.com/org-roam/org-roam/pull/1046) New user option to exclude files from Org-roam
 - [#1032](https://github.com/org-roam/org-roam/pull/1032) File changes are now propagated to the database on idle timer. This prevents large wait times during file saves.
 - [#974](https://github.com/org-roam/org-roam/pull/974) Protect region targeted by `org-roam-insert`
 - [#994](https://github.com/org-roam/org-roam/pull/994) Simplify org-roam-store-link

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -513,6 +513,10 @@ This section concerns the placement and creation of files.
   It is the user’s responsibility to set this correctly, especially when used
   with multiple Org-roam instances.
 
+- Variable: org-roam-file-exclude-regexp
+
+  Files matching this regular expression are excluded from the Org-roam.
+
 ** The Org-roam Buffer
 
 The Org-roam buffer displays backlinks for the currently active Org-roam note.

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -731,6 +731,11 @@ database is saved here.
 
 It is the user’s responsibility to set this correctly, especially when used
 with multiple Org-roam instances.
+
+@item
+Variable: org-roam-file-exclude-regexp
+
+Files matching this regular expression are excluded from the Org-roam.
 @end itemize
 
 @node The Org-roam Buffer

--- a/org-roam.el
+++ b/org-roam.el
@@ -100,6 +100,13 @@ ensure that."
   :type '(repeat string)
   :group 'org-roam)
 
+(defcustom org-roam-file-exclude-regexp nil
+  "Files matching this regular expression are excluded from the Org-roam."
+  :type '(choice
+          (string :tag "Regular expression matching files to ignore")
+          (const :tag "Include everything" nil))
+  :group 'org-roam)
+
 (defcustom org-roam-find-file-function nil
   "Function called when visiting files in Org-roam commands.
 If nil, `find-file' is used."
@@ -342,6 +349,8 @@ If FILE is not specified, use the current buffer's file-path."
       (save-match-data
         (and
          (org-roam--org-file-p path)
+         (not (and org-roam-file-exclude-regexp
+                   (string-match-p org-roam-file-exclude-regexp path)))
          (f-descendant-of-p (file-truename path)
                             (file-truename org-roam-directory))))))
 


### PR DESCRIPTION
###### Motivation for this change

I personally store all my finished tasks in one big archive file, and I want to be able to ignore its existence.

This PR modifies `org-roam--org-roam-file-p` to take a new user option, `org-roam-file-exclude-regexp`, into account. If a file matches that regular expression it is not considered an Org-roam file.