### PR TITLE
(feat): add `org-roam-db-update-method`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## 1.2.3 (TBD)
 
-### Features
+### Changed
+- [#1264](https://github.com/org-roam/org-roam/pull/1264) renamed `org-roam-update-db-idle-seconds` to `org-roam-db-idle-idle-seconds` 
 
+### Features
 - [#1183](https://github.com/org-roam/org-roam/pull/1183) add interactive functions for managing aliases and tags in Org-roam file, namely `org-roam-alias-add`, `org-roam-alias-delete`, `org-roam-tag-add`, and `org-roam-tag-delete`.
 - [#1215](https://github.com/org-roam/org-roam/pull/1215) Multiple `ROAM_KEY` keywords can now be specified in one file. This allows bibliographical entries to share the same note file.
 - [#1238](https://github.com/org-roam/org-roam/pull/1238) add `org-roam-prefer-id-links` variable to select linking method
 - [#1239](https://github.com/org-roam/org-roam/pull/1239) Allow `org-roam-protocol` to capture the webpage's selection, and add a toggle for storing the links to the pages
+- [#1264](https://github.com/org-roam/org-roam/pull/1264) add `org-roam-db-update-method`
 
 ### Bugfixes
 

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -671,6 +671,23 @@ The ~org-roam-link-current~ face corresponds to links to the same file it is in.
 
 The ~org-roam-link-invalid~ face is applied to links that are broken. These are
 links to files or IDs that cannot be found.
+** TODO The Database
+
+Org-roam is backed by a Sqlite database.
+
+- User Option: org-roam-db-update-method
+
+  Method to update the Org-roam database.
+
+  ~'immediate~: Update the database immediately upon file changes.
+
+  ~'idle-timer~: Updates the database if dirty, if Emacs idles for
+  ~org-roam-db-update-idle-seconds~.
+
+- User Option: org-roam-db-update-idle-seconds
+
+  Number of idle seconds before triggering an Org-roam database update. This is
+  only valid if ~org-roam-db-update-method~ is ~'idle-timer~.
 
 * Inserting Links
 

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -119,6 +119,7 @@ Concepts and Configuration
 * The Org-roam Buffer::
 * Org-roam Files::
 * Org-roam Faces::
+* The Database::
 
 Navigating Around
 
@@ -878,6 +879,7 @@ org-roam}.
 * The Org-roam Buffer::
 * Org-roam Files::
 * Org-roam Faces::
+* The Database::
 @end menu
 
 @node Directories and Files
@@ -969,6 +971,27 @@ The @code{org-roam-link-current} face corresponds to links to the same file it i
 
 The @code{org-roam-link-invalid} face is applied to links that are broken. These are
 links to files or IDs that cannot be found.
+
+@node The Database
+@section @strong{TODO} The Database
+
+Org-roam is backed by a Sqlite database.
+
+@defopt org-roam-db-update-method
+
+Method to update the Org-roam database.
+
+@code{'immediate}: Update the database immediately upon file changes.
+
+@code{'idle-timer}: Updates the database if dirty, if Emacs idles for
+@code{org-roam-db-update-idle-seconds}.
+@end defopt
+
+@defopt org-roam-db-update-idle-seconds
+
+Number of idle seconds before triggering an Org-roam database update. This is
+only valid if @code{org-roam-db-update-method} is @code{'idle-timer}.
+@end defopt
 
 @node Inserting Links
 @chapter Inserting Links

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -103,6 +103,9 @@
   'org-roam-dailies-capture-templates "org-roam 1.0.0")
 (define-obsolete-variable-alias 'org-roam-date-filename-format
   'org-roam-dailies-capture-templates "org-roam 1.0.0")
+(define-obsolete-variable-alias 'org-roam-update-db-idle-seconds
+  'org-roam-db-update-idle-seconds "org-roam 1.2.2")
+
 (make-obsolete-variable 'org-roam-buffer-no-delete-other-windows
   'org-roam-buffer-window-parameters "org-roam 1.1.1")
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -101,12 +101,12 @@ so that multi-directories are updated.")
   Update the database immediately upon file changes.
 
 `idle-timer'
-  Updates the database if dirty, if Emacs idles for `org-roam-update-db-idle-seconds'."
+  Updates the database if dirty, if Emacs idles for `org-roam-db-update-idle-seconds'."
   :type '(set (const :tag "idle-timer" idle-timer)
               (const :tag "immediate" immediate))
   :group 'org-roam)
 
-(defcustom org-roam-update-db-idle-seconds 2
+(defcustom org-roam-db-update-idle-seconds 2
   "Number of idle seconds before triggering an Org-roam database update."
   :type 'integer
   :group 'org-roam)

--- a/org-roam.el
+++ b/org-roam.el
@@ -1494,7 +1494,7 @@ M-x info for more information at Org-roam > Installation > Post-Installation Tas
     (add-hook 'org-open-at-point-functions #'org-roam-open-id-at-point)
     (if (and org-roam-db-file-update-timer
              (eq org-roam-db-update-method 'idle-timer))
-        (setq org-roam-db-file-update-timer (run-with-idle-timer org-roam-update-db-idle-seconds t #'org-roam-db-update-cache-on-timer)))
+        (setq org-roam-db-file-update-timer (run-with-idle-timer org-roam-db-update-idle-seconds t #'org-roam-db-update-cache-on-timer)))
     (advice-add 'rename-file :after #'org-roam--rename-file-advice)
     (advice-add 'delete-file :before #'org-roam--delete-file-advice)
     (advice-add 'org-id-new :after #'org-roam--id-new-advice)


### PR DESCRIPTION
Add `org-roam-db-update-method`, which can be one of two choices:

1. `immediate`: the cache is updated upon file changes
2. `idle-timer`: Marks the org-roam database as dirty. If Emacs idles
for some seconds, the Org-roam cache is updated. This is the default,
and current behaviour.

The idle method makes for a smoother editing experience, but some
inconsistencies can be faced.

Using the `immediate` method fixes #1137.