### PR TITLE
(internal): use regexp search for link-extraction

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -579,55 +579,51 @@ FILE-FROM is typically the buffer file path, but this may not exist, for example
 in temp buffers.  In cases where this occurs, we do know the file path, and pass
 it as FILE-PATH."
   (require 'org-ref nil t)
-  (let ((file-path (or file-path
-                       (file-truename (buffer-file-name))))
-        links)
-    (org-element-map (org-element-parse-buffer) 'link
-      (lambda (link)
-        (let* ((type (org-element-property :type link))
-               (path (org-element-property :path link))
-               (start (org-element-property :begin link)))
-          (goto-char start)
-          (let* ((element (org-element-at-point))
+  (unless file-path
+    (setq file-path (file-truename (buffer-file-name))))
+  (let (links)
+    (save-excursion
+      (goto-char (point-min))
+      (while (re-search-forward org-link-any-re nil t)
+        (save-excursion
+          (goto-char (match-beginning 0))
+          (let* ((link (org-element-link-parser))
+                 (type (org-element-property :type link))
+                 (path (org-element-property :path link))
+                 (element (org-element-at-point))
                  (begin (or (org-element-property :content-begin element)
                             (org-element-property :begin element)))
                  (content (or (org-element-property :raw-value element)
-                              (buffer-substring-no-properties
-                               begin
-                               (or (org-element-property :content-end element)
-                                   (org-element-property :end element)))))
+                                (buffer-substring-no-properties
+                                 begin
+                                 (or (org-element-property :content-end element)
+                                     (org-element-property :end element)))))
                  (content (string-trim content))
-                 ;; Expand all relative links to absolute links
-                 (content (org-roam--expand-links content file-path)))
-            (let ((properties (list :outline (mapcar (lambda (path)
-                                                       (org-roam--expand-links path file-path))
-                                                     (org-roam--get-outline-path))
-                                    :content content
-                                    :point begin))
-                  (names (pcase type
-                           ("id"
-                            (list (car (org-roam-id-find path))))
-                           ((pred (lambda (typ)
-                                    (and (boundp 'org-ref-cite-types)
-                                         (-contains? org-ref-cite-types typ))))
-                            (setq type "cite")
-                            (org-ref-split-and-strip-string path))
-                           ("fuzzy" (list path))
-                           (_ (if (file-remote-p path)
-                                  (list path)
-                                (let ((file-maybe (file-truename
-                                                   (expand-file-name path (file-name-directory file-path)))))
-                                  (if (f-exists? file-maybe)
-                                      (list file-maybe)
-                                    (list path))))))))
-              (seq-do (lambda (name)
-                        (when name
-                          (push (vector file-path
-                                        name
-                                        type
-                                        properties)
-                                links)))
-                      names))))))
+                 (content (org-roam--expand-links content file-path))
+                 (properties (list :outline (mapcar (lambda (path)
+                                                         (org-roam--expand-links path file-path))
+                                                       (org-roam--get-outline-path))
+                                      :content content
+                                      :point begin))
+                 (names (pcase type
+                             ("id"
+                              (list (car (org-roam-id-find path))))
+                             ((pred (lambda (typ)
+                                      (and (boundp 'org-ref-cite-types)
+                                           (-contains? org-ref-cite-types typ))))
+                              (setq type "cite")
+                              (org-ref-split-and-strip-string path))
+                             ("fuzzy" (list path))
+                             (_ (if (file-remote-p path)
+                                    (list path)
+                                  (let ((file-maybe (file-truename
+                                                     (expand-file-name path (file-name-directory file-path)))))
+                                    (if (f-exists? file-maybe)
+                                        (list file-maybe)
+                                      (list path))))))))
+            (dolist (name names)
+              (when name
+                (push (vector file-path name type properties) links)))))))
     links))
 
 (defun org-roam--extract-headlines (&optional file-path)


### PR DESCRIPTION
Replace call to org-element-parse-buffer with simple regexp search.