### PR TITLE
(ci): do not return on package-lint error

### DIFF
--- a/makem.sh
+++ b/makem.sh
@@ -591,6 +591,12 @@ function debug {
         }
     fi
 }
+
+function error_continue {
+    echo_color red "ERROR ($(ts)): $@" >&2
+    ((errors++))
+}
+
 function error {
     echo_color red "ERROR ($(ts)): $@" >&2
     ((errors++))
@@ -763,7 +769,7 @@ function lint-package {
         --funcall package-lint-batch-and-exit \
         "${files_project_feature[@]}" \
         && success "Linting package finished without errors." \
-            || error "Linting package failed."
+            || error_continue "Linting package failed."
 }
 
 function lint-regexps {


### PR DESCRIPTION
###### Motivation for this change

Package-lint gives errors that are not really fixable, as it makem does not install the version of Org we require for Org-roam, demanding a minimum version of Emacs 27.1 instead.