### PR TITLE
Allow timestamps as links and #+roam_keys

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -808,8 +808,8 @@ Each ref is returned as a cons of its type and its key."
           ((pred string-empty-p)
            (user-error "Org property #+roam_key cannot be empty"))
           ((pred (string-match org-link-plain-re))
-           (setq type (org-roam--collate-types (match-string 1 ref))
-                 path (match-string 2 ref)))
+           (setq type (org-roam--collate-types (match-string 1 roam-key))
+                 path (match-string 2 roam-key)))
           ((pred (string-match org-ts-regexp2))
            (setq type "timestamp"
                  path roam-key)))


### PR DESCRIPTION
With this change, timestamps are recorded as links of type "timestamp". Org active timestamps are recognised as ref keys. This means that e.g. daily note files can show all places where a matching org timestamp occurs in the backlinks buffer.

###### Motivation for this change

With daily notes, it would be nice to be able to easily see events/meetings/notes that are tagged as occuring on that day in the backlinks buffer. This is possible with a link to the daily note such as `[[file:2020-11-12.org][2020-11-12]]`, but since org already has a method for linking to dates -- timestamps -- it would be nice to be able to use that. Specifically, I often already have headlines with timestamps so they show up in org-agenda; it would be nice not to have to duplicate the information as a separate link to the daily note.

This means that if I have a file `2020-11-12.org` with this contents:
```org
#+title: 2020-11-12
#+roam_key: <2020-11-12 Thu>
```

and another file with this contents:
```org
#+TITLE: Temp

Working on this today [2020-11-12 Thu]
```

Then the backlink appears in the buffer for the daily note:
```org
* 1 Ref Backlink
** [[file:temp.org][Temp]]
Working on this today [2020-11-12 Thu]
```

###### Further work needed

If you think this is a reasonable addition, there are a couple more things to do:
- Add to changelog

And possible extensions:
- Allow customising behaviour -- should inactive, active or both types of timestamp be included?
- Optionally do something sensible when the ref timestamp falls within a date range
- Optional also link CLOCKED time