### PR TITLE
(internal): remove org-roam--get-title-or-slug function

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1471,8 +1471,8 @@ using [[https://github.com/raxod502/el-patch][el-patch]]:
 #+BEGIN_SRC emacs-lisp
   (use-package el-patch
     :straight (:host github
-                     :repo "raxod502/el-patch"
-                     :branch "develop"))
+               :repo "raxod502/el-patch"
+               :branch "develop"))
 
   (eval-when-compile
     (require 'el-patch))
@@ -1491,7 +1491,7 @@ using [[https://github.com/raxod502/el-patch][el-patch]]:
                          (if begin
                              (funcall deft-parse-title-function
                                       (substring contents begin (match-end 0))))))
-                     (org-roam--get-title-or-slug file))))
+                     (org-roam-db--get-title file))))
 #+END_SRC
 
 The Deft interface can slow down quickly when the number of files get huge.

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1976,8 +1976,8 @@ using @uref{https://github.com/raxod502/el-patch, el-patch}:
 @lisp
 (use-package el-patch
   :straight (:host github
-                   :repo "raxod502/el-patch"
-                   :branch "develop"))
+             :repo "raxod502/el-patch"
+             :branch "develop"))
 
 (eval-when-compile
   (require 'el-patch))
@@ -1996,7 +1996,7 @@ used as title."
                        (if begin
                            (funcall deft-parse-title-function
                                     (substring contents begin (match-end 0))))))
-                   (org-roam--get-title-or-slug file))))
+                   (org-roam-db--get-title file))))
 @end lisp
 
 The Deft interface can slow down quickly when the number of files get huge.

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -47,9 +47,9 @@
 (defvar org-roam--org-link-bracket-typed-re)
 
 (declare-function org-roam-db--ensure-built   "org-roam-db")
+(declare-function org-roam-db--get-title      "org-roam-db")
 (declare-function org-roam--extract-refs      "org-roam")
 (declare-function org-roam--extract-titles    "org-roam")
-(declare-function org-roam--get-title-or-slug "org-roam")
 (declare-function org-roam--get-backlinks     "org-roam")
 (declare-function org-roam-backlinks-mode     "org-roam")
 (declare-function org-roam-mode               "org-roam")
@@ -116,7 +116,7 @@ For example: (setq org-roam-buffer-window-parameters '((no-other-window . t)))"
 
 (defun org-roam-buffer--insert-title ()
   "Insert the org-roam-buffer title."
-  (insert (propertize (org-roam--get-title-or-slug
+  (insert (propertize (org-roam-db--get-title
                        (buffer-file-name org-roam-buffer--current))
                       'font-lock-face
                       'org-document-title)))
@@ -164,7 +164,7 @@ ORIG-PATH is the path where the CONTENT originated."
                   (bls (cdr group)))
               (insert (format "** %s\n"
                               (org-roam-format-link file-from
-                                                    (org-roam--get-title-or-slug file-from)
+                                                    (org-roam-db--get-title file-from)
                                                     "file")))
               (dolist (backlink bls)
                 (pcase-let ((`(,file-from _ ,props) backlink))
@@ -195,7 +195,7 @@ ORIG-PATH is the path where the CONTENT originated."
             (setq props (seq-sort-by (lambda (p) (plist-get p :point)) #'< props))
             (insert (format "** %s\n"
                             (org-roam-format-link file-from
-                                                  (org-roam--get-title-or-slug file-from)
+                                                  (org-roam-db--get-title file-from)
                                                   "file")))
             (dolist (prop props)
               (insert "*** "

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -403,8 +403,8 @@ Return the number of rows inserted."
       (puthash (car row) (cadr row) ht))
     ht))
 
-(defun org-roam-db--get-titles (file)
-  "Return the titles of FILE from the cache."
+(defun org-roam-db--get-title (file)
+  "Return the main title of FILE from the cache."
   (caar (org-roam-db-query [:select [title] :from titles
                             :where (= file $s1)
                             :limit 1]

--- a/org-roam.el
+++ b/org-roam.el
@@ -796,11 +796,6 @@ Each ref is returned as a cons of its type and its key."
       (file-relative-name (expand-file-name org-roam-directory))
       (file-name-sans-extension)))
 
-(defun org-roam--get-title-or-slug (path)
-  "Convert `PATH' to the file title, if it exists.  Else, return the path."
-  (or (org-roam-db--get-titles path)
-      (org-roam--path-to-slug path)))
-
 (defun org-roam--title-to-slug (title)
   "Convert TITLE to a filename-suitable slug."
   (cl-flet* ((nonspacing-mark-p (char)
@@ -1772,7 +1767,7 @@ Return added tag."
   (interactive)
   (let* ((roam-buffers (org-roam--get-roam-buffers))
          (names-and-buffers (mapcar (lambda (buffer)
-                                      (cons (or (org-roam--get-title-or-slug
+                                      (cons (or (org-roam-db--get-title
                                                  (buffer-file-name buffer))
                                                 (buffer-name buffer))
                                             buffer))
@@ -1855,7 +1850,8 @@ the executable 'rg' in variable `exec-path'."
                   (let ((rowcol (concat row ":" col)))
                     (insert "- "
                             (org-link-make-string (concat "file:" file "::" rowcol)
-                                                       (format "[%s] %s" rowcol (org-roam--get-title-or-slug file))))
+                                                  (format "[%s] %s" rowcol (or (org-roam-db--get-title file)
+                                                                               file))))
                     (when (executable-find "sed") ; insert line contents when sed is available
                       (insert " :: "
                               (shell-command-to-string
@@ -1870,7 +1866,6 @@ the executable 'rg' in variable `exec-path'."
         (dolist (title titles)
           (highlight-phrase (downcase title) 'bold-italic))
         (goto-char (point-min))))))
-
 
 ;;;###autoload
 (defun org-roam-version (&optional message)


### PR DESCRIPTION
Every file has a title (or the slug) when saved into the database, so this
function is redundant in most cases (e.g. in org-roam-buffer, where backlinks
are fetched from the database).