### PR TITLE
(internal): move org-roam.db default location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Org-roam also now does not resolve symlinks. This significantly speeds up cache 
 
 ### Breaking Changes
 
+- [#1164](https://github.com/org-roam/org-roam/pull/1164) Org-roam now stores the database in the user's Emacs directory by default
 - [#910](https://github.com/org-roam/org-roam/pull/910) Deprecate `company-org-roam`, using `completion-at-point` instead. To use this with company, add the `company-capf` backend instead.
 - [#1109](https://github.com/org-roam/org-roam/pull/1109) Org-roam now does not resolve symlinks.
 

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -41,8 +41,6 @@
   "org-roam 1.0.0")
 (define-obsolete-function-alias 'org-roam-sql         'org-roam-db-query
   "org-roam 1.0.0")
-(define-obsolete-function-alias 'org-roam--get-db     'org-roam-db--get
-  "org-roam 1.0.0")
 (define-obsolete-function-alias 'org-roam--db-clear   'org-roam-db--clear
   "org-roam 1.0.0")
 (define-obsolete-function-alias 'org-roam-show-graph  'org-roam-graph-show

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -49,7 +49,7 @@
 
 (defun test-org-roam--teardown ()
   (org-roam-mode -1)
-  (delete-file (org-roam-db--get))
+  (delete-file org-roam-db-location)
   (org-roam-db--close))
 
 (describe "org-roam--str-to-list"


### PR DESCRIPTION
Move the default location of `org-roam.db` to the user's Emacs
directory. This is a more sensible default: those who sync their
Org files would not have the database synced over as well.