### PR TITLE
(fix): don't set default-directory if no file is passed

### DIFF
--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -62,12 +62,12 @@ If FILE, set `org-roam-temp-file-name' to file and insert its contents."
        (with-temp-buffer
          (let ((org-roam-directory ,current-org-roam-directory)
                (org-mode-hook nil)
-               (org-inhibit-startup t)
-               (default-directory (file-name-directory ,file)))
+               (org-inhibit-startup t))
            (org-mode)
            (when ,file
              (insert-file-contents ,file)
-             (setq-local org-roam-file-name ,file))
+             (setq-local org-roam-file-name ,file)
+             (setq-local default-directory (file-name-directory ,file)))
            ,@body)))))
 
 (defun org-roam-message (format-string &rest args)


### PR DESCRIPTION
This fixes calls like (org-roam--with-temp-buffer nil ...). 

Fixes #1310, fixes #1316.