### PR TITLE
(fix): widen before title extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#1199](https://github.com/org-roam/org-roam/issues/1199) make Org-roam link insertions respect `org-roam-link-title-format` everywhere.
 - [#1201](https://github.com/org-roam/org-roam/issues/1201) fix `org-roam-db-build-cache` failing in scenarios involving duplicate IDs and deleted files.
 - [#1226](https://github.com/org-roam/org-roam/issues/1226) only update relative path of file links
+- [#1232](https://github.com/org-roam/org-roam/issues/1232) fix incorrect title extractions from narrowed buffers
 
 ## 1.2.2 (06-10-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -669,18 +669,19 @@ Reads from the \"roam_alias\" property."
 (defun org-roam--extract-titles (&optional sources nested)
   "Extract the titles from current buffer using SOURCES.
 If NESTED, return the first successful result from SOURCES."
-  (let (coll res)
-    (cl-dolist (source (or sources
-                           org-roam-title-sources))
-      (setq res (if (symbolp source)
-                    (funcall (intern (concat "org-roam--extract-titles-" (symbol-name source))))
-                  (org-roam--extract-titles source t)))
-      (when res
-        (if (not nested)
-            (setq coll (nconc coll res))
-          (setq coll res)
-          (cl-return))))
-    coll))
+  (org-with-wide-buffer
+   (let (coll res)
+     (cl-dolist (source (or sources
+                            org-roam-title-sources))
+       (setq res (if (symbolp source)
+                     (funcall (intern (concat "org-roam--extract-titles-" (symbol-name source))))
+                   (org-roam--extract-titles source t)))
+       (when res
+         (if (not nested)
+             (setq coll (nconc coll res))
+           (setq coll res)
+           (cl-return))))
+     coll)))
 
 (defun org-roam--extract-tags-all-directories (file)
   "Extract tags from using the directory path FILE.


### PR DESCRIPTION
###### Motivation for this change

Prevent renaming file and changing links incorrectly due to using `(org-narrow-to-subtree)` and saving.

The extract title functions will only use the narrowed contents when the buffer being read is narrowed.  These functions might ignore the `#+title` line, and use the first found subtree as the title instead.  Now all the links to the file and the filename has been changed, and won't be changed back unless narrowing is removed and another change is made and the file is saved again.  However if the file is reloaded and the title changed, it won't be since all the links no longer match the title, leaving the affected files with links that no longer match the title.