### PR TITLE
documentation example for org-roam-dailies typo

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1124,14 +1124,14 @@ specifying the outline-path to a heading:
            "* %?"
            :file-name "daily/%<%Y-%m-%d>"
            :head "#+title: %<%Y-%m-%d>\n"
-           :olp ("Journal"))
+           :olp ("Lab notes"))
 
           ("j" "journal" entry
            #'org-roam-capture--get-point
            "* %?"
            :file-name "daily/%<%Y-%m-%d>"
            :head "#+title: %<%Y-%m-%d>\n"
-           :olp ("Lab notes"))))
+           :olp ("Journal"))))
 #+end_src
 
 The template ~l~ will put its notes under the heading ‘Lab notes’, and the

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1526,14 +1526,14 @@ specifying the outline-path to a heading:
          "* %?"
          :file-name "daily/%<%Y-%m-%d>"
          :head "#+title: %<%Y-%m-%d>\n"
-         :olp ("Journal"))
+         :olp ("Lab notes"))
 
         ("j" "journal" entry
          #'org-roam-capture--get-point
          "* %?"
          :file-name "daily/%<%Y-%m-%d>"
          :head "#+title: %<%Y-%m-%d>\n"
-         :olp ("Lab notes"))))
+         :olp ("Journal"))))
 @end lisp
 
 The template @code{l} will put its notes under the heading ‘Lab notes’, and the


### PR DESCRIPTION
The `olp` option in the lab notes example was swapped.
