### PR TITLE
(fix) Add org-roam--completion-exit-fn for post-completion of [[Title]] to move cursor out of the brackets

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1146,6 +1146,13 @@ This function hooks into `org-open-at-point' via
   :group 'org-roam
   :type 'boolean)
 
+(defun org-roam--completion-exit-fn (&rest _)
+  "After accepting complete-at-point, move out of `]]`.
+This is intended to be set to :exit-function within
+`org-roam-complete-at-point` function."
+  
+  (forward-char 2))
+
 (defun org-roam-complete-at-point ()
   "Do appropriate completion for the thing at point."
   (let ((end (point))
@@ -1207,7 +1214,7 @@ This function hooks into `org-open-at-point' via
                      (cl-remove-if (apply-partially #'string= prefix)
                                    (funcall collection))))
                 collection)
-              :exit-function exit-fn)))))
+              :exit-function #'org-roam--completion-exit-fn)))))
 
 ;;; Fuzzy Links
 (defcustom org-roam-enable-fuzzy-links t


### PR DESCRIPTION
Currently Org-roam's completion-at-point implements :exit-fn as
a lambda function. For some reason, it is not triggered at post-
completion; however, it has been observed that a named function is
triggered as expected. 

This commit implements a function, and
replaces the assignment of :exit-function with the newly
created function. This is intended to get the cursor (point)
out of the [[Title]] bracket for more intuitive writing experience.

###### Motivation for this change
At the moment, when you type [[Title]], accepts a company completion, the cursor remains within the square brackets, like this:

`[[Title|]]`
`-------^ here`

---

I realise this implementation is crude, and probably does not address the "tag" completion.
Please take this PR as a suggestion. 
It works...
![company-fix](https://user-images.githubusercontent.com/12507865/93914387-c67e0480-fd06-11ea-90f8-344e69eddd69.gif)


