### PR TITLE
(perf): disable org-agenda while building the cache

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -478,6 +478,7 @@ If FORCE, force a rebuild of the cache from scratch."
   (org-roam-db--close) ;; Force a reconnect
   (org-roam-db) ;; To initialize the database, no-op if already initialized
   (let* ((gc-cons-threshold org-roam-db-gc-threshold)
+	 (org-agenda-files nil)
          (org-roam-files (org-roam--list-all-files))
          (current-files (org-roam-db--get-current-files))
          (file-count 0)


### PR DESCRIPTION
`org-mode` builds the `org-agenda-files` menu entry for every file
visited. This functionality isn't required and useful when building
the cache in temporary org buffers.

###### Motivation for this change
Performance improvement. Master:
```
ELISP> (benchmark 1 '(org-roam-db-build-cache 1))
"Elapsed time: 45.214780s (11.347281s in 219 GCs)"
```
This branch:
```
ELISP> (benchmark 1 '(org-roam-db-build-cache 1))
"Elapsed time: 10.499171s (2.793775s in 54 GCs)"
```
I have all my org-roam files (550 currently) in my agenda-files:

`(add-to-list 'org-agenda-files "~/shared/org/roam"))`

I was surprised that org makes 550 menu entries for every visited file, even if the buffer is only in temporary use (while building the cache). 

