### PR TITLE
(fix): fix refs not showing in backlinks buffer

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -126,10 +126,10 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
 
 (defun org-roam-buffer--insert-ref-links ()
   "Insert ref backlinks for the current buffer."
-  (when-let ((ref (cdr (with-temp-buffer
+  (when-let ((path (cdr (with-temp-buffer
                         (insert-buffer-substring org-roam-buffer--current)
                         (org-roam--extract-ref)))))
-    (if-let* ((key-backlinks (org-roam--get-backlinks ref))
+    (if-let* ((key-backlinks (org-roam--get-backlinks path))
               (grouped-backlinks (--group-by (nth 0 it) key-backlinks)))
         (progn
           (insert (let ((l (length key-backlinks)))

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -127,8 +127,8 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
 (defun org-roam-buffer--insert-ref-links ()
   "Insert ref backlinks for the current buffer."
   (when-let ((path (cdr (with-temp-buffer
-                        (insert-buffer-substring org-roam-buffer--current)
-                        (org-roam--extract-ref)))))
+                          (insert-buffer-substring org-roam-buffer--current)
+                          (org-roam--extract-ref)))))
     (if-let* ((key-backlinks (org-roam--get-backlinks path))
               (grouped-backlinks (--group-by (nth 0 it) key-backlinks)))
         (progn

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -63,19 +63,6 @@ If FILE, set `org-roam-temp-file-name' to file and insert its contents."
              (setq-local org-roam-file-name ,file))
            ,@body)))))
 
-(defmacro org-roam--with-file (file &rest body)
-  "Execute BODY within a FILE.
-Closes the file if the file is not yet visited."
-  (declare (indent 1) (debug t))
-  `(let* ((existing-buf (find-buffer-visiting ,file))
-          (buf (or existing-buf
-                   (find-file-noselect file)))
-          res)
-     (with-current-buffer buf
-       (setq res ,@body))
-     (when existing-buf (kill-buffer existing-buf))
-     res))
-
 (defun org-roam-message (format-string &rest args)
   "Pass FORMAT-STRING and ARGS to `message' when `org-roam-verbose' is t."
   (when org-roam-verbose

--- a/org-roam.el
+++ b/org-roam.el
@@ -782,8 +782,7 @@ Tags are obtained via:
 Packages like `org-ref' introduce many different link prefixes,
 but we collate them under the same parent type to clean up
 backlinks."
-  (cond ((and (require 'org-ref nil t)
-              (member type org-ref-cite-types))
+  (cond ((member type org-ref-cite-types)
          "cite")
         ((member type '("http" "https"))
          "website")

--- a/org-roam.el
+++ b/org-roam.el
@@ -782,7 +782,8 @@ Tags are obtained via:
 Packages like `org-ref' introduce many different link prefixes,
 but we collate them under the same parent type to clean up
 backlinks."
-  (cond ((member type org-ref-cite-types)
+  (cond ((and (boundp 'org-ref-cite-types)
+              (member type org-ref-cite-types))
          "cite")
         ((member type '("http" "https"))
          "website")

--- a/org-roam.el
+++ b/org-roam.el
@@ -799,9 +799,9 @@ backlinks."
       (ref
        (when (string-match org-link-plain-re ref)
          (setq type (org-roam--collate-types (match-string 1 ref))
-               path (match-string 2 ref)))
-       (when (and type path)
-         (cons type path))))))
+               path (match-string 2 ref)))))
+    (when (and type path)
+      (cons type path))))
 
 ;;;; Title/Path/Slug conversion
 (defun org-roam--path-to-slug (path)
@@ -1092,8 +1092,8 @@ When KEEP-BUFFER-P is non-nil, keep the buffers navigated by Org-roam open."
   (let ((file (or (org-roam-id-get-file id)
                   (unless strict (org-id-find-id-file id)))))
     (when file
-      (let* ((existing-buf (find-buffer-visiting file))
-             (res (org-id-find-id-in-file id file markerp)))
+      (let ((existing-buf (find-buffer-visiting file))
+            (res (org-id-find-id-in-file id file markerp)))
         (when (and (not keep-buffer-p)
                    existing-buf)
           (kill-buffer existing-buf))

--- a/org-roam.el
+++ b/org-roam.el
@@ -782,7 +782,8 @@ Tags are obtained via:
 Packages like `org-ref' introduce many different link prefixes,
 but we collate them under the same parent type to clean up
 backlinks."
-  (cond ((member type org-ref-cite-types)
+  (cond ((and (require 'org-ref nil t)
+              (member type org-ref-cite-types))
          "cite")
         ((member type '("http" "https"))
          "website")

--- a/org-roam.el
+++ b/org-roam.el
@@ -611,7 +611,7 @@ it as FILE-PATH."
       (org-element-map (org-element-parse-buffer) 'link
         (lambda (link)
           (goto-char (org-element-property :begin link))
-          (let* ((type (org-element-property :type link))
+          (let* ((type (org-roam--collate-types (org-element-property :type link)))
                  (path (org-element-property :path link))
                  (element (org-element-at-point))
                  (begin (or (org-element-property :content-begin element)
@@ -631,11 +631,8 @@ it as FILE-PATH."
                  (names (pcase type
                           ("id"
                            (list (car (org-roam-id-find path))))
-                          ((pred (lambda (typ)
-                                   (and (boundp 'org-ref-cite-types)
-                                        (-contains? org-ref-cite-types typ))))
-                           (setq type "cite")
-                           (org-ref-split-and-strip-string path))
+                          ("cite" (list path))
+                          ("website" (list path))
                           ("fuzzy" (list path))
                           ("roam" (list path))
                           (_ (if (or (file-remote-p path)
@@ -780,47 +777,31 @@ Tags are obtained via:
                           `((booleanp (list symbolp))
                             ,wrong-type))))))
 
-(defun org-roam--cite-prefix (ref)
-  "Return the citation prefix of REF, or nil otherwise.
-The prefixes are defined in `org-ref-cite-types`.
-Examples:
-   (org-roam--cite-prefix \"cite:foo\") -> \"cite:\"
-   (org-roam--cite-prefix \"https://google.com\") -> nil"
-  (when (require 'org-ref nil t)
-    (seq-find
-     (lambda (prefix) (s-prefix? prefix ref))
-     (-map (lambda (type) (concat type ":"))
-           org-ref-cite-types))))
-
-(defun org-roam--ref-type (ref)
-  "Determine the type of the REF from the prefix."
-  (let* ((cite-prefix (org-roam--cite-prefix ref))
-         (is-website (seq-some
-                      (lambda (prefix) (s-prefix? prefix ref))
-                      '("http" "https")))
-         (type (cond (cite-prefix "cite")
-                     (is-website "website")
-                     (t "file"))))
-    type))
+(defun org-roam--collate-types (type)
+  "Collate TYPE into a parent type.
+Packages like `org-ref' introduce many different link prefixes,
+but we collate them under the same parent type to clean up
+backlinks."
+  (cond ((member type org-ref-cite-types)
+         "cite")
+        ((member type '("http" "https"))
+         "website")
+        (t type)))
 
 (defun org-roam--extract-ref ()
   "Extract the ref from current buffer and return the type and the key of the ref."
-  (pcase (cdr (assoc "ROAM_KEY"
-                     (org-roam--extract-global-props '("ROAM_KEY"))))
-    ('nil nil)
-    ((pred string-empty-p)
-     (user-error "Org property #+roam_key cannot be empty"))
-    (ref
-     (let* ((type (org-roam--ref-type ref))
-            (key (cond ((string= "cite" type)
-                        (s-chop-prefix (org-roam--cite-prefix ref) ref))
-                       (t ref))))
-       (cons type key)))))
-
-(defun org-roam--ref-type-p (type)
-  "Return t if the ref from current buffer is TYPE."
-  (let ((current (car (org-roam--extract-ref))))
-    (eq current type)))
+  (let (type path)
+    (pcase (cdr (assoc "ROAM_KEY"
+                       (org-roam--extract-global-props '("ROAM_KEY"))))
+      ('nil nil)
+      ((pred string-empty-p)
+       (user-error "Org property #+roam_key cannot be empty"))
+      (ref
+       (when (string-match org-link-plain-re ref)
+         (setq type (org-roam--collate-types (match-string 1 ref))
+               path (match-string 2 ref)))
+       (when (and type path)
+         (cons type path))))))
 
 ;;;; Title/Path/Slug conversion
 (defun org-roam--path-to-slug (path)
@@ -1111,10 +1092,12 @@ When KEEP-BUFFER-P is non-nil, keep the buffers navigated by Org-roam open."
   (let ((file (or (org-roam-id-get-file id)
                   (unless strict (org-id-find-id-file id)))))
     (when file
-      (if keep-buffer-p
-          (org-id-find-id-in-file id file markerp)
-        (org-roam--with-file file
-          (org-id-find-id-in-file id file markerp))))))
+      (let* ((existing-buf (find-buffer-visiting file))
+             (res (org-id-find-id-in-file id file markerp)))
+        (when (and (not keep-buffer-p)
+                   existing-buf)
+          (kill-buffer existing-buf))
+        res))))
 
 (defun org-roam-id-open (id-or-marker &optional strict)
   "Go to the entry with ID-OR-MARKER.


### PR DESCRIPTION
This changes ref extraction to parse the ref using the org plain-links
syntax. This works for arbitrary `cite` links, and web links.

Link storage and ref lookup is now based on the path (e.g.
`//google.com`) or `author_year`.