### PR TITLE
improvement: skip check filepath when the path is remote style for wh…

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1541,8 +1541,8 @@ update with NEW-DESC."
       (when-let ((link (org-element-lineage (org-element-context) '(link) t)))
         (let ((type (org-element-property :type link))
               (path (org-element-property :path link)))
-          (when (and (not (tramp-handle-file-remote-p path))
-                     (string-equal (file-truename path) old-path)a
+          (when (and (not (file-remote-p path))
+                     (string-equal (file-truename path) old-path)
                      (org-in-regexp org-link-bracket-re 1))
             (let* ((label (if (match-end 2)
                               (match-string-no-properties 2)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1541,7 +1541,8 @@ update with NEW-DESC."
       (when-let ((link (org-element-lineage (org-element-context) '(link) t)))
         (let ((type (org-element-property :type link))
               (path (org-element-property :path link)))
-          (when (and (string-equal (file-truename path) old-path)
+          (when (and (not (tramp-handle-file-remote-p path))
+                     (string-equal (file-truename path) old-path)a
                      (org-in-regexp org-link-bracket-re 1))
             (let* ((label (if (match-end 2)
                               (match-string-no-properties 2)


### PR DESCRIPTION
…en network is not work or serve

It will cause tramp erro signal when update link with the filepath which remote server is down

###### Motivation for this change

Skip the remote path link update, because the server will be down sometimes. In my situation I closed some azure server, but the org file have link to the server which is closed