### PR TITLE
(doc): various improvements

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -12,7 +12,7 @@
 #+texinfo_dir_desc: Rudimentary Roam Replica for Emacs.
 #+subtitle: for version 1.2.2
 
-#+options: H:4 num:3 toc:2 creator:t
+#+options: H:4 num:3 toc:2 creator:t ':t
 #+property: header-args :eval never
 #+texinfo: @noindent
 
@@ -122,12 +122,16 @@ create new zettels, pre-filling boilerplate content using a powerful templating
 system. Org-roam also facilitates the linking of zettels using Org-mode ~file:~
 links.
 
+** Fleeting notes
+
 A slip-box requires a method of quickly capturing ideas. These are called
 *fleeting notes*: they are simple reminders of information or ideas that will
 need to be processed later on, or trashed. This is typically accomplished using
 ~org-capture~ (see info:org#capture), or using Org-roam's daily notes
 functionality (see [[*Daily-notes][Daily-notes]]). This provides a central inbox for collecting
 thoughts, to be processed later into permanent notes.
+
+** Permanent notes
 
 Permanent notes are further split into two categories: *literature notes* and
 *concept notes*. Literature notes can be brief annotations on a particular
@@ -370,7 +374,7 @@ title extraction methods supported are:
 1. ~'title~: This extracts the title using the file ~#+title~ property
 2. ~'headline~: This extracts the title from the first headline in the Org file
 3. ~'alias~: This extracts a list of titles using the ~#+roam_alias~ property.
-   The aliases are space-delimited, and can be multi-worded using quotes
+   The aliases are space-delimited, and can be multi-worded using quotes.
 
 Take for example the following org file:
 
@@ -727,7 +731,7 @@ Note that Emacs will prompt for a password for encrypted files during
 cache updates if it requires reading the encrypted file. To reduce the
 number of password prompts, you may wish to cache the password.
 
-- Variable: org-roam-encrypt-files
+- User Option: org-roam-encrypt-files
 
   Whether to encrypt new files.  If true, create files with .org.gpg extension.
 * Graphing
@@ -843,9 +847,9 @@ commands, set:
 Other options include ~'ido~, and ~'ivy~.
 
 * Roam Protocol
-** _ :ignore:
-Org-roam extending ~org-protocol~ with 2 protocols: the ~roam-file~
-and ~roam-ref~ protocol.
+
+Org-roam extends ~org-protocol~ with 2 protocols: the ~roam-file~
+and ~roam-ref~ protocols.
 
 ** Installation
 
@@ -1145,8 +1149,9 @@ org-roam-doctor~, but note that this may take some time.
   Perform a check on Org-roam files to ensure cleanliness. If THIS-BUFFER, run
   the check only for the current buffer.
 
-The checks run are defined in ~org-roam-doctor--checkers~. Each checker is an
-instance of ~org-roam-doctor-checker~. To define a checker, use
+The checks run are defined in ~org-roam-doctor--checkers~. By default, there are checkers for broken links and invalid =#+roam_*= properties.
+
+Each checker is an instance of ~org-roam-doctor-checker~. To define a checker, use
 ~make-org-roam-doctor-checker~. Here is a sample definition:
 
 #+BEGIN_SRC emacs-lisp
@@ -1401,6 +1406,8 @@ tight integration between
 [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]] and
 ~org-roam~. This helps you manage your bibliographic notes under
 ~org-roam~.
+
+For example, though helm-bibtex provides the ability to visit notes for bibliographic entries, org-roam-bibtex extends it with the ability to visit the file with the right =#+roam_key=.
 
 **** Spaced Repetition
     :PROPERTIES:

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -89,6 +89,11 @@ General Public License for more details.
 @detailmenu
 --- The Detailed Node Listing ---
 
+A Brief Introduction to the Zettelkasten Method
+
+* Fleeting notes::
+* Permanent notes::
+
 Installation
 
 * Installing from MELPA::
@@ -125,7 +130,6 @@ Graphing
 
 Roam Protocol
 
-* _::
 * Installation: Installation (1). 
 * The roam-file protocol::
 * The roam-ref protocol::
@@ -267,12 +271,23 @@ create new zettels, pre-filling boilerplate content using a powerful templating
 system. Org-roam also facilitates the linking of zettels using Org-mode @code{file:}
 links.
 
+@menu
+* Fleeting notes::
+* Permanent notes::
+@end menu
+
+@node Fleeting notes
+@section Fleeting notes
+
 A slip-box requires a method of quickly capturing ideas. These are called
 @strong{fleeting notes}: they are simple reminders of information or ideas that will
 need to be processed later on, or trashed. This is typically accomplished using
 @code{org-capture} (see @ref{capture,,,org,}), or using Org-roam's daily notes
 functionality (see @ref{Daily-notes}). This provides a central inbox for collecting
 thoughts, to be processed later into permanent notes.
+
+@node Permanent notes
+@section Permanent notes
 
 Permanent notes are further split into two categories: @strong{literature notes} and
 @strong{concept notes}. Literature notes can be brief annotations on a particular
@@ -418,7 +433,7 @@ Where @code{/path/to/my/info/files} is the location where you keep info files. T
 @lisp
 (require 'info)
 (add-to-list 'Info-default-directory-list
-         "/path/to/my/info/files")
+             "/path/to/my/info/files")
 @end lisp
 
 You can also use one of the default locations, such as:
@@ -568,7 +583,7 @@ title extraction methods supported are:
 
 @item
 @code{'alias}: This extracts a list of titles using the @code{#+roam_alias} property.
-The aliases are space-delimited, and can be multi-worded using quotes
+The aliases are space-delimited, and can be multi-worded using quotes.
 @end itemize
 
 Take for example the following org file:
@@ -1022,10 +1037,10 @@ Note that Emacs will prompt for a password for encrypted files during
 cache updates if it requires reading the encrypted file. To reduce the
 number of password prompts, you may wish to cache the password.
 
-@defvar org-roam-encrypt-files
+@defopt org-roam-encrypt-files
 
 Whether to encrypt new files.  If true, create files with .org.gpg extension.
-@end defvar
+@end defopt
 
 @node Graphing
 @chapter Graphing
@@ -1177,18 +1192,14 @@ Other options include @code{'ido}, and @code{'ivy}.
 @node Roam Protocol
 @chapter Roam Protocol
 
+Org-roam extends @code{org-protocol} with 2 protocols: the @code{roam-file}
+and @code{roam-ref} protocols.
+
 @menu
-* _::
 * Installation: Installation (1). 
 * The roam-file protocol::
 * The roam-ref protocol::
 @end menu
-
-@node _
-@section _ :ignore:
-
-Org-roam extending @code{org-protocol} with 2 protocols: the @code{roam-file}
-and @code{roam-ref} protocol.
 
 @node Installation (1)
 @section Installation
@@ -1523,8 +1534,9 @@ Perform a check on Org-roam files to ensure cleanliness. If THIS-BUFFER, run
 the check only for the current buffer.
 @end defun
 
-The checks run are defined in @code{org-roam-doctor--checkers}. Each checker is an
-instance of @code{org-roam-doctor-checker}. To define a checker, use
+The checks run are defined in @code{org-roam-doctor--checkers}. By default, there are checkers for broken links and invalid @samp{#+roam_*} properties.
+
+Each checker is an instance of @code{org-roam-doctor-checker}. To define a checker, use
 @code{make-org-roam-doctor-checker}. Here is a sample definition:
 
 @lisp
@@ -1817,6 +1829,8 @@ tight integration between
 @uref{https://github.com/tmalsburg/helm-bibtex, helm-bibtex} and
 @code{org-roam}. This helps you manage your bibliographic notes under
 @code{org-roam}.
+
+For example, though helm-bibtex provides the ability to visit notes for bibliographic entries, org-roam-bibtex extends it with the ability to visit the file with the right @samp{#+roam_key}.
 
 @node Spaced Repetition
 @unnumberedsubsubsec Spaced Repetition


### PR DESCRIPTION
###### Motivation for this change

These are various manual changes that I think are too small to be in their own individual PRs.

Motivation for each change:

- options: explicitly enable smart quotes on export

  This prevents this file from accidentally being exported without smart quotes.

- zettelkasten introduction: put fleeting notes and permanent notes in their own sections

  This IMO serves two purposes:

  1. Show the fleeting / permanent notes concept up front in the table of contents, and
  2. Allow people to eg. link to https://www.orgroam.com/manual/Fleeting-notes.html for easier reference of this concept.

- roam protocal: remove extraneous heading

  I'm not sure if this heading had / has a purpose, but right now it just causes the table of contents to look like

  ```
  14 Roam Protocol
    14.1 _ :ignore:
  ```

These changes are minor style fixes:

- anatomy: add a missing period
- encryption: clarify org-roam-encrypt-files is a user option
- roam protocal: small grammar fix

And these changes expand on sections that I think didn't provide enough information:

- doctor: explain what the doctor does by default

  If one were to read the current version, they'd have no idea what `org-roam-doctor` actually checks for. I added a sentence to explain that.

- org-roam-bibtex: explain part of what orb actually does

  When I first started to use org-roam, I had no idea what "tight integration between [these packages]" means. I hope that by providing an example of what orb does this confusion can be alleviated.