### PR TITLE
(fix): do not display buffer if it is not processed in db

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -251,7 +251,8 @@ This needs to be quick or infrequent, because this is run at
     (when (and (or redisplay
                    (not (eq org-roam-buffer--current buffer)))
                (eq 'visible (org-roam-buffer--visibility))
-               (buffer-file-name buffer))
+               (buffer-file-name buffer)
+               (org-roam-db-has-file-p (buffer-file-name buffer)))
       (setq org-roam-buffer--current buffer)
       (org-roam-buffer-update))))
 

--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -48,6 +48,7 @@
 
 (declare-function org-roam-db--ensure-built   "org-roam-db")
 (declare-function org-roam-db--get-title      "org-roam-db")
+(declare-function org-roam-db-has-file-p      "org-roam-db")
 (declare-function org-roam--extract-refs      "org-roam")
 (declare-function org-roam--extract-titles    "org-roam")
 (declare-function org-roam--get-backlinks     "org-roam")

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -395,6 +395,13 @@ Return the number of rows inserted."
       0)))
 
 ;;;;; Fetching
+(defun org-roam-db-has-file-p (file)
+  "Return t if FILE is in the database, nil otherwise."
+  (> (caar (org-roam-db-query [:select (funcall count) :from files
+                              :where (= file $s1)]
+                              file))
+     0))
+
 (defun org-roam-db--get-current-files ()
   "Return a hash-table of file to the hash of its file contents."
   (let* ((current-files (org-roam-db-query [:select * :from files]))


### PR DESCRIPTION
Finding an Org-roam file that does not exist yet triggers the find-file
hook, resulting in an Org-roam buffer update, attempting to show the
file. However, if the file does not yet exist, attempts to show the file
will not work, since the database does not contain the relevant
information yet.

This bug has always been present, but was only recently made visible by
the code cleanups in #1284.

Now, we ensure that the file has been processed by the database before
attempting to re-display the buffer.

Fixes #1297