### PR TITLE
update `org-roam-graph-show` in README.md:

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Here's a sample configuration with using `use-package`:
       :bind (:map org-roam-mode-map
               (("C-c n l" . org-roam)
                ("C-c n f" . org-roam-find-file)
-               ("C-c n g" . org-roam-graph-show))
+               ("C-c n g" . org-roam-graph))
               :map org-mode-map
               (("C-c n i" . org-roam-insert))
               (("C-c n I" . org-roam-insert-immediate))))


### PR DESCRIPTION
- emacs throws a warning. It's removed by using `org-roam-graph`

###### Motivation for this change
Fixes #1120 