### PR TITLE
(fix) Link to the documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ General Public License, Version 3
 [roamresearch]: https://www.roamresearch.com/
 [org]: https://orgmode.org/
 [badge-license]: https://img.shields.io/badge/license-GPL_3-green.svg
-[docs]: https://www.orgroam.com/manual/
+[docs]: https://www.orgroam.com/manual.html
 [discourse]: https://org-roam.discourse.group/
 [slack]: https://join.slack.com/t/orgroam/shared_invite/zt-deoqamys-043YQ~s5Tay3iJ5QRI~Lxg
 [issues]: https://github.com/org-roam/org-roam/issues


### PR DESCRIPTION
###### Motivation for this change
I was setting up the org-roam today and saw that the current link in `README.md` points to the 404 page. This change should fix this.