### PR TITLE
Speed up extraction of global props, headlines, and title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ In this release we support fuzzy links of the form `[[Title]]`, `[[*Headline]]` 
 
 ### Features
 
+- [#1061](https://github.com/org-roam/org-roam/pull/1061) Speed up the extraction of file properties, headlines, and titles
 - [#1046](https://github.com/org-roam/org-roam/pull/1046) New user option to exclude files from Org-roam
 - [#1032](https://github.com/org-roam/org-roam/pull/1032) File changes are now propagated to the database on idle timer. This prevents large wait times during file saves.
 - [#974](https://github.com/org-roam/org-roam/pull/974) Protect region targeted by `org-roam-insert`

--- a/org-roam.el
+++ b/org-roam.el
@@ -635,8 +635,8 @@ it as FILE-PATH."
 If FILE-PATH is nil, use the current file."
   (let ((file-path (or file-path
                        (file-truename (buffer-file-name)))))
-    ;; `org-map-entries' always includes all entries, forcing us to
-    ;; have to filter out nil values.
+    ;; Use `org-map-region' instead of `org-map-entries' as the latter
+    ;; would require another step to remove all nil values.
     (let ((result nil))
       (org-map-region
        (lambda ()

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -255,7 +255,7 @@
     (it "extracts headlines"
       (expect (test #'org-roam--extract-headlines
                     "headlines/headline.org")
-              :to-equal
+              :to-have-same-items-as
               `(["e84d0630-efad-4017-9059-5ef917908823" ,(test-org-roam--abs-path "headlines/headline.org")]
                 ["801b58eb-97e2-435f-a33e-ff59a2f0c213" ,(test-org-roam--abs-path "headlines/headline.org")])))))
 


### PR DESCRIPTION
###### Motivation for this change

Org-roam takes a long time to process files. In addition, big files (10000+ lines) can take several seconds to process after it is modified. This becomes unbearable for eg. habit (`org-habit`) tracking files.

This PR introduces some optimizations:

- Replace unnecessary uses of `org-element-parse-buffer`
  - `org-roam--extract-headlines`: Use `org-map-region` and `org-entry-get` instead of `org-element-parse-buffer`.
  - `org-roam--extract-titles-headline`: Find the first headline with `org-outline-regexp-bol` instead of using `org-element-parse-buffer`.
- If it's available, use `org-collect-keywords` which is a lot faster as it also avoids `org-element-parse-buffer`. (As it is a relatively new function in Org, [added in April 2020](https://code.orgmode.org/bzg/org-mode/commit/b4e91b7e944c900db6b8217d78011afcd2c1e62c), I have kept the previous implementation if it's not present.)

## Performance comparison

`vocab.org` is an Org file with 14795 lines (1052 headings).

I'm running this on a Ryzen 1400 CPU.

```elisp
(with-current-buffer "vocab.org"
  (list
   (list 'total 'gc-count 'gc-time)
   (benchmark-run 1
     (org-roam--extract-headlines))
   (benchmark-run 1
     (org-roam--extract-titles-title))
   (benchmark-run 1
     (org-roam--extract-titles-headline))
   (benchmark-run 1
     (org-roam--extract-titles-alias))))
```

Before:

| total       | gc-count | gc-time            |
|-------------|----------|--------------------|
| 1.771265479 | 1        | 0.7655653740000048 |
| 0.932756371 | 0        | 0.0                |
| 1.645399532 | 1        | 0.7050031620000254 |
| 1.701283592 | 1        | 0.742148186999998  |

After:

| total       | gc-count | gc-time |
|-------------|----------|---------|
| 0.149613758 | 0        | 0.0     |
| 0.00223786  | 0        | 0.0     |
| 8.2539e-05  | 0        | 0.0     |
| 0.001961503 | 0        | 0.0     |

From 5 seconds down to 0.15 seconds.
