### PR TITLE
(fix): use correct type for `org-roam-db-update-method`

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -102,8 +102,8 @@ so that multi-directories are updated.")
 
 `idle-timer'
   Updates the database if dirty, if Emacs idles for `org-roam-db-update-idle-seconds'."
-  :type '(set (const :tag "idle-timer" idle-timer)
-              (const :tag "immediate" immediate))
+  :type '(choice (const :tag "idle-timer" idle-timer)
+		 (const :tag "immediate" immediate))
   :group 'org-roam)
 
 (defcustom org-roam-db-update-idle-seconds 2


### PR DESCRIPTION
Fixes #1294.

