### PR TITLE
(feat): add org-roam-prefer-id-links to select linking method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#1183](https://github.com/org-roam/org-roam/pull/1183) add interactive functions for managing aliases and tags in Org-roam file, namely `org-roam-alias-add`, `org-roam-alias-delete`, `org-roam-tag-add`, and `org-roam-tag-delete`.
+- [#1238](https://github.com/org-roam/org-roam/pull/1238) add `org-roam-prefer-id-links` variable to select linking method
 
 ### Bugfixes
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -149,7 +149,7 @@ Formatter may be a function that takes title as its only argument."
 
 (defcustom org-roam-prefer-id-links t
   "If non-nil, when inserting links with Org-roam and an ID is
-  available, Org-roam will use the ID for linking instead."
+available, Org-roam will use the ID for linking instead."
   :type 'boolean
   :group 'org-roam)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -148,8 +148,7 @@ Formatter may be a function that takes title as its only argument."
   :group 'org-roam)
 
 (defcustom org-roam-prefer-id-links t
-  "If non-nil, when inserting links with Org-roam and an ID is
-available, Org-roam will use the ID for linking instead."
+  "If non-nil, use ID for linking instead where available."
   :type 'boolean
   :group 'org-roam)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -147,6 +147,12 @@ Formatter may be a function that takes title as its only argument."
           (function :tag "Custom function"))
   :group 'org-roam)
 
+(defcustom org-roam-prefer-id-links t
+  "If non-nil, when inserting links with Org-roam and an ID is
+  available, Org-roam will use the ID for linking instead."
+  :type 'boolean
+  :group 'org-roam)
+
 (defcustom org-roam-list-files-commands
   (if (member system-type '(windows-nt ms-dos cygwin))
       nil
@@ -806,7 +812,8 @@ backlinks."
 TYPE defaults to \"file\".
 Here, we also check if there is an ID for the file."
   (setq type (or type "file"))
-  (when-let ((id (and (string-equal type "file")
+  (when-let ((id (and org-roam-prefer-id-links
+                      (string-equal type "file")
                       (caar (org-roam-db-query [:select [id] :from ids
                                                 :where (= file $s1)
                                                 :and (= level 0)


### PR DESCRIPTION
Adds a boolean variable `org-roam-prefer-id-links`. When non-nil, it
will create ID links where possible.

Addresses #1235