### PR TITLE
POC: buffer revamp

### DIFF
--- a/org-roam-widget.el
+++ b/org-roam-widget.el
@@ -42,7 +42,9 @@ Items are of the form: ((key (list of values for key)))")
     (magit-insert-heading (oref widget header))
     (let ((items (funcall (oref widget items))))
       (if items
-          (funcall (oref widget render) items)
+          (progn
+            (funcall (oref widget render) items)
+            (insert "\n"))
         (magit-cancel-section)))))
 
 ;;; Widgets
@@ -139,6 +141,5 @@ Items are of the form: ((key (list of values for key)))")
          (magit-insert-section (demo-buffer)
            (dolist (widget org-roam-widgets)
              (when (org-roam-widget-show widget)
-               (org-roam-widget-render widget)))
-           (insert "\n"))))
+               (org-roam-widget-render widget))))))
      (switch-to-buffer-other-window buffer)))

--- a/org-roam-widget.el
+++ b/org-roam-widget.el
@@ -1,0 +1,103 @@
+;; For the lack of a better name, we're now calling this file org-roam-widget,
+;; but it is meant to replace org-roam-buffer at some point
+
+(require 'eieio)
+(require 'magit-section)
+
+(cl-deftype function ()
+  '(satisfies fboundp))
+
+(defclass org-roam-widget ()
+  ((name :initarg :name
+         :type symbol
+         :custom symbol
+         :documentation "The symbol for the widget.")
+   (header :initarg :header
+           :initform ""
+           :type string
+           :custom string
+           :documentation "The header used for this widget")
+   (items :initarg :items
+          :type function
+          :custom function
+          :documentation "The function to call to obtain the items.
+Items are of the form: ((key (list of values for key)))")
+   (render :initarg :render
+           :type function
+           :custom function
+           :documentation "The function used to render the items.")
+   (show-p :initarg :show-p
+           :type function
+           :custom function
+           :documentation "The predicate function to use to see if the widget should be used.")))
+
+(cl-defmethod org-roam-widget-show ((widget org-roam-widget))
+  "Return t if WIDGET is to be shown, nil otherwise."
+  (funcall (oref widget show-p)))
+
+(cl-defmethod org-roam-widget-render ((widget org-roam-widget))
+  "Render items in WIDGET."
+  (magit-insert-section widget-root
+    (magit-insert-heading (oref widget header))
+    (let ((items (funcall (oref widget items))))
+      (if items
+          (funcall (oref widget render) items)
+        (magit-cancel-section)))))
+
+(defun org-roam-widget-get-backlinks ()
+  (let* ((file-path (buffer-file-name org-roam-buffer--current))
+         (titles (with-current-buffer org-roam-buffer--current
+                   (org-roam--extract-titles)))
+         (backlinks (org-roam--get-backlinks (push file-path titles))))
+    (--group-by (nth 0 it) backlinks)))
+
+(defun org-roam-widget-show-backlinks-p ()
+  t)
+
+(defun org-roam-widget-render-backlinks (items)
+  (let (key values prop)
+    (dolist (item items)
+      (setq key (car item))
+      (setq values (cdr item))
+      (magit-insert-section (backlinks-file)
+        (magit-insert-heading (concat
+                               (org-fontify-like-in-org-mode
+                                (org-roam-format-link key (org-roam--get-title-or-slug key)))
+                               ":"))
+        (dolist (value values)
+          (setq prop (nth 2 value))
+          (let ((outline (or (plist-get prop :outline) '("Top")))
+                (content (or (plist-get prop :content) "")))
+            (magit-insert-section (backlink-outline)
+              (magit-insert-heading (-> outline
+                                        (string-join " > ")
+                                        (org-roam-buffer-expand-links key)))
+              (magit-insert-section (backlink-preview)
+                (insert (org-fontify-like-in-org-mode content) "\n")))))))))
+
+(defconst org-roam-widgets
+  (list
+   (org-roam-widget :name 'backlinks
+                    :header "Backlinks:"
+                    :items #'org-roam-widget-get-backlinks
+                    :render #'org-roam-widget-render-backlinks
+                    :show-p #'org-roam-widget-show-backlinks-p)))
+
+(defmacro with-org-roam-buffer (&rest body)
+  (declare (indent 0))
+  `(let ((buffer (get-buffer-create "*org-roam*")))
+     (with-current-buffer buffer
+       (let ((inhibit-read-only t))
+         (erase-buffer)
+         (magit-section-mode)
+         (magit-insert-section (demo-buffer)
+           ,@body)))
+     (switch-to-buffer-other-window buffer)))
+
+;; Current Test Function
+(defun org-roam-widget ()
+  (interactive)
+  (with-org-roam-buffer
+    (dolist (widget org-roam-widgets)
+      (when (org-roam-widget-show widget)
+        (org-roam-widget-render widget)))))

--- a/org-roam-widget.el
+++ b/org-roam-widget.el
@@ -1,7 +1,6 @@
 ;; For the lack of a better name, we're now calling this file org-roam-widget,
 ;; but it is meant to replace org-roam-buffer at some point
 
-(require 's)
 (require 'eieio)
 (require 'magit-section)
 
@@ -185,10 +184,10 @@ Items are of the form: ((key (list of values for key)))")
                      (not (f-equal-p (expand-file-name file org-roam-directory)
                                      (buffer-file-name org-roam-buffer--current))))
             (magit-insert-section (unlinked-reference)
-              (insert (s-pad-right 8
-                                   " "
-                                   (propertize (format "%s:%s" row col)
-                                               'font-lock-face 'org-roam-rowcol))
+              (insert (propertize (format
+                                   "%-8s"
+                                   (format "%s:%s" row col))
+                                  'font-lock-face 'org-roam-rowcol)
                       " "
                       (org-roam--get-title-or-slug file)
                       "\n"))

--- a/org-roam-widget.el
+++ b/org-roam-widget.el
@@ -4,6 +4,12 @@
 (require 'eieio)
 (require 'magit-section)
 
+;; Faces
+(defface org-roam-title
+  '((t :weight bold))
+  "Face for Org-roam titles."
+  :group 'org-roam-faces)
+
 ;;; Widget Class Definition
 (cl-deftype function ()
   '(satisfies fboundp))
@@ -65,9 +71,11 @@ Items are of the form: ((key (list of values for key)))")
             values (cdr item)
             empty nil)
       (magit-insert-section (backlinks-file)
+        (propertize (org-roam-db--get-title key)
+                    'font-lock-face 'org-roam-title)
         (magit-insert-heading (concat
                                (org-fontify-like-in-org-mode
-                                (org-roam-format-link key (org-roam--get-title-or-slug key)))
+                                (org-roam-format-link key (org-roam-db--get-title key)))
                                ":"))
         (dolist (value values)
           (setq prop (nth 2 value))
@@ -113,7 +121,7 @@ Items are of the form: ((key (list of values for key)))")
         (magit-insert-heading
           (org-fontify-like-in-org-mode
            (org-roam-format-link file-from
-                                 (org-roam--get-title-or-slug file-from)
+                                 (org-roam-db--get-title file-from)
                                  "file")))
         (dolist (reflink reflinks)
           (pcase-let ((`(_ _ ,props) reflink))
@@ -189,7 +197,7 @@ Items are of the form: ((key (list of values for key)))")
                                    (format "%s:%s" row col))
                                   'font-lock-face 'org-roam-rowcol)
                       " "
-                      (org-roam--get-title-or-slug file)
+                      (org-roam-db--get-title file)
                       "\n"))
             (setq empty nil)))))
     empty))


### PR DESCRIPTION
Revamp the Org-roam buffer.

Use `magit-section` to render the buffer for more flexibility, rather than Org-mode.

![image](https://user-images.githubusercontent.com/1667473/98660754-9fe05f80-2380-11eb-8f56-f298686ad55c.png)
