### PR TITLE
(fix): fix org-roam--extract-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.3 (TBD)
+
+## Bugfixes
+
+- [#1074](https://github.com/org-roam/org-roam/issues/1074) fix `org-roam--extract-links` to handle content boundaries
+
 ## 1.2.2 (06-10-2020)
 
 In this release we support fuzzy links of the form `[[roam:Title]]`, `[[roam:*Headline]]` and `[[roam:Title*Headline]]`. Completion for these fuzzy links is supported via `completion-at-point`.

--- a/org-roam.el
+++ b/org-roam.el
@@ -586,12 +586,12 @@ it as FILE-PATH."
           (let* ((type (org-roam--collate-types (org-element-property :type link)))
                  (path (org-element-property :path link))
                  (element (org-element-at-point))
-                 (begin (or (org-element-property :content-begin element)
+                 (begin (or (org-element-property :contents-begin element)
                             (org-element-property :begin element)))
                  (content (or (org-element-property :raw-value element)
                               (buffer-substring-no-properties
                                begin
-                               (or (org-element-property :content-end element)
+                               (or (org-element-property :contents-end element)
                                    (org-element-property :end element)))))
                  (content (string-trim content))
                  (properties (list :outline (org-roam--get-outline-path)

--- a/org-roam.el
+++ b/org-roam.el
@@ -588,12 +588,11 @@ it as FILE-PATH."
                  (element (org-element-at-point))
                  (begin (or (org-element-property :contents-begin element)
                             (org-element-property :begin element)))
+                 (end (or (org-element-property :content-end element)
+                          (org-element-property :end element)))
                  (content (or (org-element-property :raw-value element)
-                              (buffer-substring-no-properties
-                               begin
-                               (or (org-element-property :contents-end element)
-                                   (org-element-property :end element)))))
-                 (content (string-trim content))
+                              (when (and begin end)
+                                (string-trim (buffer-substring-no-properties begin end)))))
                  (properties (list :outline (org-roam--get-outline-path)
                                    :content content
                                    :point begin))


### PR DESCRIPTION
Fix `org-roam--extract-links` erroring at content boundaries. Cherry-picked commits from both @d12frosted and @Whil-'s PR.