### PR TITLE
(fix): fix relative link replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#1201](https://github.com/org-roam/org-roam/issues/1201) fix `org-roam-db-build-cache` failing in scenarios involving duplicate IDs and deleted files.
 - [#1226](https://github.com/org-roam/org-roam/issues/1226) only update relative path of file links
 - [#1232](https://github.com/org-roam/org-roam/issues/1232) fix incorrect title extractions from narrowed buffers
+- [#1233](https://github.com/org-roam/org-roam/issues/1233) fixes bug where descriptive file links become plain links during update for relative paths
 
 ## 1.2.2 (06-10-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1315,30 +1315,21 @@ update with NEW-DESC."
                               old-path new-path old-desc new-desc))))
         (replace-match new-link)))))
 
-(defun org-roam--get-relative-link-replacement (old-path)
-  "Create file-relative link for link at point if needed.
-File relative links are assumed to originate from OLD-PATH. The
-replaced links are made relative to the current buffer."
-  (when-let ((link (org-element-lineage (org-element-context) '(link) t)))
-    (let ((type (org-element-property :type link))
-          (path (org-element-property :path link)))
-      (when (and (string= type "file")
-                 (f-relative-p path)
-                 (org-in-regexp org-link-bracket-re 1))
-        (let* ((file-path (expand-file-name path (file-name-directory old-path)))
-               (new-path (org-roam-link-get-path file-path)))
-          (concat type ":" new-path))))))
-
 (defun org-roam--fix-relative-links (old-path)
   "Fix file-relative links in current buffer.
 File relative links are assumed to originate from OLD-PATH. The
 replaced links are made relative to the current buffer."
-  (save-excursion
-    (goto-char (point-min))
-    (while (re-search-forward org-link-any-re nil t)
-      (when-let ((new-link (save-match-data
-                             (org-roam--get-relative-link-replacement old-path))))
-        (replace-match new-link nil t nil 1)))))
+  (org-with-point-at 1
+    (let (link new-link type path)
+      (while (re-search-forward org-link-bracket-re nil t)
+        (when (setq link (save-match-data (org-element-lineage (org-element-context) '(link) t)))
+          (setq type (org-element-property :type link))
+          (setq path (org-element-property :path link))
+          (when (and (string= type "file")
+                     (f-relative-p path))
+            (setq new-link
+                  (concat type ":" (org-roam-link-get-path (expand-file-name path (file-name-directory old-path)))))
+            (replace-match new-link nil t nil 1)))))))
 
 (defcustom org-roam-rename-file-on-title-change t
   "If non-nil, alter the filename on title change.


### PR DESCRIPTION
Fixes #1227. Targets bracket links only.