### PR TITLE
Handle new file title change.

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1550,7 +1550,8 @@ respectively."
   "Detect a title change, and run `org-roam-title-change-hook'."
   (let ((new-title (car (org-roam--extract-titles)))
         (old-title org-roam-current-title))
-    (unless (string-equal old-title new-title)
+    (unless (or (eq old-title nil)
+                (string-equal old-title new-title))
       (run-hook-with-args 'org-roam-title-change-hook old-title new-title)
       (setq-local org-roam-current-title new-title))))
 


### PR DESCRIPTION
Creating new files with org-roam-insert causes errors:

Wrong type argument: char-or-string-p, nil
