### PR TITLE
(fix): remove other occurrences of file-truename

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -224,7 +224,7 @@ This needs to be quick or infrequent, because this is run at
     (when (and (or redisplay
                    (not (eq org-roam-buffer--current buffer)))
                (eq 'visible (org-roam-buffer--visibility))
-               (buffer-local-value 'buffer-file-truename buffer))
+               (buffer-file-name buffer))
       (setq org-roam-buffer--current buffer)
       (org-roam-buffer-update))))
 

--- a/tests/test-org-roam-perf.el
+++ b/tests/test-org-roam-perf.el
@@ -29,7 +29,7 @@
 
 (defun test-org-roam-perf--abs-path (file-path)
   "Get absolute FILE-PATH from `org-roam-directory'."
-  (file-truename (expand-file-name file-path org-roam-directory)))
+  (expand-file-name file-path org-roam-directory))
 
 (defun test-org-roam-perf--init ()
   "."

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -27,7 +27,7 @@
 
 (defun test-org-roam--abs-path (file-path)
   "Get absolute FILE-PATH from `org-roam-directory'."
-  (file-truename (expand-file-name file-path org-roam-directory)))
+  (expand-file-name file-path org-roam-directory))
 
 (defun test-org-roam--find-file (path)
   "PATH."
@@ -35,7 +35,7 @@
     (make-directory (file-name-directory path) t)
     (find-file path)))
 
-(defvar test-org-roam-directory (file-truename (concat default-directory "tests/roam-files"))
+(defvar test-org-roam-directory (expand-file-name "tests/roam-files")
   "Directory containing org-roam test org files.")
 
 (defun test-org-roam--init ()


### PR DESCRIPTION
org-roam-buffer should no longer be resolving the symlinks as well.