### PR TITLE
Use relative path in side buffer

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -139,7 +139,7 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
             (let ((file-from (car group))
                   (bls (cdr group)))
               (insert (format "** [[file:%s][%s]]\n"
-                              file-from
+                              (file-relative-name file-from)
                               (org-roam--get-title-or-slug file-from)))
               (dolist (backlink bls)
                 (pcase-let ((`(,file-from _ ,props) backlink))
@@ -166,7 +166,7 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
                 (bls (mapcar (lambda (row)
                                  (nth 2 row)) (cdr group))))
             (insert (format "** [[file:%s][%s]]\n"
-                            file-from
+                            (file-relative-name file-from)
                             (org-roam--get-title-or-slug file-from)))
             ;; Sort backlinks according to time of occurrence in buffer
             (setq bls (seq-sort-by (lambda (bl)


### PR DESCRIPTION
###### Motivation for this change

This allows faster copy-and-paste into one's notes to create an explicit list note.

Before:

![Screenshot_20200930_154459](https://user-images.githubusercontent.com/11722318/94651923-2cd0db80-0334-11eb-93dd-fa1c6bae02ad.png)

After:

![Screenshot_20200930_154257](https://user-images.githubusercontent.com/11722318/94651916-29d5eb00-0334-11eb-9cc1-b7e8e5af15fa.png)
