### PR TITLE
(internal): remove compat functions

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -35,6 +35,7 @@
 (require 'dash)
 (require 's)
 (require 'f)
+(require 'ol)
 
 (defvar org-roam-directory)
 (defvar org-link-frame-setup)
@@ -54,7 +55,6 @@
 (declare-function org-roam-mode               "org-roam")
 (declare-function org-roam--find-file         "org-roam")
 (declare-function org-roam-format-link        "org-roam")
-(declare-function org-roam-link-make-string   "org-roam-compat")
 (declare-function org-roam-link-get-path      "org-roam-link")
 
 (defcustom org-roam-buffer-position 'right

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -80,16 +80,6 @@
 (define-obsolete-function-alias 'org-roam-db--clear 'org-roam-db-clear
   "org-roam 1.2.0")
 
-(defalias 'org-roam-link-store-props
-  (if (fboundp 'org-link-store-props)
-      'org-link-store-props
-    'org-store-link-props))
-
-(defalias 'org-roam-link-decode
-  (if (fboundp 'org-link-decode)
-      'org-link-decode
-    'org-link-escape))
-
 ;;;; Variables
 (define-obsolete-variable-alias 'org-roam-graphviz-extra-options
   'org-roam-graph-extra-config "org-roam 1.0.0")

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -80,11 +80,6 @@
 (define-obsolete-function-alias 'org-roam-db--clear 'org-roam-db-clear
   "org-roam 1.2.0")
 
-(defalias 'org-roam-link-make-string
-  (if (fboundp 'org-link-make-string)
-      'org-link-make-string
-    'org-make-link-string))
-
 (defalias 'org-roam-link-store-props
   (if (fboundp 'org-link-store-props)
       'org-link-store-props

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -37,6 +37,7 @@
 ;;; Code:
 (require 'org-protocol)
 (require 'org-roam)
+(require 'ol) ;; for org-link-decode
 
 ;;;; Functions
 (defun org-roam-protocol-open-ref (info)
@@ -52,7 +53,7 @@ It opens or creates a note with the given ref.
               (decoded-alist (mapcar (lambda (k.v)
                                        (let ((key (car k.v))
                                              (val (cdr k.v)))
-                                         (cons key (org-roam-link-decode val)))) alist)))
+                                         (cons key (org-link-decode val)))) alist)))
     (unless (assoc 'ref decoded-alist)
       (error "No ref key provided"))
     (when-let ((title (cdr (assoc 'title decoded-alist))))

--- a/org-roam.el
+++ b/org-roam.el
@@ -823,7 +823,7 @@ Here, we also check if there is an ID for the file."
     (setq type "id" target id))
   (when (string-equal type "file")
     (setq target (org-roam-link-get-path target)))
-  (org-roam-link-make-string (concat type ":" target) description))
+  (org-link-make-string (concat type ":" target) description))
 
 (defun org-roam--prepend-tag-string (str tags)
   "Prepend TAGS to STR."
@@ -1763,7 +1763,7 @@ linked, lest the network graph get too crowded."
                                            file-loc)))
                   (let ((rowcol (concat row ":" col)))
                     (insert "- "
-                            (org-roam-link-make-string (concat "file:" file "::" rowcol)
+                            (org-link-make-string (concat "file:" file "::" rowcol)
                                                        (format "[%s] %s" rowcol (org-roam--get-title-or-slug file))))
                     (when (executable-find "sed") ; insert line contents when sed is available
                       (insert " :: "


### PR DESCRIPTION
Now that CI throws a non-fatal error, this cleans up the code quite a bit, since we already require a minimum of Org 9.3 in the package header.