### PR TITLE
(feat): Support quoting text when storing via org-roam-protocol

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -975,6 +975,8 @@ javascript:location.href =
 + encodeURIComponent(location.href)
 + '&title='
 + encodeURIComponent(document.title)
++ '&body='
++ encodeURIComponent(window.getSelection())
 #+END_SRC
 
 or as a keybinding in ~qutebrowser~ in , using the ~config.py~ file (see

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1301,6 +1301,8 @@ javascript:location.href =
 + encodeURIComponent(location.href)
 + '&title='
 + encodeURIComponent(document.title)
++ '&body='
++ encodeURIComponent(window.getSelection())
 @end example
 
 or as a keybinding in @code{qutebrowser} in , using the @code{config.py} file (see

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -219,7 +219,7 @@ Template string   :\n%v")
 
 (defcustom org-roam-capture-ref-templates
   '(("r" "ref" plain (function org-roam-capture--get-point)
-     "%?"
+     "%i%?"
      :file-name "${slug}"
      :head "#+title: ${title}\n#+roam_key: ${ref}\n"
      :unnarrowed t))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -79,7 +79,7 @@ note with the given `ref'.")
 
 (defcustom org-roam-capture-templates
   '(("d" "default" plain (function org-roam-capture--get-point)
-     "%i%?"
+     "%?"
      :file-name "%<%Y%m%d%H%M%S>-${slug}"
      :head "#+title: ${title}\n"
      :unnarrowed t))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -79,7 +79,7 @@ note with the given `ref'.")
 
 (defcustom org-roam-capture-templates
   '(("d" "default" plain (function org-roam-capture--get-point)
-     "%?"
+     "%i%?"
      :file-name "%<%Y%m%d%H%M%S>-${slug}"
      :head "#+title: ${title}\n"
      :unnarrowed t))

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -63,14 +63,14 @@ It opens or creates a note with the given ref.
            (template (cdr (assoc 'template decoded-alist)))
            (org-capture-link-is-already-stored t))
       (let* ((title (cdr (assoc 'title decoded-alist)))
-            (url (cdr (assoc 'ref decoded-alist)))
-            (body (cdr (assoc 'body decoded-alist)))
-            (type (and url
-                       (string-match "^\\([a-z]+\\):" url)
-                       (match-string 1 url)))
-            (orglink
-             (if (null url) title
-               (org-link-make-string url (or (org-string-nw-p title) url)))))
+             (url (cdr (assoc 'ref decoded-alist)))
+             (body (or (cdr (assoc 'body decoded-alist)) ""))
+             (type (and url
+                        (string-match "^\\([a-z]+\\):" url)
+                        (match-string 1 url)))
+             (orglink
+              (if (null url) title
+                (org-link-make-string url (or (org-string-nw-p title) url)))))
         (when url
           (push (list url
                       title)

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -5,7 +5,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.2.1
-;; Package-Requires: ((emacs "27.1") (org "9.3"))
+;; Package-Requires: ((emacs "26.1") (org "9.3"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -75,16 +75,14 @@ It opens or creates a note with the given ref.
              (quoted-text (unless (string-equal body "")
                             (format org-roam-protocol-quote-template body)))
              (type (and url
-                        (string-match "^\\([a-z]+\\):" url)
+                        (string-match org-link-plain-re url)
                         (match-string 1 url)))
-             (orglink
-              (if (null url) title
-                (org-link-make-string url (or (org-string-nw-p title) url)))))
+             (orglink (if url
+                          (org-link-make-string url (or (org-string-nw-p title) url))
+                        title)))
         (when url
-          (push (list url
-                      title)
-                org-stored-links))
-        (org-link-store-props
+          (push (list url title) org-stored-links))
+        (org-roam-link-store-props
          :type type
          :link url
          :annotation orglink

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -45,7 +45,7 @@
 It opens or creates a note with the given ref.
 
   javascript:location.href = \\='org-protocol://roam-ref?template=r&ref=\\='+ \\
-        encodeURIComponent(location.href) + \\='&title=\\=' \\
+        encodeURIComponent(location.href) + \\='&title=\\=' + \\
         encodeURIComponent(document.title) + \\='&body=\\=' + \\
         encodeURIComponent(window.getSelection())"
   (when-let* ((alist (org-roam--plist-to-alist info))

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -38,6 +38,13 @@
 (require 'org-protocol)
 (require 'org-roam)
 
+(defcustom org-roam-protocol-quote-template "\n#+BEGIN_QUOTE\n%s\n#+END_QUOTE\n"
+  "The template used to quote text passed in.
+This is evaluated with the `format' function and only one
+argument the `body' is passed in."
+  :type 'string
+  :group 'org-roam)
+
 ;;;; Functions
 (defun org-roam-protocol-open-ref (info)
   "Process an org-protocol://roam-ref?ref= style url with INFO.
@@ -65,6 +72,8 @@ It opens or creates a note with the given ref.
       (let* ((title (cdr (assoc 'title decoded-alist)))
              (url (cdr (assoc 'ref decoded-alist)))
              (body (or (cdr (assoc 'body decoded-alist)) ""))
+             (quoted-text (unless (string-equal body "")
+                            (format org-roam-protocol-quote-template body)))
              (type (and url
                         (string-match "^\\([a-z]+\\):" url)
                         (match-string 1 url)))
@@ -79,7 +88,7 @@ It opens or creates a note with the given ref.
          :type type
          :link url
          :annotation orglink
-         :initial body))
+         :initial quoted-text))
       (raise-frame)
       (org-roam-capture--capture nil template)
       (org-roam-message "Item captured.")))

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -5,7 +5,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.2.1
-;; Package-Requires: ((emacs "26.1") (org "9.3"))
+;; Package-Requires: ((emacs "27.1") (org "9.3"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -60,7 +60,26 @@ It opens or creates a note with the given ref.
     (let* ((org-roam-capture-templates org-roam-capture-ref-templates)
            (org-roam-capture--context 'ref)
            (org-roam-capture--info decoded-alist)
-           (template (cdr (assoc 'template decoded-alist))))
+           (template (cdr (assoc 'template decoded-alist)))
+           (org-capture-link-is-already-stored t))
+      (let* ((title (cdr (assoc 'title decoded-alist)))
+            (url (cdr (assoc 'ref decoded-alist)))
+            (body (cdr (assoc 'body decoded-alist)))
+            (type (and url
+                       (string-match "^\\([a-z]+\\):" url)
+                       (match-string 1 url)))
+            (orglink
+             (if (null url) title
+               (org-link-make-string url (or (org-string-nw-p title) url)))))
+        (when url
+          (push (list url
+                      title)
+                org-stored-links))
+        (org-link-store-props
+         :type type
+         :link url
+         :annotation orglink
+         :initial body))
       (raise-frame)
       (org-roam-capture--capture nil template)
       (org-roam-message "Item captured.")))


### PR DESCRIPTION
###### Motivation for this change

There is a difference documentation between the elisp file and the example in the online documentation. The online documentation contains less functionality than the example in the elisp file. There was also a bug in the example in the emacs lisp file.   

![image](https://user-images.githubusercontent.com/2660/92326260-2ad76d80-f051-11ea-8bf5-4017feeeb3e8.png)
