### PR TITLE
Set default-directory in org-roam-with-temp-buffer

### DIFF
--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -62,7 +62,8 @@ If FILE, set `org-roam-temp-file-name' to file and insert its contents."
        (with-temp-buffer
          (let ((org-roam-directory ,current-org-roam-directory)
                (org-mode-hook nil)
-               (org-inhibit-startup t))
+               (org-inhibit-startup t)
+               (default-directory (file-name-directory ,file)))
            (org-mode)
            (when ,file
              (insert-file-contents ,file)


### PR DESCRIPTION
This ensures that relative paths in keywords such as `#+setupfile:` and
`#+include:` work when building cache etc.

After some _very brief_ testing it didn't seem to break anything and it has fixed the issue I was having. However someone more familiar on where else and how `org-roam--with-temp-buffer` is used would probably want to double check that this won't break something.

###### Motivation for this change
Some discussion [here](https://org-roam.discourse.group/t/parsing-of-tmp-buffers-breaks-relative-include-handling/919). Basically every time the cache is built if you have a relative `#+setupfile:` it throws a warning (and doesn't include it). This is annoying and could potentially break if you need behaviour that is in that setupfile during cache builds (e.g. if you included roam tags, aliases, titles in it).
