### PR TITLE
(fix): Make org-roam--extract-links less likely to throw error

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -588,12 +588,12 @@ it as FILE-PATH."
                  (element (org-element-at-point))
                  (begin (or (org-element-property :content-begin element)
                             (org-element-property :begin element)))
+                 (end (or (org-element-property :content-end element)
+                          (org-element-property :end element)))
                  (content (or (org-element-property :raw-value element)
-                              (buffer-substring-no-properties
-                               begin
-                               (or (org-element-property :content-end element)
-                                   (org-element-property :end element)))))
-                 (content (string-trim content))
+                              (when (and begin end)
+                                (buffer-substring-no-properties begin end))))
+                 (content (when content (string-trim content)))
                  (properties (list :outline (org-roam--get-outline-path)
                                    :content content
                                    :point begin))


### PR DESCRIPTION
* org-roam.el (org-roam--extract-links): Remove risk of
wrong-type-argument error in call to buffer-substring-no-properties.

###### Motivation for this change
I ran in to issues on my machine where `before` parameter was set to nil and `buffer-substring-no-properties` threw an error. The fixup in this pull request removes the risk of such errors when `element` doesn't have `:content-end` or `:end` properties (or where `element` by any reason is `nil` itself). While that in itself may warrant an investigation, this change cleans up the function a tad and adds a few guardrails to at least prevent this type of error in the future.