### PR TITLE
(fix):  org-roam--extract-links leaves files open

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -598,7 +598,7 @@ it as FILE-PATH."
                                    :point begin))
                  (names (pcase type
                           ("id"
-                           (list (car (org-roam-id-find path nil nil 'keep-buffer))))
+                           (list (car (org-roam-id-find path nil nil))))
                           ("cite" (list path))
                           ("website" (list path))
                           ("fuzzy" (list path))


### PR DESCRIPTION
fixes #1203.

###### Motivation for this change