### PR TITLE
(feat): enable capt for [[|]]; add exit-fn

### DIFF
--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -236,27 +236,28 @@ DESC is the link description."
   "Do appropriate completion for the link at point."
   (let ((end (point))
         (start (point))
-        (exit-fn (lambda (&rest _) nil))
+        (exit-fn (lambda (str &rest _)
+                   (delete-char (- (length str)))
+                   (insert "roam:" str)))
         collection)
     (when (org-in-regexp org-link-bracket-re 1)
-      (setq start (+ (match-beginning 1) (length "roam:"))
+      (setq start (match-beginning 1)
             end (match-end 1))
       (let ((context (org-element-context)))
         (pcase (org-element-lineage context '(link) t)
           (`nil nil)
-          (link (when (string-equal "roam" (org-element-property :type link))
-                  (pcase-let ((`(,type ,title _ ,star-idx)
-                               (org-roam-link--split-path (org-element-property :path link))))
-                    (pcase type
-                      ('title+headline
-                       (when-let ((file (org-roam-link--get-file-from-title title t)))
-                         (setq collection (apply-partially #'org-roam-link--get-headlines file))
-                         (setq start (+ start star-idx 1))))
-                      ('title
-                       (setq collection #'org-roam-link--get-titles))
-                      ('headline
-                       (setq collection #'org-roam-link--get-headlines)
-                       (setq start (+ start star-idx 1))))))))))
+          (link (pcase-let ((`(,type ,title _ ,star-idx)
+                             (org-roam-link--split-path (org-element-property :path link))))
+                  (pcase type
+                    ('title+headline
+                     (when-let ((file (org-roam-link--get-file-from-title title t)))
+                       (setq collection (apply-partially #'org-roam-link--get-headlines file))
+                       (setq start (+ start star-idx 1))))
+                    ('title
+                     (setq collection #'org-roam-link--get-titles))
+                    ('headline
+                     (setq collection #'org-roam-link--get-headlines)
+                     (setq start (+ start star-idx 1)))))))))
     (when collection
       (let ((prefix (buffer-substring-no-properties start end)))
         (list start end

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -236,28 +236,29 @@ DESC is the link description."
   "Do appropriate completion for the link at point."
   (let ((end (point))
         (start (point))
-        (exit-fn (lambda (str &rest _)
-                   (delete-char (- (length str)))
-                   (insert "roam:" str)))
-        collection)
+        collection link-type)
     (when (org-in-regexp org-link-bracket-re 1)
       (setq start (match-beginning 1)
             end (match-end 1))
       (let ((context (org-element-context)))
         (pcase (org-element-lineage context '(link) t)
           (`nil nil)
-          (link (pcase-let ((`(,type ,title _ ,star-idx)
-                             (org-roam-link--split-path (org-element-property :path link))))
-                  (pcase type
-                    ('title+headline
-                     (when-let ((file (org-roam-link--get-file-from-title title t)))
-                       (setq collection (apply-partially #'org-roam-link--get-headlines file))
-                       (setq start (+ start star-idx 1))))
-                    ('title
-                     (setq collection #'org-roam-link--get-titles))
-                    ('headline
-                     (setq collection #'org-roam-link--get-headlines)
-                     (setq start (+ start star-idx 1)))))))))
+          (link
+           (setq link-type (org-element-property :type link))
+           (when (member link-type '("roam" "fuzzy"))
+             (when (string= link-type "roam") (setq start (+ start (length "roam:"))))
+             (pcase-let ((`(,type ,title _ ,star-idx)
+                          (org-roam-link--split-path (org-element-property :path link))))
+               (pcase type
+                 ('title+headline
+                  (when-let ((file (org-roam-link--get-file-from-title title t)))
+                    (setq collection (apply-partially #'org-roam-link--get-headlines file))
+                    (setq start (+ start star-idx 1))))
+                 ('title
+                  (setq collection #'org-roam-link--get-titles))
+                 ('headline
+                  (setq collection #'org-roam-link--get-headlines)
+                  (setq start (+ start star-idx 1))))))))))
     (when collection
       (let ((prefix (buffer-substring-no-properties start end)))
         (list start end
@@ -269,7 +270,10 @@ DESC is the link description."
                                     (funcall collection))))
                    (not org-roam-completion-ignore-case))
                 collection)
-              :exit-function exit-fn)))))
+              :exit-function
+              (lambda (str &rest _)
+                (delete-char (- (length str)))
+                (insert (concat (unless (string= link-type "roam") "roam:") str))))))))
 
 (provide 'org-roam-link)
 ;;; org-roam-link.el ends here


### PR DESCRIPTION
Please take this as a gentle inviting for a discussion with a concrete implementation.

The intention of this commit / PR is to suggest an alternative to the current
capf in org-roam-link.el. Currently, you need to type [[roam:]] for capf to
work for the link completion-at-point. This alternative enables capf to be
triggered without roam: for [[|]]. roam: is added automatically with
exit-fn (implemented as a lambda function as originally intended).

###### Motivation for this change
The keycord for `[[roam:]]` is not necessarily fluid for writing. I assumed this was a workaround, and ideally the way this alternative proposes is an originally intended behavior for completion-at-point for links with titles.
Up for discussion of course.

My initial testing shows that it works as intended.
In this animation, capf is not manually triggered (it's automatic).
![org-roam-link-alt](https://user-images.githubusercontent.com/12507865/94169665-5bac0500-fe8f-11ea-9ee4-5fb2698c7731.gif)



