### PR TITLE
Disable latex preview and images for temp buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ In this release we support fuzzy links of the form `[[Title]]`, `[[*Headline]]` 
 
 ### Bugfixes
 
+- [#1057](https://github.com/org-roam/org-roam/pull/1057) Improve performance of database builds by preventing generation of LaTeX and image previews.
+
 ## 1.2.1 (27-07-2020)
 
 This release consisted of a big deal of refactoring and bug fixes. Notably, we fixed several catastrophic failures on db builds with bad setups (#854), and modularized tag and title extractions.

--- a/doc/AUTHORS.md
+++ b/doc/AUTHORS.md
@@ -34,4 +34,4 @@ Contributors
 - Rafael Accácio Nogueira <raccacio@poli.ufrj.br>
 - Roland Coeurjoly <rolandcoeurjoly@gmail.com>
 - Sayan <dit7ya@users.noreply.github.com>
-- Tim Quelch <tim@quelch.name>
+- Tim Quelch <tim@tquelch.com>

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -58,6 +58,7 @@
 
 (defvar org-roam-verbose)
 (defvar org-roam-mode)
+(defvar org-roam-doctor-inhibit-startup)
 
 (cl-defstruct (org-roam-doctor-checker (:copier nil))
   (name 'missing-checker-name)

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -294,7 +294,9 @@ If CHECKALL, run the check for all Org-roam files."
 (defun org-roam-doctor-start (files checkers)
   "Lint FILES using CHECKERS."
   (save-window-excursion
-    (let ((existing-buffers (org-roam--get-roam-buffers)))
+    (let ((existing-buffers (org-roam--get-roam-buffers))
+          (org-startup-with-latex-preview nil)
+          (org-startup-with-inline-images nil))
       (dolist (f files)
         (let ((buf (find-file-noselect f)))
           (org-roam-doctor--check buf checkers)

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -295,8 +295,7 @@ If CHECKALL, run the check for all Org-roam files."
   "Lint FILES using CHECKERS."
   (save-window-excursion
     (let ((existing-buffers (org-roam--get-roam-buffers))
-          (org-startup-with-latex-preview nil)
-          (org-startup-with-inline-images nil))
+          (org-inhibit-startup org-roam-doctor-inhibit-startup))
       (dolist (f files)
         (let ((buf (find-file-noselect f)))
           (org-roam-doctor--check buf checkers)

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -58,7 +58,15 @@
 
 (defvar org-roam-verbose)
 (defvar org-roam-mode)
-(defvar org-roam-doctor-inhibit-startup)
+
+(defcustom org-roam-doctor-inhibit-startup t
+  "Inhibit `org-mode' startup when processing files with `org-doctor'.
+When non-nil, images and LaTeX preview will not be generated,
+tables will not be aligned, and headlines will not respect
+startup visability. This significantly improves performance when
+processing multiple files"
+  :type 'boolean
+  :group 'org-roam)
 
 (cl-defstruct (org-roam-doctor-checker (:copier nil))
   (name 'missing-checker-name)

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -56,8 +56,7 @@ If FILE, set `org-roam-temp-file-name' to file and insert its contents."
        (with-temp-buffer
          (let ((org-roam-directory ,current-org-roam-directory)
                (org-mode-hook nil)
-               (org-startup-with-latex-preview nil)
-               (org-startup-with-inline-images nil))
+               (org-inhibit-startup t))
            (org-mode)
            (when ,file
              (insert-file-contents ,file)

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -55,7 +55,9 @@ If FILE, set `org-roam-temp-file-name' to file and insert its contents."
     `(let ((,current-org-roam-directory org-roam-directory))
        (with-temp-buffer
          (let ((org-roam-directory ,current-org-roam-directory)
-               (org-mode-hook nil))
+               (org-mode-hook nil)
+               (org-startup-with-latex-preview nil)
+               (org-startup-with-inline-images nil))
            (org-mode)
            (when ,file
              (insert-file-contents ,file)

--- a/org-roam.el
+++ b/org-roam.el
@@ -261,6 +261,15 @@ space-delimited strings.
   :type 'boolean
   :group 'org-roam)
 
+(defcustom org-roam-doctor-inhibit-startup t
+  "Inhibit `org-mode' startup when processing files with `org-doctor'.
+When non-nil, images and LaTeX preview will not be generated,
+tables will not be aligned, and headlines will not respect
+startup visability. This significantly improves performance when
+processing multiple files"
+  :type 'boolean
+  :group 'org-roam)
+
 ;;;; Dynamic variables
 (defvar org-roam-last-window nil
   "Last window `org-roam' was called from.")

--- a/org-roam.el
+++ b/org-roam.el
@@ -261,15 +261,6 @@ space-delimited strings.
   :type 'boolean
   :group 'org-roam)
 
-(defcustom org-roam-doctor-inhibit-startup t
-  "Inhibit `org-mode' startup when processing files with `org-doctor'.
-When non-nil, images and LaTeX preview will not be generated,
-tables will not be aligned, and headlines will not respect
-startup visability. This significantly improves performance when
-processing multiple files"
-  :type 'boolean
-  :group 'org-roam)
-
 ;;;; Dynamic variables
 (defvar org-roam-last-window nil
   "Last window `org-roam' was called from.")


### PR DESCRIPTION
Generation of these preview is often expensive and completely unnecessary
when the buffer won't actually be viewed.

This will have the side effect of not showing latex or images when fixing something in a doctor run, but I think that is worth the sacrifice.

----

###### Motivation for this change

Should make DB builds and doctor runs faster when the user has `org-startup-with-latex-preview` or `org-startup-with-inline-images` set.