### PR TITLE
(feat): clean up link expansions

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -106,6 +106,7 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
 
 (defun org-roam-buffer--find-file (file)
   "Open FILE in the window `org-roam' was called from."
+  (setq file (expand-file-name file))
   (if (and org-roam-last-window (window-valid-p org-roam-last-window))
       (progn (with-selected-window org-roam-last-window
                (org-roam--find-file file))

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -38,6 +38,7 @@
 (require 'org-roam-compat)
 
 (defvar org-roam-completion-ignore-case)
+(defvar org-roam-directory)
 (declare-function  org-roam--find-file                  "org-roam")
 (declare-function  org-roam-find-file                   "org-roam")
 
@@ -46,6 +47,21 @@
   "When non-nil, replace Org-roam's roam links with file or id links whenever possible."
   :group 'org-roam
   :type 'boolean)
+
+(defcustom org-roam-link-file-path-type 'relative
+  "How the path name in file links should be stored.
+Valid values are:
+
+relative  Relative to the current directory, i.e. the directory of the file
+          into which the link is being inserted.
+absolute  Absolute path, if possible with ~ for home directory.
+noabbrev  Absolute path, no abbreviation of home directory."
+  :group 'org-roam
+  :type '(choice
+          (const relative)
+          (const absolute)
+          (const noabbrev))
+  :safe #'symbolp)
 
 ;;; the roam: link
 (org-link-set-parameters "roam"
@@ -139,6 +155,19 @@ If there is no corresponding headline, return nil."
                   (org-id-get-create))))))))
 
 ;;; Path-related functions
+(defun org-roam-link-get-path (path &optional dir)
+  "Return the PATH of the link to use.
+Respect `org-link-file-path-type', see the variable documentation for details.
+If DIR is passed, use DIR as the default directory."
+  (let ((default-directory (or dir default-directory)))
+    (pcase org-roam-link-file-path-type
+      ('absolute
+       (abbreviate-file-name (expand-file-name path)))
+      ('noabbrev
+       (expand-file-name path))
+      ('relative
+       (file-relative-name path)))))
+
 (defun org-roam-link--split-path (path)
   "Splits PATH into title and headline.
 Return a list of the form (type title has-headline-p headline star-idx).
@@ -185,8 +214,7 @@ marker is a marker to the headline, if applicable."
         ('title
          (setq loc (org-roam-link--get-file-from-title title)
                desc title
-               link-type "file")
-         (when loc (setq loc (file-relative-name loc))))
+               link-type "file"))
         ('headline
          (setq mkr (org-roam-link--get-id-from-headline headline))
          (pcase mkr
@@ -209,6 +237,8 @@ DESC is the link description."
       (unless (org-in-regexp org-link-bracket-re 1)
         (user-error "No link at point"))
       (replace-match "")
+      (when (string-equal link-type "file")
+        (setq loc (org-roam-link-get-path loc)))
       (insert (org-roam-link-make-string (concat link-type ":" loc) desc)))))
 
 (defun org-roam-link-replace-all ()

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -155,18 +155,17 @@ If there is no corresponding headline, return nil."
                   (org-id-get-create))))))))
 
 ;;; Path-related functions
-(defun org-roam-link-get-path (path &optional dir)
+(defun org-roam-link-get-path (path)
   "Return the PATH of the link to use.
 Respect `org-link-file-path-type', see the variable documentation for details.
 If DIR is passed, use DIR as the default directory."
-  (let ((default-directory (or dir default-directory)))
-    (pcase org-roam-link-file-path-type
+  (pcase org-roam-link-file-path-type
       ('absolute
        (abbreviate-file-name (expand-file-name path)))
       ('noabbrev
        (expand-file-name path))
       ('relative
-       (file-relative-name path)))))
+       (file-relative-name path))))
 
 (defun org-roam-link--split-path (path)
   "Splits PATH into title and headline.

--- a/org-roam.el
+++ b/org-roam.el
@@ -820,16 +820,10 @@ If `org-roam-link-title-format title' is defined, use it with TYPE."
 (defun org-roam--format-link (target &optional description type)
   "Formats an org link for a given file TARGET, link DESCRIPTION and link TYPE.
 TYPE defaults to \"file\"."
-  (let ((current-dir (ignore-errors
-                       (-> (or (buffer-base-buffer)
-                               (current-buffer))
-                           (buffer-file-name)
-                           (file-name-directory))))
-        (type (or type "file")))
-    (when (string-equal type "file")
-      (setq target (org-roam-link-get-path target current-dir)))
-    (org-roam-link-make-string (concat type ":" target)
-                               description)))
+  (setq type (or type "file"))
+  (when (string-equal type "file")
+    (setq target (org-roam-link-get-path target)))
+  (org-roam-link-make-string (concat type ":" target) description))
 
 (defun org-roam--prepend-tag-string (str tags)
   "Prepend TAGS to STR."

--- a/org-roam.el
+++ b/org-roam.el
@@ -536,27 +536,6 @@ The search terminates when the first property is encountered."
           (push (cons prop p) res)))
       res)))
 
-(defun org-roam--expand-links (content path)
-  "Crawl CONTENT for relative links and expand them.
-PATH should be the root from which to compute the relativity."
-  (let ((dir (file-name-directory path))
-        link link-type)
-    (with-temp-buffer
-      (insert content)
-      (goto-char (point-min))
-      ;; Loop over links
-      (while (re-search-forward org-roam--org-link-bracket-typed-re (point-max) t)
-        (setq link-type (match-string 1)
-              link (match-string 2))
-        (when (and (string-equal link-type "file")
-                   (f-relative-p link))
-          (save-excursion
-            (goto-char (match-beginning 2))
-            (delete-region (match-beginning 2)
-                           (match-end 2))
-            (insert (expand-file-name link dir)))))
-      (buffer-string))))
-
 (defun org-roam--get-outline-path ()
   "Return the outline path to the current entry.
 
@@ -624,10 +603,7 @@ it as FILE-PATH."
                                (or (org-element-property :content-end element)
                                    (org-element-property :end element)))))
                  (content (string-trim content))
-                 (content (org-roam--expand-links content file-path))
-                 (properties (list :outline (mapcar (lambda (path)
-                                                      (org-roam--expand-links path file-path))
-                                                    (org-roam--get-outline-path))
+                 (properties (list :outline (org-roam--get-outline-path)
                                    :content content
                                    :point begin))
                  (names (pcase type
@@ -844,16 +820,16 @@ If `org-roam-link-title-format title' is defined, use it with TYPE."
 (defun org-roam--format-link (target &optional description type)
   "Formats an org link for a given file TARGET, link DESCRIPTION and link TYPE.
 TYPE defaults to \"file\"."
-  (let* ((here (ignore-errors
-                 (-> (or (buffer-base-buffer)
-                         (current-buffer))
-                     (buffer-file-name)
-                     (file-name-directory)))))
-    (org-roam-link-make-string
-     (concat (or type "file") ":" (if here
-                                      (file-relative-name target here)
-                                    target))
-     description)))
+  (let ((current-dir (ignore-errors
+                       (-> (or (buffer-base-buffer)
+                               (current-buffer))
+                           (buffer-file-name)
+                           (file-name-directory))))
+        (type (or type "file")))
+    (when (string-equal type "file")
+      (setq target (org-roam-link-get-path target current-dir)))
+    (org-roam-link-make-string (concat type ":" target)
+                               description)))
 
 (defun org-roam--prepend-tag-string (str tags)
   "Prepend TAGS to STR."
@@ -1344,7 +1320,7 @@ replaced links are made relative to the current buffer."
           (when (and (f-relative-p path)
                      (org-in-regexp org-link-bracket-re 1))
             (let* ((file-path (expand-file-name path (file-name-directory old-path)))
-                   (new-path (file-relative-name file-path (file-name-directory (buffer-file-name)))))
+                   (new-path (org-roam-link-get-path file-path)))
               (replace-match (concat type ":" new-path)
                              nil t nil 1))))))))
 


### PR DESCRIPTION
Adds `org-roam-link-file-path-type`, used for link path computation
wherever sensible. This includes in the org-roam backlinks buffer, and
in link replacement.

Also moves link expansion/fixing from cache build to Org-roam buffer
render time. This reduces cache build time, but makes buffer rendering
slightly slower.