### PR TITLE
Exclude backup files (i.e., *.org~*) when navigating notes

### DIFF
--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -295,6 +295,7 @@ EXTRA-FILES can be used to append extra files to the list."
   (let ((dir (org-roam-dailies-directory--get-absolute-path)))
     (append (--remove (let ((file (file-name-nondirectory it)))
                         (when (or (auto-save-file-name-p file)
+                                  (backup-file-name-p file)
                                   (string-match "^\\." file))
                           it))
                       (directory-files-recursively dir ""))


### PR DESCRIPTION
The function org-roam-dailies--list-files includes backup files when
creating a list of all daily notes. This change filters those out, alongside
auto-save files which are already properly handled.

###### Motivation for this change
Without this change, navigating to the 'next-note' from 2020-09-10.org would take me to 2020-09-10.org~ instead of 2020-09-11.org

This applies to #978. I notice that this is the same issue that was fixed in org-roam--org-file-p in #98.