### PR TITLE
(fix): pass file name to extract-headlines.

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -447,7 +447,7 @@ connections, nil is returned."
     (org-roam-db-query [:delete :from headlines
                         :where (= file $s1)]
                        file)
-    (when-let ((headlines (org-roam--extract-headlines)))
+    (when-let ((headlines (org-roam--extract-headlines file)))
       (org-roam-db--insert-headlines headlines))))
 
 (defun org-roam-db--update-file (&optional file-path)


### PR DESCRIPTION
Another location where filename needs to be passed down as per #1150.


###### Motivation for this change