### PR TITLE
(fix): save current position in mark ring before id-open

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1083,6 +1083,7 @@ When STRICT is non-nil, only consider Org-roam’s database."
   (when-let ((marker (if (markerp id-or-marker)
                          id-or-marker
                        (org-roam-id-find id-or-marker t strict t))))
+    (org-mark-ring-push)
     (org-goto-marker-or-bmk marker)
     (set-marker marker nil)))
 


### PR DESCRIPTION
###### Motivation for this change
`org-roam-id-open` overrides the behavior of `org-id-open`, but it doesn't replicate the behavior of calling `org-mark-ring-push`: https://code.orgmode.org/bzg/org-mode/src/master/lisp/org-id.el#L713, so when using org-roam, it's not possible to go back with `C-c &` after opening ID links.