### PR TITLE
(fix): fix link-extraction extracting wrong element

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -586,8 +586,9 @@ it as FILE-PATH."
       (lambda (link)
         (let* ((type (org-element-property :type link))
                (path (org-element-property :path link))
-               (element (progn (org-skip-whitespace)
-                               (org-element-at-point)))
+               (element (save-excursion
+                          (goto-char (org-element-property :begin link))
+                          (org-element-at-point)))
                (begin (or (org-element-property :content-begin element)
                           (org-element-property :begin element)))
                (content (or (org-element-property :raw-value element)


### PR DESCRIPTION
Fixes #1082, #1077, #1074

When reverting link extraction to using the `org-element` api, the
preview content (org-element-at-point) was incorrectly extracted,
causing incorrect preview content and cryptic error messages.