### PR TITLE
(fix): fix rename file corrupting database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - [#1281](https://github.com/org-roam/org-roam/pull/1281) fixed idle-timer not instantiated on `org-roam-mode`
+- [#1308](https://github.com/org-roam/org-roam/pull/1308) fixed file renames corrupting database
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -255,15 +255,14 @@ This function is called on `org-roam-db-file-update-timer'."
     (dolist (table (mapcar #'car org-roam-db--table-schemata))
       (org-roam-db-query `[:delete :from ,table]))))
 
-(defun org-roam-db--clear-file (&optional filepath)
-  "Remove any related links to the file at FILEPATH.
+(defun org-roam-db--clear-file (&optional file)
+  "Remove any related links to the FILE.
 This is equivalent to removing the node from the graph."
-  (let ((file (expand-file-name (or filepath
-                                    (buffer-file-name (buffer-base-buffer))))))
-    (dolist (table (mapcar #'car org-roam-db--table-schemata))
-      (org-roam-db-query `[:delete :from ,table
-                           :where (= ,(if (eq table 'links) 'source 'file) $s1)]
-                         file))))
+  (setq file (or file (buffer-file-name (buffer-base-buffer))))
+  (dolist (table (mapcar #'car org-roam-db--table-schemata))
+    (org-roam-db-query `[:delete :from ,table
+                         :where (= ,(if (eq table 'links) 'source 'file) $s1)]
+                       file)))
 
 ;;;;; Inserting
 (defun org-roam-db--insert-meta (&optional update-p)


### PR DESCRIPTION
The rename file advice is passed relative file names: e.g. "foo.org" ->
"bar.org". This was not accounted for, and paths in the Org-roam
database are supposed to be absolute paths. This caused the storing of
relative paths in the Org-roam database, which were then never purged.

Fixes #1304