### PR TITLE
(internal): make sure there are no byte-comp warnings about undefined functions or unused lexical variables

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -35,13 +35,18 @@
 (require 'emacsql)
 (require 'emacsql-sqlite3)
 (require 'seq)
-(require 'org-macs)
-(require 'org-roam-macs)
+
+(eval-and-compile
+  (require 'org-roam-macs)
+  ;; For `org-with-wide-buffer'
+  (require 'org-macs))
 
 (defvar org-roam-directory)
 (defvar org-roam-enable-headline-linking)
 (defvar org-roam-verbose)
 (defvar org-roam-file-name)
+
+(defvar org-agenda-files)
 
 (declare-function org-roam--org-roam-file-p                "org-roam")
 (declare-function org-roam--extract-titles                 "org-roam")

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -32,7 +32,8 @@
 ;;; Code:
 (require 'xml) ;xml-escape-string
 (require 's)   ;s-truncate, s-replace
-(require 'org-roam-macs)
+(eval-and-compile
+  (require 'org-roam-macs))
 (require 'org-roam-db)
 
 ;;;; Declarations

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -36,6 +36,10 @@
 
 (require 'ol)
 (require 'org-roam-compat)
+(require 'org-roam-macs)
+(require 'org-roam-db)
+
+(require 'org-element)
 
 (defvar org-roam-completion-ignore-case)
 (defvar org-roam-directory)

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -34,8 +34,14 @@
 ;;; Code:
 ;;;; Library Requires
 (require 'dash)
+(require 's)
 
 (defvar org-roam-verbose)
+
+;; This is necessary to ensure all dependents on this module see
+;; `org-mode-hook' and `org-inhibit-startup' as dynamic variables,
+;; regardless of whether Org is loaded before their compilation.
+(require 'org)
 
 ;;;; Utility Functions
 (defun org-roam--list-interleave (lst separator)


### PR DESCRIPTION
###### Motivation for this change

For undefined functions: for example, s.el and org-element should be `require`'d when their functions are used.

Unused lexical variables: if Org isn't loaded yet, dynamic variables defined in org.el would be treated as lexical and byte-comp would emit this warning. This is especially important in the future as native-comp / gccemacs will optimize away unused lexical variables, and we cannot rely on Org having been implicitly loaded before our modules are compiled.

(This is also the second culprit behind why the infinite loop happened in #1078: besides org-roam-mode being started in org-mode-hook, the code setting org-mode-hook to nil is optimized away.)

Explicitly stating in our modules that the variables are dynamic prevents that.
