### PR TITLE
possibly fix hang for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ In this release we support fuzzy links of the form `[[Title]]`, `[[*Headline]]` 
 ### Bugfixes
 
 - [#1057](https://github.com/org-roam/org-roam/pull/1057) Improve performance of database builds by preventing generation of LaTeX and image previews.
+- [#1103](https://github.com/org-roam/org-roam/pull/1103) Fix long build-times for Windows on files with URL links
 
 ## 1.2.1 (27-07-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -335,12 +335,11 @@ function are expected to catch the error."
                  (t
                   (signal 'wrong-type-argument `((stringp numberp symbolp) ,item))))) items))))
 
-(defun org-roam--is-url-p (path)
+(defun org-roam--url-p (path)
   "Check if PATH is a URL.
 Assume the protocol is not present in PATH; e.g. URL `https://google.com' is
 passed as `//google.com'."
-
-  (s-starts-with-p "//" path))
+  (string-prefix-p "//" path))
 
 ;;;; File functions and predicates
 (defun org-roam--file-name-extension (filename)
@@ -629,7 +628,7 @@ it as FILE-PATH."
                            (org-ref-split-and-strip-string path))
                           ("fuzzy" (list path))
                           (_ (if (or (file-remote-p path)
-                                     (org-roam--is-url-p path))
+                                     (org-roam--url-p path))
                                  (list path)
                                (let ((file-maybe (file-truename
                                                   (expand-file-name path (file-name-directory file-path)))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -335,6 +335,13 @@ function are expected to catch the error."
                  (t
                   (signal 'wrong-type-argument `((stringp numberp symbolp) ,item))))) items))))
 
+(defun org-roam--is-url-p (path)
+  "Check if PATH is a URL.
+Assume the protocol is not present in PATH; e.g. URL `https://google.com' is
+passed as `//google.com'."
+
+  (s-starts-with-p "//" path))
+
 ;;;; File functions and predicates
 (defun org-roam--file-name-extension (filename)
   "Return file name extension for FILENAME.
@@ -532,8 +539,7 @@ PATH should be the root from which to compute the relativity."
       ;; Loop over links
       (while (re-search-forward org-roam--org-link-bracket-typed-re (point-max) t)
         (setq link (match-string 2))
-        (when (and (file-attributes link)
-                   (f-relative-p link))
+        (when (f-relative-p link)
           (save-excursion
             (goto-char (match-beginning 2))
             (delete-region (match-beginning 2)
@@ -622,7 +628,8 @@ it as FILE-PATH."
                            (setq type "cite")
                            (org-ref-split-and-strip-string path))
                           ("fuzzy" (list path))
-                          (_ (if (file-remote-p path)
+                          (_ (if (or (file-remote-p path)
+                                     (org-roam--is-url-p path))
                                  (list path)
                                (let ((file-maybe (file-truename
                                                   (expand-file-name path (file-name-directory file-path)))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -531,15 +531,15 @@ PATH should be the root from which to compute the relativity."
       (goto-char (point-min))
       ;; Loop over links
       (while (re-search-forward org-roam--org-link-bracket-typed-re (point-max) t)
-        (goto-char (match-beginning 2))
         (setq link-type (match-string 1)
               link (match-string 2))
-        ;; Delete relative link
-        (when (and (member link-type '("file")) ; TODO: Fix this
+        (when (and (file-attributes link)
                    (f-relative-p link))
-          (delete-region (match-beginning 2)
-                         (match-end 2))
-          (insert (expand-file-name link dir))))
+          (save-excursion
+            (goto-char (match-beginning 2))
+            (delete-region (match-beginning 2)
+                           (match-end 2))
+            (insert (expand-file-name link dir)))))
       (buffer-string))))
 
 (defun org-roam--get-outline-path ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -525,14 +525,13 @@ The search terminates when the first property is encountered."
   "Crawl CONTENT for relative links and expand them.
 PATH should be the root from which to compute the relativity."
   (let ((dir (file-name-directory path))
-        link link-type)
+        link)
     (with-temp-buffer
       (insert content)
       (goto-char (point-min))
       ;; Loop over links
       (while (re-search-forward org-roam--org-link-bracket-typed-re (point-max) t)
-        (setq link-type (match-string 1)
-              link (match-string 2))
+        (setq link (match-string 2))
         (when (and (file-attributes link)
                    (f-relative-p link))
           (save-excursion


### PR DESCRIPTION
URL links such as `https://google.com/hi/` get split into link-type `https` and path `google.com/hi/`.

On Linux, the `f-relative-p` check passes since `google.com` is a valid relative path on unix filesystems. It is possible that this path is not valid on Windows, so the db build gets stuck forever in this function.

Not sure if this is the true cause, but I think it makes sense to me, will require some testing.

cc @nobiot @ahristow