### PR TITLE
(fix): fix file-name change not working on new files

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1596,8 +1596,8 @@ respectively."
         (old-title org-roam-current-title))
     (unless (or (eq old-title nil)
                 (string-equal old-title new-title))
-      (run-hook-with-args 'org-roam-title-change-hook old-title new-title)
-      (setq-local org-roam-current-title new-title))))
+      (run-hook-with-args 'org-roam-title-change-hook old-title new-title))
+    (setq-local org-roam-current-title new-title)))
 
 (defun org-roam--setup-title-auto-update ()
   "Setup automatic link description update on title change."


### PR DESCRIPTION
PR #1076 prevented the title change hook from causing errors for new files,
but completely disables the behaviour. To cause the title hooks to take
effect, we set the local variable `org-roam-current-title` upon save,
regardless of whether the hook ran.

This should have the effect of enabling the title change behaviour upon
first save, assuming the save succeeds.

Addresses https://org-roam.discourse.group/t/org-roam-update-file-name-on-title-change-works-discontinuously/767