### PR TITLE
(internal): simplify internal db cache update api

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -419,7 +419,7 @@ Returns the number of rows inserted."
       (org-roam-db-query [:delete :from ids
                           :where (= file $s1)]
                          file))
-    (when-let ((ids (org-roam--extract-ids file)))
+    (if-let ((ids (org-roam--extract-ids file)))
       (condition-case nil
           (progn
             (org-roam-db-query
@@ -433,7 +433,8 @@ Returns the number of rows inserted."
                         (aref (car ids) 1)
                         (string-join (mapcar (lambda (hl)
                                                (aref hl 0)) ids) "\n")))
-         0)))))
+         0))
+      0)))
 
 (defun org-roam-db--update-file (&optional file-path)
   "Update Org-roam cache for FILE-PATH.
@@ -496,7 +497,7 @@ If FORCE, force a rebuild of the cache from scratch."
                      (vector file contents-hash (list :atime atime :mtime mtime)))
                     (setq file-count (1+ file-count))
                     (when org-roam-enable-headline-linking
-                      (org-roam-db--insert-ids))
+                      (setq id-count (+ id-count (org-roam-db--insert-ids))))
                     (when-let (links (org-roam--extract-links file))
                       (org-roam-db-query
                        [:insert :into links

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -334,18 +334,21 @@ Returns the number of rows inserted."
 
 (defun org-roam-db--insert-tags (&optional update-p)
   "Insert tags for the current buffer into the Org-roam cache.
-If UPDATE-P is non-nil, first remove tags for the file in the database."
+If UPDATE-P is non-nil, first remove tags for the file in the database.
+Return the number of rows inserted."
   (let* ((file (or org-roam-file-name (buffer-file-name)))
          (tags (org-roam--extract-tags file)))
     (when update-p
       (org-roam-db-query [:delete :from tags
                           :where (= file $s1)]
                          file))
-    (when tags
-      (org-roam-db-query
-       [:insert :into tags
-        :values $v1]
-       (list (vector file tags))))))
+    (if tags
+        (progn (org-roam-db-query
+                [:insert :into tags
+                 :values $v1]
+                (list (vector file tags)))
+               1)
+      0)))
 
 ;;;;; Fetching
 (defun org-roam-db--get-current-files ()

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -292,9 +292,10 @@ If UPDATE-P is non-nil, first remove the ref for the file in the database."
 If UPDATE-P is non-nil, first remove the links for the file in the database.
 Return the number of rows inserted."
   (let ((file (or org-roam-file-name (buffer-file-name))))
-    (org-roam-db-query [:delete :from links
-                        :where (= from $s1)]
-                       file)
+    (when update-p
+      (org-roam-db-query [:delete :from links
+                          :where (= from $s1)]
+                         file))
     (if-let ((links (org-roam--extract-links)))
         (progn
           (org-roam-db-query

--- a/org-roam.el
+++ b/org-roam.el
@@ -1746,7 +1746,7 @@ Return added tag."
     (org-roam--set-global-prop
      "ROAM_TAGS"
      (combine-and-quote-strings (seq-uniq (cons tag existing-tags))))
-    (org-roam-db--update-tags)
+    (org-roam-db--insert-tags 'update)
     tag))
 
 (defun org-roam-tag-delete ()
@@ -1759,7 +1759,7 @@ Return added tag."
         (org-roam--set-global-prop
          "ROAM_TAGS"
          (combine-and-quote-strings (delete tag tags)))
-        (org-roam-db--update-tags))
+        (org-roam-db--insert-tags 'update))
     (user-error "No tag to delete")))
 
 ;;;###autoload


### PR DESCRIPTION
###### Motivation for this change

This is in preparation to fix an unreported bug, and should cause no logical changes.

When processing the file update queue, we need to clear the database for all the files first, or there may be false reports on duplicate items (e.g. renaming a file with IDs in them).