### PR TITLE
(fix): Fix org-roam--extract-ids at outline level 0

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -623,8 +623,9 @@ If FILE-PATH is nil, use the current file."
   (let (result)
       ;; We need to handle the special case of the file property drawer (at outline level 0)
       (org-with-point-at (point-min)
-        (when-let ((id (org-entry-get nil "ID")))
-           (push (vector id file-path (org-outline-level)) result)))
+        (when-let ((id (org-entry-get nil "ID"))
+                   (before-first-heading (= 0 (org-outline-level))))
+           (push (vector id file-path 0) result)))
       (org-map-region
        (lambda ()
          (when-let ((id (org-entry-get nil "ID")))

--- a/org-roam.el
+++ b/org-roam.el
@@ -623,8 +623,8 @@ If FILE-PATH is nil, use the current file."
   (let (result)
       ;; We need to handle the special case of the file property drawer (at outline level 0)
       (org-with-point-at (point-min)
-        (when-let ((id (org-entry-get nil "ID"))
-                   (before-first-heading (= 0 (org-outline-level))))
+        (when-let ((before-first-heading (= 0 (org-outline-level)))
+                   (id (org-entry-get nil "ID")))
            (push (vector id file-path 0) result)))
       (org-map-region
        (lambda ()


### PR DESCRIPTION
* org-roam.el (org-roam--extract-ids): Only check for ID if first
character in file is at outline level 0. #1172

###### Motivation for this change
#1172 