### PR TITLE
(test): reduce expected cache time-to-build

### DIFF
--- a/tests/test-org-roam-perf.el
+++ b/tests/test-org-roam-perf.el
@@ -45,7 +45,7 @@
     (pcase (benchmark-run 1 (org-roam-db-build-cache t))
       (`(,time ,gcs ,time-in-gc)
        (message "Elapsed time: %fs (%fs in %d GCs)" time time-in-gc gcs)
-       (expect time :to-be-less-than 100))))
+       (expect time :to-be-less-than 70))))
   (it "builds quickly without change"
     (pcase (benchmark-run 1 (org-roam-db-build-cache))
       (`(,time ,gcs ,time-in-gc)


### PR DESCRIPTION
Several performance improvements have vastly improved the cache build
time. We reduce it so CI catches any further degradation.