### PR TITLE
(feat): support file-level IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Org-roam also now does not resolve symlinks. This significantly speeds up cache 
 
 ### Features
 
+- [#1163](https://github.com/org-roam/org-roam/pull/1163) Support file-level IDs introduced in Org 9.4
 - [#1093](https://github.com/org-roam/org-roam/pull/1093) Add `vanilla` org-roam-tag-source to extract buffer Org tags
 - [#1079](https://github.com/org-roam/org-roam/pull/1079) Add `org-roam-tag-face` to customize appearance of tags in interactive commandsg
 - [#1073](https://github.com/org-roam/org-roam/pull/1073) Rename file on title change, when `org-roam-rename-file-on-title-change` is non-nil.

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -53,7 +53,7 @@
 (declare-function org-roam-backlinks-mode     "org-roam")
 (declare-function org-roam-mode               "org-roam")
 (declare-function org-roam--find-file         "org-roam")
-(declare-function org-roam--format-link       "org-roam")
+(declare-function org-roam-format-link        "org-roam")
 (declare-function org-roam-link-make-string   "org-roam-compat")
 (declare-function org-roam-link-get-path      "org-roam-link")
 
@@ -161,7 +161,7 @@ ORIG-PATH is the path where the CONTENT originated."
             (let ((file-from (car group))
                   (bls (cdr group)))
               (insert (format "** %s\n"
-                              (org-roam--format-link file-from
+                              (org-roam-format-link file-from
                                                      (org-roam--get-title-or-slug file-from)
                                                      "file")))
               (dolist (backlink bls)
@@ -189,7 +189,7 @@ ORIG-PATH is the path where the CONTENT originated."
                 (bls (mapcar (lambda (row)
                                  (nth 2 row)) (cdr group))))
             (insert (format "** %s\n"
-                            (org-roam--format-link file-from
+                            (org-roam-format-link file-from
                                                    (org-roam--get-title-or-slug file-from)
                                                    "file")))
             ;; Sort backlinks according to time of occurrence in buffer

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -45,7 +45,7 @@
 (declare-function  org-roam--get-ref-path-completions   "org-roam")
 (declare-function  org-roam--file-path-from-id          "org-roam")
 (declare-function  org-roam--find-file                  "org-roam")
-(declare-function  org-roam--format-link                "org-roam")
+(declare-function  org-roam-format-link                "org-roam")
 (declare-function  org-roam-mode                        "org-roam")
 (declare-function  org-roam-completion--completing-read "org-roam-completion")
 
@@ -337,9 +337,9 @@ the capture)."
                    (type (org-roam-capture--get :link-type))
                    (desc (org-roam-capture--get :link-description)))
                (if (eq (point) (marker-position mkr))
-                   (insert (org-roam--format-link path desc type))
+                   (insert (org-roam-format-link path desc type))
                  (org-with-point-at mkr
-                   (insert (org-roam--format-link path desc type))))))))))
+                   (insert (org-roam-format-link path desc type))))))))))
     (when region
       (set-marker beg nil)
       (set-marker end nil))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -490,11 +490,13 @@ If FORCE, force a rebuild of the cache from scratch."
          (tag-count 0)
          (title-count 0)
          (ref-count 0)
-         (deleted-count 0))
+         (deleted-count 0)
+         (processed-count 0))
     (emacsql-with-transaction (org-roam-db)
       ;; Two-step building
       ;; First step: Rebuild files and ids
       (dolist (file org-roam-files)
+        (org-roam-message "Processed %s/%s files..." processed-count (length org-roam-files))
         (let* ((attr (file-attributes file))
                (atime (file-attribute-access-time attr))
                (mtime (file-attribute-modification-time attr)))
@@ -537,7 +539,8 @@ If FORCE, force a rebuild of the cache from scratch."
                  (org-roam-db--clear-file file)
                  (lwarn '(org-roam) :warning
                         "Skipping unreadable file while building cache: %s" file))))
-            (remhash file current-files))))
+            (remhash file current-files)
+            (setq processed-count (+ processed-count 1)))))
       (dolist (file (hash-table-keys current-files))
         ;; These files are no longer around, remove from cache...
         (org-roam-db--clear-file file)

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -235,7 +235,8 @@ DESC is the link description."
     (save-match-data
       (unless (org-in-regexp org-link-bracket-re 1)
         (user-error "No link at point"))
-      (replace-match (org-roam-format-link loc desc link-type)))))
+      (replace-match "")
+      (insert (org-roam-format-link loc desc link-type)))))
 
 (defun org-roam-link-replace-all ()
   "Replace all roam links in the current buffer."

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -235,10 +235,7 @@ DESC is the link description."
     (save-match-data
       (unless (org-in-regexp org-link-bracket-re 1)
         (user-error "No link at point"))
-      (replace-match "")
-      (when (string-equal link-type "file")
-        (setq loc (org-roam-link-get-path loc)))
-      (insert (org-roam-link-make-string (concat link-type ":" loc) desc)))))
+      (replace-match (org-roam--format-link loc desc link-type)))))
 
 (defun org-roam-link-replace-all ()
   "Replace all roam links in the current buffer."

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -41,7 +41,7 @@
 (defvar org-roam-directory)
 (declare-function  org-roam--find-file                  "org-roam")
 (declare-function  org-roam-find-file                   "org-roam")
-
+(declare-function org-roam-format-link                  "org-roam")
 
 (defcustom org-roam-link-auto-replace t
   "When non-nil, replace Org-roam's roam links with file or id links whenever possible."
@@ -235,7 +235,7 @@ DESC is the link description."
     (save-match-data
       (unless (org-in-regexp org-link-bracket-re 1)
         (user-error "No link at point"))
-      (replace-match (org-roam--format-link loc desc link-type)))))
+      (replace-match (org-roam-format-link loc desc link-type)))))
 
 (defun org-roam-link-replace-all ()
   "Replace all roam links in the current buffer."

--- a/org-roam.el
+++ b/org-roam.el
@@ -809,7 +809,7 @@ If `org-roam-link-title-format title' is defined, use it with TYPE."
       (funcall org-roam-link-title-format title type)
     (format org-roam-link-title-format title)))
 
-(defun org-roam--format-link (target &optional description type)
+(defun org-roam-format-link (target &optional description type)
   "Formats an org link for a given file TARGET, link DESCRIPTION and link TYPE.
 TYPE defaults to \"file\".
 Here, we also check if there is an ID for the file."
@@ -1296,7 +1296,7 @@ update with NEW-DESC."
                    (new-label (if (string-equal label old-desc)
                                   new-desc
                                 label)))
-              (replace-match (org-roam--format-link new-path new-label type)))))))))
+              (replace-match (org-roam-format-link new-path new-label type)))))))))
 
 (defun org-roam--fix-relative-links (old-path)
   "Fix file-relative links in current buffer.
@@ -1626,7 +1626,7 @@ If DESCRIPTION is provided, use this as the link label.  See
                    (delete-region beg end)
                    (set-marker beg nil)
                    (set-marker end nil))
-                 (insert (org-roam--format-link target-file-path link-description link-type)))
+                 (insert (org-roam-format-link target-file-path link-description link-type)))
                 (t
                  (let ((org-roam-capture--info `((title . ,title-with-tags)
                                                  (slug . ,(funcall org-roam-title-to-slug-function title-with-tags))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -380,15 +380,6 @@ If FILE is not specified, use the current buffer's file-path."
                    (string-match-p org-roam-file-exclude-regexp path)))
          (f-descendant-of-p path (expand-file-name org-roam-directory))))))
 
-(defun org-roam--org-roam-headline-p (&optional id)
-  "Return t if ID is part of Org-roam system, nil otherwise.
-If ID is not specified, use the ID of the entry at point."
-  (if-let ((id (or id
-                   (org-id-get))))
-      (org-roam-db-query [:select [file] :from headlines
-                          :where (= id $s1)]
-                         id)))
-
 (defun org-roam--shell-command-files (cmd)
   "Run CMD in the shell and return a list of files. If no files are found, an empty list is returned."
   (--> cmd
@@ -625,20 +616,21 @@ it as FILE-PATH."
                 (push (vector file-path name type properties) links))))))
       links)))
 
-(defun org-roam--extract-headlines (&optional file-path)
-  "Extract all headlines with IDs within the current buffer.
+(defun org-roam--extract-ids (&optional file-path)
+  "Extract all IDs within the current buffer.
 If FILE-PATH is nil, use the current file."
-  (let ((file-path (or file-path
-                       (buffer-file-name))))
-    ;; Use `org-map-region' instead of `org-map-entries' as the latter
-    ;; would require another step to remove all nil values.
-    (let ((result nil))
+  (setq file-path (or file-path org-roam-file-name (buffer-file-name)))
+  (let (result)
+      ;; We need to handle the special case of the file property drawer (at outline level 0)
+      (org-with-point-at (point-min)
+        (when-let ((id (org-entry-get nil "ID")))
+           (push (vector id file-path (org-outline-level)) result)))
       (org-map-region
        (lambda ()
          (when-let ((id (org-entry-get nil "ID")))
-           (push (vector id file-path) result)))
+           (push (vector id file-path (org-outline-level)) result)))
        (point-min) (point-max))
-      result)))
+      result))
 
 (defun org-roam--extract-titles-title ()
   "Return title from \"#+title\" of the current buffer."
@@ -1035,14 +1027,14 @@ citation key, for Org-ref cite links."
   "Return the file if ID exists in the Org-roam database.
 Return nil otherwise."
   (caar (org-roam-db-query [:select [file]
-                            :from headlines
+                            :from ids
                             :where (= id $s1)
                             :limit 1]
                            id)))
 
 (defun org-roam-id-find (id &optional markerp strict keep-buffer-p)
   "Return the location of the entry with the id ID.
-When MARKERP is non-nil, return a marker pointing to theheadline.
+When MARKERP is non-nil, return a marker pointing to the headline.
 Otherwise, return a cons formatted as \(file . pos).
 When STRICT is non-nil, only consider Org-roam’s database.
 When KEEP-BUFFER-P is non-nil, keep the buffers navigated by Org-roam open."

--- a/tests/roam-files/headlines/headline.org
+++ b/tests/roam-files/headlines/headline.org
@@ -1,6 +1,3 @@
-:PROPERTIES:
-:ID:       73e767c2-a364-4748-a950-8d8f5dbd29c8
-:END:
 #+TITLE: Headline
 
 * Headline 1

--- a/tests/roam-files/headlines/headline.org
+++ b/tests/roam-files/headlines/headline.org
@@ -1,3 +1,6 @@
+:PROPERTIES:
+:ID:       73e767c2-a364-4748-a950-8d8f5dbd29c8
+:END:
 #+TITLE: Headline
 
 * Headline 1

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -256,8 +256,9 @@
       (expect (test #'org-roam--extract-ids
                     "headlines/headline.org")
               :to-have-same-items-as
-              `(["e84d0630-efad-4017-9059-5ef917908823" ,(test-org-roam--abs-path "headlines/headline.org")]
-                ["801b58eb-97e2-435f-a33e-ff59a2f0c213" ,(test-org-roam--abs-path "headlines/headline.org")])))))
+              `(["73e767c2-a364-4748-a950-8d8f5dbd29c8" ,(test-org-roam--abs-path "headlines/headline.org") 0]
+                ["e84d0630-efad-4017-9059-5ef917908823" ,(test-org-roam--abs-path "headlines/headline.org") 1]
+                ["801b58eb-97e2-435f-a33e-ff59a2f0c213" ,(test-org-roam--abs-path "headlines/headline.org") 1])))))
 
 (describe "Test roam links"
   (it ""

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -256,8 +256,7 @@
       (expect (test #'org-roam--extract-ids
                     "headlines/headline.org")
               :to-have-same-items-as
-              `(["73e767c2-a364-4748-a950-8d8f5dbd29c8" ,(test-org-roam--abs-path "headlines/headline.org") 0]
-                ["e84d0630-efad-4017-9059-5ef917908823" ,(test-org-roam--abs-path "headlines/headline.org") 1]
+              `(["e84d0630-efad-4017-9059-5ef917908823" ,(test-org-roam--abs-path "headlines/headline.org") 1]
                 ["801b58eb-97e2-435f-a33e-ff59a2f0c213" ,(test-org-roam--abs-path "headlines/headline.org") 1])))))
 
 (describe "Test roam links"

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -239,7 +239,7 @@
                 :to-equal
                 '("t1" "t2 with space" "t3" "tags"))))))
 
-(describe "Headline extraction"
+(describe "ID extraction"
   (before-all
     (test-org-roam--init))
 
@@ -252,8 +252,8 @@
                     (buf (find-file-noselect fname)))
                (with-current-buffer buf
                  (funcall fn fname)))))
-    (it "extracts headlines"
-      (expect (test #'org-roam--extract-headlines
+    (it "extracts ids"
+      (expect (test #'org-roam--extract-ids
                     "headlines/headline.org")
               :to-have-same-items-as
               `(["e84d0630-efad-4017-9059-5ef917908823" ,(test-org-roam--abs-path "headlines/headline.org")]


### PR DESCRIPTION
###### Motivation for this change

Additionally cache IDs at outline-level 0, now that property drawers are supported in Org 9.4.

Update `org-roam--format-link` to prefer ID links wherever possible. That is, when a file has an ID, use an id link instead of file link.

Addresses #1091