### PR TITLE
(fix): perform link expansion only on file links

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -531,14 +531,16 @@ The search terminates when the first property is encountered."
   "Crawl CONTENT for relative links and expand them.
 PATH should be the root from which to compute the relativity."
   (let ((dir (file-name-directory path))
-        link)
+        link link-type)
     (with-temp-buffer
       (insert content)
       (goto-char (point-min))
       ;; Loop over links
       (while (re-search-forward org-roam--org-link-bracket-typed-re (point-max) t)
-        (setq link (match-string 2))
-        (when (f-relative-p link)
+        (setq link-type (match-string 1)
+              link (match-string 2))
+        (when (and (string-equal link-type "file")
+                   (f-relative-p link))
           (save-excursion
             (goto-char (match-beginning 2))
             (delete-region (match-beginning 2)


### PR DESCRIPTION
This prevents ID links from being expanded in the Org-roam buffer.