### PR TITLE
feat: extract idle timer interval as a customizable value

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -113,7 +113,7 @@ If nil, `find-file' is used."
   :type 'function
   :group 'org-roam)
 
-(defcustom org-roam-update-db-idletimer-by-seconds 2
+(defcustom org-roam-update-db-idle-seconds 2
   "Number of idle seconds before triggering an Org-roam database update."
   :type 'integer
   :group 'org-roam)
@@ -1721,7 +1721,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (add-hook 'org-open-at-point-functions #'org-roam-open-id-at-point)
     (add-hook 'org-open-link-functions #'org-roam--open-fuzzy-link)
     (unless org-roam--file-update-timer
-      (setq org-roam--file-update-timer (run-with-idle-timer org-roam-update-db-idletimer-by-seconds t #'org-roam--process-update-queue)))
+      (setq org-roam--file-update-timer (run-with-idle-timer org-roam-update-db-idle-seconds t #'org-roam--process-update-queue)))
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)

--- a/org-roam.el
+++ b/org-roam.el
@@ -113,6 +113,11 @@ If nil, `find-file' is used."
   :type 'function
   :group 'org-roam)
 
+(defcustom org-roam-update-db-idle-delay 2
+  "The idle timer when org-roam update db index"
+  :type 'integer
+  :group 'org-roam)
+
 (defcustom org-roam-include-type-in-ref-path-completions nil
   "When t, include the type in ref-path completions.
 Note that this only affects interactive calls.
@@ -1716,7 +1721,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (add-hook 'org-open-at-point-functions #'org-roam-open-id-at-point)
     (add-hook 'org-open-link-functions #'org-roam--open-fuzzy-link)
     (unless org-roam--file-update-timer
-      (setq org-roam--file-update-timer (run-with-idle-timer 2 t #'org-roam--process-update-queue)))
+      (setq org-roam--file-update-timer (run-with-idle-timer org-roam-update-db-idle-delay t #'org-roam--process-update-queue)))
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)

--- a/org-roam.el
+++ b/org-roam.el
@@ -113,8 +113,8 @@ If nil, `find-file' is used."
   :type 'function
   :group 'org-roam)
 
-(defcustom org-roam-update-db-idle-delay 2
-  "The idle timer when org-roam update db index."
+(defcustom org-roam-update-db-idletimer-by-seconds 2
+  "Number of idle seconds before triggering an Org-roam database update."
   :type 'integer
   :group 'org-roam)
 
@@ -1721,7 +1721,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (add-hook 'org-open-at-point-functions #'org-roam-open-id-at-point)
     (add-hook 'org-open-link-functions #'org-roam--open-fuzzy-link)
     (unless org-roam--file-update-timer
-      (setq org-roam--file-update-timer (run-with-idle-timer org-roam-update-db-idle-delay t #'org-roam--process-update-queue)))
+      (setq org-roam--file-update-timer (run-with-idle-timer org-roam-update-db-idletimer-by-seconds t #'org-roam--process-update-queue)))
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
     (when (fboundp 'org-link-set-parameters)

--- a/org-roam.el
+++ b/org-roam.el
@@ -114,7 +114,7 @@ If nil, `find-file' is used."
   :group 'org-roam)
 
 (defcustom org-roam-update-db-idle-delay 2
-  "The idle timer when org-roam update db index"
+  "The idle timer when org-roam update db index."
   :type 'integer
   :group 'org-roam)
 


### PR DESCRIPTION
###### Motivation for this change
My org-roam buffer list is very long. The number is about 200 files, and in my workflow I aways refile heading. So when the auto save trigger the push queue function will stuck. And then the idle timer will trigger in 2 secs. So In may situation I like to customize this idle timer interval to bigger value