### PR TITLE
(feat): capture: create OLP if does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 1.2.4 (TBD)
+
+### Added
+- [#1270](https://github.com/org-roam/org-roam/pull/1270) capture: create OLP if it does not exist. Removes need for OLP setup in `:head`.
+
+### Changed
+
+### Fixed
 
 ## 1.2.3 (13-11-2020)
 

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1123,20 +1123,19 @@ specifying the outline-path to a heading:
            #'org-roam-capture--get-point
            "* %?"
            :file-name "daily/%<%Y-%m-%d>"
-           :head "#+title: %<%Y-%m-%d>\n\n* Lab notes\n* Journal"
+           :head "#+title: %<%Y-%m-%d>\n"
            :olp ("Journal"))
 
           ("j" "journal" entry
            #'org-roam-capture--get-point
            "* %?"
            :file-name "daily/%<%Y-%m-%d>"
-           :head "#+title: %<%Y-%m-%d>\n\n* Lab notes\n* Journal"
+           :head "#+title: %<%Y-%m-%d>\n"
            :olp ("Lab notes"))))
 #+end_src
 
 The template ~l~ will put its notes under the heading ‘Lab notes’, and the
-template ~j~ will put its notes under the heading ‘Journal’. When you use
-~:olp~, make sure that the headings are present in ~:head~.
+template ~j~ will put its notes under the heading ‘Journal’. 
 
 ** Capturing and finding daily-notes
 

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1525,20 +1525,19 @@ specifying the outline-path to a heading:
          #'org-roam-capture--get-point
          "* %?"
          :file-name "daily/%<%Y-%m-%d>"
-         :head "#+title: %<%Y-%m-%d>\n\n* Lab notes\n* Journal"
+         :head "#+title: %<%Y-%m-%d>\n"
          :olp ("Journal"))
 
         ("j" "journal" entry
          #'org-roam-capture--get-point
          "* %?"
          :file-name "daily/%<%Y-%m-%d>"
-         :head "#+title: %<%Y-%m-%d>\n\n* Lab notes\n* Journal"
+         :head "#+title: %<%Y-%m-%d>\n"
          :olp ("Lab notes"))))
 @end lisp
 
 The template @code{l} will put its notes under the heading ‘Lab notes’, and the
-template @code{j} will put its notes under the heading ‘Journal’. When you use
-@code{:olp}, make sure that the headings are present in @code{:head}.
+template @code{j} will put its notes under the heading ‘Journal’.
 
 @node Capturing and finding daily-notes
 @section Capturing and finding daily-notes

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -442,9 +442,9 @@ the file if the original value of :no-save is not t and
       (org-capture-put :no-save t))
     file-path))
 
-(defun org-roam-capture-find-or-create-olp (path)
+(defun org-roam-capture-find-or-create-olp (olp)
   "Return a marker pointing to the entry at OLP in the current buffer.
-if OLP does not exist, create it. If anything goes wrong, throw
+If OLP does not exist, create it. If anything goes wrong, throw
 an error, and if you need to do something based on this error,
 you can catch it with `condition-case'."
   (let* ((level 1)
@@ -457,7 +457,7 @@ you can catch it with `condition-case'."
       (error "Buffer %s needs to be in Org mode" (current-buffer)))
     (org-with-wide-buffer
      (goto-char start)
-     (dolist (heading path)
+     (dolist (heading olp)
        (let ((re (format org-complex-heading-regexp-format
                          (regexp-quote heading)))
              (cnt 0))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -443,7 +443,7 @@ the file if the original value of :no-save is not t and
     file-path))
 
 (defun org-roam-capture-find-or-create-olp (path)
-  "Return a marker pointing to the entry at outline path OLP in the current buffer.
+  "Return a marker pointing to the entry at OLP in the current buffer.
 if OLP does not exist, create it. If anything goes wrong, throw
 an error, and if you need to do something based on this error,
 you can catch it with `condition-case'."
@@ -454,7 +454,7 @@ you can catch it with `condition-case'."
          (end (point-max))
          found flevel)
     (unless (derived-mode-p 'org-mode)
-      (error "Buffer %s needs to be in Org mode" buffer))
+      (error "Buffer %s needs to be in Org mode" (current-buffer)))
     (org-with-wide-buffer
      (goto-char start)
      (dolist (heading path)


### PR DESCRIPTION
Remove the requirement that the OLP already exists in the captured file.
Also, make OLP available beyond dailies functionality.