### PR TITLE
(feat): follow lowercase convention for buffer properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1270](https://github.com/org-roam/org-roam/pull/1270) capture: create OLP if it does not exist. Removes need for OLP setup in `:head`.
 
 ### Changed
+- [#1312](https://github.com/org-roam/org-roam/pull/1312) follow new org-mode convention to use lowercase for buffer properties like `#+roam_key`, `#+roam_alias`, etc.
 
 ### Fixed
 - [#1281](https://github.com/org-roam/org-roam/pull/1281) fixed idle-timer not instantiated on `org-roam-mode`

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -102,7 +102,7 @@ AST is the org-element parse tree."
     (org-element-map ast 'keyword
       (lambda (kw)
         (let ((key (org-element-property :key kw)))
-          (when (and (string-prefix-p "ROAM_" key t)
+          (when (and (string-prefix-p "roam_" key 'ignore-case)
                      (not (member (downcase key) org-roam-doctor--supported-roam-properties)))
             (push
              `(,(org-element-property :begin kw)


### PR DESCRIPTION
##### Motivation for this change

See https://github.com/org-roam/org-roam/pull/769 for more information

