### PR TITLE
(fix): org-roam leaves files open when it shouldnt

### DIFF
--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -46,6 +46,17 @@
         (nconc new-lst (list separator it)))
       new-lst)))
 
+(defmacro org-roam--with-file (file &rest body)
+  "Execute BODY within a FILE.
+Closes the file if the file is not yet visited."
+  (declare (indent 1) (debug t))
+  `(let* ((existing-buf (find-buffer-visiting ,file))
+          (res ,@body))
+     ;; find-buffer-visiting needs to be recomputed because it was created by
+     ;; @body
+     (unless existing-buf (kill-buffer (find-buffer-visiting ,file)))
+     res))
+
 (defmacro org-roam--with-temp-buffer (file &rest body)
   "Execute BODY within a temp buffer.
 Like `with-temp-buffer', but propagates `org-roam-directory'.

--- a/org-roam.el
+++ b/org-roam.el
@@ -1094,12 +1094,10 @@ When KEEP-BUFFER-P is non-nil, keep the buffers navigated by Org-roam open."
   (let ((file (or (org-roam-id-get-file id)
                   (unless strict (org-id-find-id-file id)))))
     (when file
-      (let ((existing-buf (find-buffer-visiting file))
-            (res (org-id-find-id-in-file id file markerp)))
-        (when (and (not keep-buffer-p)
-                   existing-buf)
-          (kill-buffer existing-buf))
-        res))))
+      (if keep-buffer-p
+          (org-id-find-id-in-file id file markerp)
+        (org-roam--with-file file
+          (org-id-find-id-in-file id file markerp))))))
 
 (defun org-roam-id-open (id-or-marker &optional strict)
   "Go to the entry with ID-OR-MARKER.


### PR DESCRIPTION
###### Motivation for this change
`org-roam-db--update-file` and `org-roam-roam-find-file` open unvisited files
and leave them open while in most cases, unvisited files should be closed back
again.

this commit fixes that. it extends work in #1129, #1131, #1140.