### PR TITLE
added two file-truename calls to fix backlinks in *org-roam* buffer

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -110,7 +110,7 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
 (defun org-roam-buffer--insert-title ()
   "Insert the org-roam-buffer title."
   (insert (propertize (org-roam--get-title-or-slug
-                       (buffer-file-name org-roam-buffer--current))
+                       (file-truename (buffer-file-name org-roam-buffer--current)))
                        'font-lock-face
                        'org-document-title)))
 
@@ -152,7 +152,7 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
 
 (defun org-roam-buffer--insert-backlinks ()
   "Insert the org-roam-buffer backlinks string for the current buffer."
-  (if-let* ((file-path (buffer-file-name org-roam-buffer--current))
+  (if-let* ((file-path (file-truename (buffer-file-name org-roam-buffer--current)))
             (titles (with-current-buffer org-roam-buffer--current
                       (org-roam--extract-titles)))
             (backlinks (org-roam--get-backlinks (push file-path titles)))


### PR DESCRIPTION
Without this change nothing of value is displayed in `*org-roam*` buffer due to use of symbolic links to my org files.  The only thing I see is some path like "../../../x/y/z" as the first line, then simply "No backlinks!" as the third line.

With this fix, I see the title of the org file in bold as the first line as well as backlinks which I can click.