### PR TITLE
(fix): do not kill temp buffer when extracting links for file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Bugfixes
 
-- [#1074](https://github.com/org-roam/org-roam/issues/1074) fix `org-roam--extract-links` to handle content boundaries
+- [#1074](https://github.com/org-roam/org-roam/issues/1074) fix `org-roam--extract-links` to handle content boundaries.
+- [#1193](https://github.com/org-roam/org-roam/issues/1193) fix `org-roam-db-build-cache` by not killing temporary buffer in `org-roam--extract-links`.
 
 ## 1.2.2 (06-10-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -598,7 +598,7 @@ it as FILE-PATH."
                                    :point begin))
                  (names (pcase type
                           ("id"
-                           (list (car (org-roam-id-find path))))
+                           (list (car (org-roam-id-find path nil nil 'keep-buffer))))
                           ("cite" (list path))
                           ("website" (list path))
                           ("fuzzy" (list path))


### PR DESCRIPTION
###### Motivation for this change

Otherwise it breaks `org-roam-db-build-cache` as it relies on temporary buffer.
Without keeping the buffer, `org-roam--extract-links` kills it and any further
functionality of file processing breaks.

