### PR TITLE
(feat): rename file on title change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ In this release we support fuzzy links of the form `[[Title]]`, `[[*Headline]]` 
 - [#910](https://github.com/org-roam/org-roam/pull/910) Deprecate `company-org-roam`, using `completion-at-point` instead. To use this with company, add the `company-capf` backend instead.
 
 ### Features
-
+ 
+- [#1073](https://github.com/org-roam/org-roam/pull/1073) Rename file on title change, when `org-roam-rename-file-on-title-change` is non-nil.
 - [#1071](https://github.com/org-roam/org-roam/pull/1071) Update link descriptions on title changes, and clean-up rename file advice
 - [#1061](https://github.com/org-roam/org-roam/pull/1061) Speed up the extraction of file properties, headlines, and titles
 - [#1046](https://github.com/org-roam/org-roam/pull/1046) New user option to exclude files from Org-roam

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -461,22 +461,24 @@ connections, nil is returned."
       (org-roam-db--insert-headlines headlines))))
 
 (defun org-roam-db--update-file (&optional file-path)
-  "Update Org-roam cache for FILE-PATH."
-  (when (org-roam--org-roam-file-p file-path)
-    (let ((buf (or (and file-path
-                        (find-file-noselect file-path t))
-                   (current-buffer))))
-      (with-current-buffer buf
-        (org-with-wide-buffer
-         (emacsql-with-transaction (org-roam-db)
-           (org-roam-db--update-meta)
-           (org-roam-db--update-tags)
-           (org-roam-db--update-titles)
-           (org-roam-db--update-refs)
-           (when org-roam-enable-headline-linking
-             (org-roam-db--update-headlines))
-           (org-roam-db--update-links)))
-        (org-roam-buffer--update-maybe :redisplay t)))))
+  "Update Org-roam cache for FILE-PATH.
+If the file does not exist anymore, remove it from the cache.
+If the file exists, update the cache with information."
+  (setq file-path (or file-path
+                      (buffer-file-name (buffer-base-buffer))))
+  (cond ((not (file-exists-p file-path))
+         (org-roam-db--clear-file file-path))
+        ((org-roam--org-roam-file-p file-path)
+         (with-current-buffer (find-file-noselect file-path t)
+           (org-with-wide-buffer
+            (emacsql-with-transaction (org-roam-db)
+              (org-roam-db--update-meta)
+              (org-roam-db--update-tags)
+              (org-roam-db--update-titles)
+              (org-roam-db--update-refs)
+              (when org-roam-enable-headline-linking
+                (org-roam-db--update-headlines))
+              (org-roam-db--update-links)))))))
 
 (defun org-roam-db-build-cache (&optional force)
   "Build the cache for `org-roam-directory'.

--- a/org-roam.el
+++ b/org-roam.el
@@ -1546,7 +1546,7 @@ respectively."
   "The current title of the Org-roam file.")
 
 (defun org-roam--handle-title-change ()
-  "Detect a title change, and run `org-roam-title-change-hook'."
+  "Detect a title change, and run `org-roam-title-change-hook'"
   (let ((new-title (car (org-roam--extract-titles)))
         (old-title org-roam-current-title))
     (unless (string-equal old-title new-title)
@@ -1565,6 +1565,7 @@ respectively."
 Iterate over all Org-roam files that have link description of
 OLD-TITLE, and replace the link descriptions with the NEW-TITLE
 if applicable.
+
 To be added to `org-roam-title-change-hook'."
   (let* ((current-path (file-truename (buffer-file-name)))
          (files-affected (org-roam-db-query [:select :distinct [from]
@@ -1579,14 +1580,19 @@ To be added to `org-roam-title-change-hook'."
 
 (defun org-roam--update-file-name-on-title-change (old-title new-title)
   "Update the file name on title change.
+The slug is computed from OLD-TITLE using
+`org-roam-title-to-slug-function'. If the slug is part of the
+current filename, the new slug is computed with NEW-TITLE, and
+that portion of the filename is renamed.
+
 To be added to `org-roam-title-change-hook'."
   (when org-roam-rename-file-on-title-change
     (let* ((old-slug (funcall org-roam-title-to-slug-function old-title))
-           (new-slug (funcall org-roam-title-to-slug-function new-title))
            (file (buffer-file-name (buffer-base-buffer)))
            (file-name (file-name-nondirectory file)))
       (when (string-match-p old-slug file-name)
-        (let ((new-file-name (replace-regexp-in-string old-slug new-slug file-name)))
+        (let ((new-slug (funcall org-roam-title-to-slug-function new-title))
+              (new-file-name (replace-regexp-in-string old-slug new-slug file-name)))
           (rename-file file-name new-file-name)
           (set-visited-file-name new-file-name t t)
           (org-roam-message "File moved to %S" (abbreviate-file-name new-file-name)))))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1594,6 +1594,7 @@ To be added to `org-roam-title-change-hook'."
                (new-file-name (replace-regexp-in-string old-slug new-slug file-name)))
           (rename-file file-name new-file-name)
           (set-visited-file-name new-file-name t t)
+          (add-to-list 'org-roam--file-update-queue new-file-name)
           (org-roam-message "File moved to %S" (abbreviate-file-name new-file-name)))))))
 
 (defun org-roam--rename-file-advice (old-file new-file-or-dir &rest _args)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1546,7 +1546,7 @@ respectively."
   "The current title of the Org-roam file.")
 
 (defun org-roam--handle-title-change ()
-  "Detect a title change, and run `org-roam-title-change-hook'"
+  "Detect a title change, and run `org-roam-title-change-hook'."
   (let ((new-title (car (org-roam--extract-titles)))
         (old-title org-roam-current-title))
     (unless (string-equal old-title new-title)
@@ -1591,8 +1591,8 @@ To be added to `org-roam-title-change-hook'."
            (file (buffer-file-name (buffer-base-buffer)))
            (file-name (file-name-nondirectory file)))
       (when (string-match-p old-slug file-name)
-        (let ((new-slug (funcall org-roam-title-to-slug-function new-title))
-              (new-file-name (replace-regexp-in-string old-slug new-slug file-name)))
+        (let* ((new-slug (funcall org-roam-title-to-slug-function new-title))
+               (new-file-name (replace-regexp-in-string old-slug new-slug file-name)))
           (rename-file file-name new-file-name)
           (set-visited-file-name new-file-name t t)
           (org-roam-message "File moved to %S" (abbreviate-file-name new-file-name)))))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1535,7 +1535,8 @@ filename."
   :group 'org-roam
   :type 'boolean)
 
-(defcustom org-roam-title-change-hook nil
+(defcustom org-roam-title-change-hook '(org-roam--update-file-name-on-title-change
+                                        org-roam--update-links-on-title-change)
   "Hook run after detecting a title change.
 Each hook is passed two arguments: the old title, and new title
 respectively."
@@ -1556,8 +1557,6 @@ respectively."
 (defun org-roam--setup-title-auto-update ()
   "Setup automatic link description update on title change."
   (setq-local org-roam-current-title (car (org-roam--extract-titles)))
-  (add-hook 'org-roam-title-change-hook #'org-roam--update-file-name-on-title-change)
-  (add-hook 'org-roam-title-change-hook #'org-roam--update-links-on-title-change)
   (add-hook 'after-save-hook #'org-roam--handle-title-change nil t))
 
 (defun org-roam--update-links-on-title-change (old-title new-title)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1546,7 +1546,7 @@ respectively."
   "The current title of the Org-roam file.")
 
 (defun org-roam--handle-title-change ()
-  "Detect title changes, and run hooks in `org-roam-title-change-hook'."
+  "Detect a title change, and run `org-roam-title-change-hook'."
   (let ((new-title (car (org-roam--extract-titles)))
         (old-title org-roam-current-title))
     (unless (string-equal old-title new-title)


### PR DESCRIPTION
Adds `org-roam-title-change-hook`. This now contains two functions:

1. `org-roam--update-links-on-title-change`: updates the link
description of all files that link to the current file.
2. `org-roam--update-file-name-on-title-change`: updates the current
buffer's filename to reflect the updated title.

Resolves #939 .

![rename](https://user-images.githubusercontent.com/1667473/91435097-5e1f3d00-e898-11ea-818f-f4c86225a248.gif)
