### PR TITLE
(fix): fall back to org-id search ID face computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#1074](https://github.com/org-roam/org-roam/issues/1074) fix `org-roam--extract-links` to handle content boundaries.
 - [#1193](https://github.com/org-roam/org-roam/issues/1193) fix `org-roam-db-build-cache` by not killing temporary buffer in `org-roam--extract-links`.
+- [#1195](https://github.com/org-roam/org-roam/issues/1195) fix ID face showing as invalid if within Org ID files, but not Org-roam's.
 
 ## 1.2.2 (06-10-2020)
 

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -614,6 +614,25 @@ The Org-roam buffer displays backlinks for the currently active Org-roam note.
 Org-roam files are created and prefilled using Org-roam's templating
 system. The templating system is customizable (see [[*The Templating System][The Templating System]]).
 
+** Org-roam Faces
+
+Org-roam introduces several faces to distinguish links within the same buffer.
+These faces are enabled by default in Org-roam notes.
+
+- User Option: org-roam-link-use-custom-faces
+
+  When ~t~, use custom faces only inside Org-roam notes.
+  When ~everywhere~, the custom face is applied additionally to non Org-roam notes.
+  When ~nil~, do not use Org-roam's custom faces.
+
+The ~org-roam-link~ face is the face applied to links to other Org-roam files.
+This distinguishes internal links from external links (e.g. external web links).
+
+The ~org-roam-link-current~ face corresponds to links to the same file it is in.
+
+The ~org-roam-link-invalid~ face is applied to links that are broken. These are
+links to files or IDs that cannot be found.
+
 * Inserting Links
 
 The preferred mode of linking is via ~file~ links to files, and ~id~ links for
@@ -672,7 +691,6 @@ To easily insert ~roam~ links, one may wish to use a package like [[https://gith
   harder to edit. Defaults to ~t~.
 
 * Navigating Around
-
 ** Index File
 
 As your collection grows, you might want to create an index where you keep links

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -111,6 +111,7 @@ Concepts and Configuration
 * Directories and Files::
 * The Org-roam Buffer::
 * Org-roam Files::
+* Org-roam Faces::
 
 Navigating Around
 
@@ -783,6 +784,7 @@ All of Org-roam's customization options can be viewed via
 * Directories and Files::
 * The Org-roam Buffer::
 * Org-roam Files::
+* Org-roam Faces::
 @end menu
 
 @node Directories and Files
@@ -857,6 +859,29 @@ For example one can prevent the window from being deleted when calling
 
 Org-roam files are created and prefilled using Org-roam's templating
 system. The templating system is customizable (see @ref{The Templating System}).
+
+@node Org-roam Faces
+@section Org-roam Faces
+
+Org-roam introduces several faces to distinguish links within the same buffer.
+These faces are enabled by default in Org-roam notes.
+
+@itemize
+@item
+User Option: org-roam-link-use-custom-faces
+
+When @code{t}, use custom faces only inside Org-roam notes.
+When @code{everywhere}, the custom face is applied additionally to non Org-roam notes.
+When @code{nil}, do not use Org-roam's custom faces.
+@end itemize
+
+The @code{org-roam-link} face is the face applied to links to other Org-roam files.
+This distinguishes internal links from external links (e.g. external web links).
+
+The @code{org-roam-link-current} face corresponds to links to the same file it is in.
+
+The @code{org-roam-link-invalid} face is applied to links that are broken. These are
+links to files or IDs that cannot be found.
 
 @node Inserting Links
 @chapter Inserting Links

--- a/org-roam.el
+++ b/org-roam.el
@@ -1190,7 +1190,7 @@ This is active when `org-roam-completion-everywhere' is non-nil."
 ;;;; Function Faces
 ;; These faces are used by `org-link-set-parameters', which take one argument,
 ;; which is the path.
-(defcustom org-roam-link-use-custom-faces 'everywhere
+(defcustom org-roam-link-use-custom-faces t
   "Define where to apply custom faces to Org-roam links.
 
 Valide values are:
@@ -1202,9 +1202,9 @@ everywhere   Apply custom faces everywhere.
 
 Otherwise, do not apply custom faces to Org-roam links."
   :type '(choice
-	  (const :tag "Use custom faces inside Org-roam notes" t)
-	  (const :tag "Apply custom faces everywhere" everywhere)
-	  (const :tag "Do not apply custom faces" nil))
+          (const :tag "Use custom faces inside Org-roam notes" t)
+          (const :tag "Apply custom faces everywhere" everywhere)
+          (const :tag "Do not apply custom faces" nil))
   :group 'org-roam)
 
 (defun org-roam--file-link-face (path)
@@ -1244,7 +1244,8 @@ file."
                        (eq org-roam-link-use-custom-faces 'everywhere))))
       (cond ((and custom
                   (not (org-roam-id-get-file id))
-                  (not (org-id-find id)))
+                  (not (and (eq org-roam-link-use-custom-faces 'everywhere)
+                            (org-id-find id))))
              'org-roam-link-invalid)
             ((and (org-roam--in-buffer-p)
                   (org-roam--backlink-to-current-p))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1243,7 +1243,8 @@ file."
            (custom (or (and in-note org-roam-link-use-custom-faces)
                        (eq org-roam-link-use-custom-faces 'everywhere))))
       (cond ((and custom
-                  (not (org-roam-id-get-file id)))
+                  (not (org-roam-id-get-file id))
+                  (not (org-id-find id)))
              'org-roam-link-invalid)
             ((and (org-roam--in-buffer-p)
                   (org-roam--backlink-to-current-p))


### PR DESCRIPTION
Fixes the scenario where the face is reported as invalid although it is part of Org's ID files (e.g. in the agenda).

Fixes #1191.

This can however slow face computation a lot (when there are many org id/agenda files). Here, we choose to focus on correctness. To mitigate this issue, we change the default scope of application of the face to Org-roam notes only.
