### PR TITLE
(internal): replace find-file-noselect with with-temp-buffer where possible

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -393,7 +393,7 @@ connections, nil is returned."
 ;;;;; Updating
 (defun org-roam-db--update-meta ()
   "Update the metadata of the current buffer into the cache."
-  (let* ((file (buffer-file-name))
+  (let* ((file (or org-roam-file-name (buffer-file-name)))
          (attr (file-attributes file))
          (atime (file-attribute-access-time attr))
          (mtime (file-attribute-modification-time attr))
@@ -405,7 +405,7 @@ connections, nil is returned."
 
 (defun org-roam-db--update-titles ()
   "Update the title of the current buffer into the cache."
-  (let* ((file (buffer-file-name))
+  (let* ((file (or org-roam-file-name (buffer-file-name)))
          (titles (or (org-roam--extract-titles)
                      (list (org-roam--path-to-slug file)))))
     (org-roam-db-query [:delete :from titles
@@ -415,8 +415,8 @@ connections, nil is returned."
 
 (defun org-roam-db--update-tags ()
   "Update the tags of the current buffer into the cache."
-  (let ((file (buffer-file-name))
-        (tags (org-roam--extract-tags)))
+  (let* ((file (or org-roam-file-name (buffer-file-name)))
+         (tags (org-roam--extract-tags file)))
     (org-roam-db-query [:delete :from tags
                         :where (= file $s1)]
                        file)
@@ -425,7 +425,7 @@ connections, nil is returned."
 
 (defun org-roam-db--update-refs ()
   "Update the ref of the current buffer into the cache."
-  (let ((file (buffer-file-name)))
+  (let ((file (or org-roam-file-name (buffer-file-name))))
     (org-roam-db-query [:delete :from refs
                         :where (= file $s1)]
                        file)
@@ -434,7 +434,7 @@ connections, nil is returned."
 
 (defun org-roam-db--update-links ()
   "Update the file links of the current buffer in the cache."
-  (let ((file (buffer-file-name)))
+  (let ((file (or org-roam-file-name (buffer-file-name))))
     (org-roam-db-query [:delete :from links
                         :where (= from $s1)]
                        file)
@@ -443,7 +443,7 @@ connections, nil is returned."
 
 (defun org-roam-db--update-headlines ()
   "Update the file headlines of the current buffer into the cache."
-  (let* ((file (buffer-file-name)))
+  (let* ((file (or org-roam-file-name (buffer-file-name))))
     (org-roam-db-query [:delete :from headlines
                         :where (= file $s1)]
                        file)
@@ -459,16 +459,15 @@ If the file exists, update the cache with information."
   (cond ((not (file-exists-p file-path))
          (org-roam-db--clear-file file-path))
         ((org-roam--org-roam-file-p file-path)
-         (with-current-buffer (find-file-noselect file-path t)
-           (org-with-wide-buffer
-            (emacsql-with-transaction (org-roam-db)
+         (org-roam--with-temp-buffer file-path
+           (emacsql-with-transaction (org-roam-db)
               (org-roam-db--update-meta)
               (org-roam-db--update-tags)
               (org-roam-db--update-titles)
               (org-roam-db--update-refs)
               (when org-roam-enable-headline-linking
                 (org-roam-db--update-headlines))
-              (org-roam-db--update-links)))))))
+              (org-roam-db--update-links))))))
 
 (defun org-roam-db-build-cache (&optional force)
   "Build the cache for `org-roam-directory'.

--- a/org-roam.el
+++ b/org-roam.el
@@ -604,8 +604,9 @@ FILE-FROM is typically the buffer file path, but this may not exist, for example
 in temp buffers.  In cases where this occurs, we do know the file path, and pass
 it as FILE-PATH."
   (require 'org-ref nil t)
-  (unless file-path
-    (setq file-path (buffer-file-name)))
+  (setq file-path (or file-path
+                      org-roam-file-name
+                      (buffer-file-name)))
   (save-excursion
     (let (links)
       (org-element-map (org-element-parse-buffer) 'link


### PR DESCRIPTION
`find-file-noselect` is affected by the user's init.el, and there is
little control over what is being activated. For database updates, read
access is all we need, so we use `with-temp-file`.