### PR TITLE
(internal): rename link columns

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -169,15 +169,15 @@ into a digraph."
     (let* ((nodes (org-roam-db-query node-query))
            (edges-query
             `[:with selected :as [:select [file] :from ,node-query]
-              :select :distinct [to from] :from links
-              :where (and (in to selected) (in from selected))])
+              :select :distinct [dest source] :from links
+              :where (and (in dest selected) (in source selected))])
            (edges-cites-query
             `[:with selected :as [:select [file] :from ,node-query]
-              :select :distinct [file from]
-              :from links :inner :join refs :on (and (= links:to refs:ref)
+              :select :distinct [file source]
+              :from links :inner :join refs :on (and (= links:dest refs:ref)
                                                      (= links:type "cite")
                                                      (= refs:type "cite"))
-              :where (and (in file selected) (in from selected))])
+              :where (and (in file selected) (in source selected))])
            (edges       (org-roam-db-query edges-query))
            (edges-cites (org-roam-db-query edges-cites-query)))
       (insert "digraph \"org-roam\" {\n")

--- a/org-roam.el
+++ b/org-roam.el
@@ -565,7 +565,7 @@ Assume buffer is widened and point is on a headline."
   "Extracts all link items within the current buffer.
 Link items are of the form:
 
-    [from to type properties]
+    [source dest type properties]
 
 This is the format that emacsql expects when inserting into the database.
 FILE-FROM is typically the buffer file path, but this may not exist, for example
@@ -1040,11 +1040,11 @@ citation key, for Org-ref cite links."
   (unless (listp targets)
     (setq targets (list targets)))
   (let ((conditions (--> targets
-                         (mapcar (lambda (i) (list '= 'to i)) it)
+                         (mapcar (lambda (i) (list '= 'dest i)) it)
                          (org-roam--list-interleave it :or))))
-    (org-roam-db-query `[:select [from to properties] :from links
+    (org-roam-db-query `[:select [source dest properties] :from links
                          :where ,@conditions
-                         :order-by (asc from)])))
+                         :order-by (asc source)])))
 
 (defun org-roam-id-get-file (id)
   "Return the file if ID exists in the Org-roam database.
@@ -1374,9 +1374,9 @@ if applicable.
 
 To be added to `org-roam-title-change-hook'."
   (let* ((current-path (buffer-file-name))
-         (files-affected (org-roam-db-query [:select :distinct [from]
+         (files-affected (org-roam-db-query [:select :distinct [source]
                                              :from links
-                                             :where (= to $s1)]
+                                             :where (= dest $s1)]
                                             current-path)))
     (dolist (file files-affected)
       (with-current-buffer (or (find-buffer-visiting (car file))
@@ -1421,9 +1421,9 @@ When NEW-FILE-OR-DIR is a directory, we use it to compute the new file path."
              (new-path (expand-file-name new-file))
              (new-buffer (or (find-buffer-visiting new-path)
                              (find-file-noselect new-path)))
-             (files-affected (org-roam-db-query [:select :distinct [from]
+             (files-affected (org-roam-db-query [:select :distinct [source]
                                                  :from links
-                                                 :where (= to $s1)]
+                                                 :where (= dest $s1)]
                                                 old-path)))
         ;; Remove database entries for old-file.org
         (org-roam-db--clear-file old-file)

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -300,21 +300,21 @@
 
     ;; Links
     (expect (caar (org-roam-db-query [:select (funcall count) :from links
-                                      :where (= from $s1)]
+                                      :where (= source $s1)]
                                      (test-org-roam--abs-path "foo.org"))) :to-be 1)
     (expect (caar (org-roam-db-query [:select (funcall count) :from links
-                                      :where (= from $s1)]
+                                      :where (= source $s1)]
                                      (test-org-roam--abs-path "nested/bar.org"))) :to-be 2)
 
     ;; Links -- File-to
     (expect (caar (org-roam-db-query [:select (funcall count) :from links
-                                      :where (= to $s1)]
+                                      :where (= dest $s1)]
                                      (test-org-roam--abs-path "nested/foo.org"))) :to-be 1)
     (expect (caar (org-roam-db-query [:select (funcall count) :from links
-                                      :where (= to $s1)]
+                                      :where (= dest $s1)]
                                      (test-org-roam--abs-path "nested/bar.org"))) :to-be 1)
     (expect (caar (org-roam-db-query [:select (funcall count) :from links
-                                      :where (= to $s1)]
+                                      :where (= dest $s1)]
                                      (test-org-roam--abs-path "unlinked.org"))) :to-be 0)
     ;; TODO Test titles
     (expect (org-roam-db-query [:select * :from titles])


### PR DESCRIPTION
from -> source
to -> dest

"from" is a reserved keyword in sqlite, so we avoid it.

Closes #1207 
