### PR TITLE
Add the use of :preselect in ivy-read

### DIFF
--- a/org-roam-completion.el
+++ b/org-roam-completion.el
@@ -79,6 +79,7 @@ Return user choice."
             (if (fboundp 'ivy-read)
                 (ivy-read prompt choices
                           :initial-input initial-input
+                          :preselect initial-input
                           :require-match require-match
                           :action (prog1 action
                                     (setq action nil))


### PR DESCRIPTION
This way, in case of the initial-input being an exact match, ivy will suggest this one first.

For example, say I have the two org-roam files with titles "vault" and "I like
vault" and I am writing a third file with the sentence "Let's discuss about
vault". If I want to transform the word vault into the link to the appropriate
org-roam file, I tend to highlight the word and press C-c n i. ivy would propose
the two files "vault" and "I like vault", with "I like vault" pre-selected. With
the `:preselect` clause, "vault" is pre-selected and I only have to press Enter to
create the link. IMHO, this default behavior quite sensible.

###### Motivation for this change
