### PR TITLE
Allow org-roam-protocol to capture the webpage's selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1183](https://github.com/org-roam/org-roam/pull/1183) add interactive functions for managing aliases and tags in Org-roam file, namely `org-roam-alias-add`, `org-roam-alias-delete`, `org-roam-tag-add`, and `org-roam-tag-delete`.
 - [#1215](https://github.com/org-roam/org-roam/pull/1215) Multiple `ROAM_KEY` keywords can now be specified in one file. This allows bibliographical entries to share the same note file.
 - [#1238](https://github.com/org-roam/org-roam/pull/1238) add `org-roam-prefer-id-links` variable to select linking method
+- [#1239](https://github.com/org-roam/org-roam/pull/1239) Allow `org-roam-protocol` to capture the webpage's selection, and add a toggle for storing the links to the pages
 
 ### Bugfixes
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -512,7 +512,8 @@ GOTO and KEYS argument have the same functionality as
 `org-capture'."
   (let* ((org-capture-templates (mapcar #'org-roam-capture--convert-template org-roam-capture-templates))
          (one-template-p (= (length org-capture-templates) 1))
-         org-capture-templates-contexts)
+         org-capture-templates-contexts
+         (org-capture-link-is-already-stored t))
     (when one-template-p
       (setq keys (caar org-capture-templates)))
     (if (or one-template-p

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -39,6 +39,11 @@
 (require 'org-roam)
 (require 'ol) ;; for org-link-decode
 
+(defcustom org-roam-protocol-store-links nil
+  "Whether to store links when capturing websites with `org-roam-protocol'."
+  :type 'boolean
+  :group 'org-roam)
+
 ;;;; Functions
 (defun org-roam-protocol-open-ref (info)
   "Process an org-protocol://roam-ref?ref= style url with INFO.
@@ -79,6 +84,9 @@ It opens or creates a note with the given ref.
            (orglink
             (if (null ref) title
               (org-link-make-string ref (or (org-string-nw-p title) ref)))))
+      (when (and org-roam-protocol-store-links
+                 ref)
+        (push (list ref title) org-stored-links))
       (org-link-store-props :type type
                             :link ref
                             :description title

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -70,10 +70,8 @@ It opens or creates a note with the given ref.
              (title (or \.title ""))
              (body (or \.body ""))
              (orglink
-              (if (null ref) title
-                (org-link-make-string ref (or (org-string-nw-p title) ref)))))
-        (when (and org-roam-protocol-store-links
-                   ref)
+              (org-link-make-string ref (or (org-string-nw-p title) ref))))
+        (when org-roam-protocol-store-links
           (push (list ref title) org-stored-links))
         (org-link-store-props :type type
                               :link ref

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -51,7 +51,7 @@
 It opens or creates a note with the given ref.
 
   javascript:location.href = \\='org-protocol://roam-ref?template=r&ref=\\='+ \\
-        encodeURIComponent(location.href) + \\='&title=\\=' \\
+        encodeURIComponent(location.href) + \\='&title=\\=' + \\
         encodeURIComponent(document.title) + \\='&body=\\=' + \\
         encodeURIComponent(window.getSelection())"
   (when-let* ((alist (org-roam--plist-to-alist info))

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -63,36 +63,22 @@ It opens or creates a note with the given ref.
       (error "No ref key provided"))
     (when-let ((title (cdr (assoc 'title decoded-alist))))
       (push (cons 'slug (funcall org-roam-title-to-slug-function title)) decoded-alist))
-    (let* ((parts
-            (pcase (org-protocol-parse-parameters info)
-              ;; New style links are parsed as a plist.
-              ((let `(,(pred keywordp) . ,_) info) info)
-              ;; Old style links, with or without template key, are
-              ;; parsed as a list of strings.
-              (p
-               (let ((k (if (= 1 (length (car p)))
-                            '(:template :url :title :body)
-                          '(:url :title :body))))
-                 (org-protocol-assign-parameters p k)))))
-           (ref (and (plist-get parts :ref)
-                     (org-protocol-sanitize-uri (plist-get parts :ref))))
-           (type (and ref
-                      (string-match "^\\([a-z]+\\):" ref)
-                      (match-string 1 ref)))
-           (title (or (plist-get parts :title) ""))
-           (region (or (plist-get parts :body) ""))
-           (orglink
-            (if (null ref) title
-              (org-link-make-string ref (or (org-string-nw-p title) ref)))))
-      (when (and org-roam-protocol-store-links
-                 ref)
-        (push (list ref title) org-stored-links))
-      (org-link-store-props :type type
-                            :link ref
-                            :description title
-                            :annotation orglink
-                            :initial region
-                            :query parts))
+    (let-alist decoded-alist
+      (let* ((ref (org-protocol-sanitize-uri \.ref))
+             (type (and (string-match "^\\([a-z]+\\):" ref)
+                        (match-string 1 ref)))
+             (title (or \.title ""))
+             (body (or \.body ""))
+             (orglink
+              (if (null ref) title
+                (org-link-make-string ref (or (org-string-nw-p title) ref)))))
+        (when (and org-roam-protocol-store-links
+                   ref)
+          (push (list ref title) org-stored-links))
+        (org-link-store-props :type type
+                              :link ref
+                              :annotation orglink
+                              :initial body)))
     (let* ((org-roam-capture-templates org-roam-capture-ref-templates)
            (org-roam-capture--context 'ref)
            (org-roam-capture--info decoded-alist)

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -64,11 +64,11 @@ It opens or creates a note with the given ref.
     (when-let ((title (cdr (assoc 'title decoded-alist))))
       (push (cons 'slug (funcall org-roam-title-to-slug-function title)) decoded-alist))
     (let-alist decoded-alist
-      (let* ((ref (org-protocol-sanitize-uri \.ref))
+      (let* ((ref (org-protocol-sanitize-uri .ref))
              (type (and (string-match "^\\([a-z]+\\):" ref)
                         (match-string 1 ref)))
-             (title (or \.title ""))
-             (body (or \.body ""))
+             (title (or .title ""))
+             (body (or .body ""))
              (orglink
               (org-link-make-string ref (or (org-string-nw-p title) ref))))
         (when org-roam-protocol-store-links


### PR DESCRIPTION
I believe we supported this feature a while ago, but an iteration must have overridden it.

You can now use `%i` in `org-roam-capture-ref-templates` to insert the selected text on the web-page you are capturing.  Note that it can either appear in `:head` (expanded once on file creation) or in the body of the template (expanded every time the ORP is called on a given webpage).  The latter makes it a good option for incremental reading.

Here's a use-case:
```el
(defun zp/org-protocol-insert-selection-dwim (selection)
  "Insert SELECTION as an org blockquote."
  (unless (string= selection "")
    (format "#+begin_quote\n%s\n#+end_quote" selection)))

(setq org-roam-capture-ref-templates
      '(("r" "ref" plain
         (function org-roam-capture--get-point)
         ""
         :file-name "web/${slug}"
         :head "#+title: ${title}
#+roam_key: ${ref}
#+created: %u
#+last_modified: %U

%(zp/org-protocol-insert-selection-dwim \"%i\")"
         :unnarrowed t)

        ("i" "incremental" plain
         (function org-roam-capture--get-point)
         "* %?\n%(zp/org-protocol-insert-selection-dwim \"%i\")"
         :file-name "web/${slug}"
         :head "#+title: ${title}
#+roam_key: ${ref}
#+created: %u
#+last_modified: %U\n\n"
         :unnarrowed t
         :empty-lines-before 1)))
```

You need to make sure that you have the proper bookmarklet (note the `template=r` to specify which template to use`):
```js
javascript:location.href = 'org-protocol://roam-ref?template=r&ref='%20+%20encodeURIComponent(location.href)%20+%20'&title='%20+%20encodeURIComponent(document.title)%20+%20'&body='%20+%20encodeURIComponent(window.getSelection())
```