### PR TITLE
update org-roam buffer fix for spacemacs

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1490,6 +1490,7 @@ Otherwise, behave as if called interactively."
 Ensure it is installed and can be found within `exec-path'. \
 M-x info for more information at Org-roam > Installation > Post-Installation Tasks."))
     (add-to-list 'org-execute-file-search-functions 'org-roam--execute-file-row-col)
+    (add-hook 'post-command-hook #'org-roam-buffer--update-maybe t)
     (add-hook 'find-file-hook #'org-roam--find-file-hook-function)
     (add-hook 'kill-emacs-hook #'org-roam-db--close-all)
     (add-hook 'org-open-at-point-functions #'org-roam-open-id-at-point)


### PR DESCRIPTION
Spacemacs does not update org-roam-buffer when changing roam files. This fixes that by adding the hook to `org-roam-buffer--update-maybe` to the autoload function.

It seems that hook get's removed on exiting org-roam-mode, but not getting added back when returning to an org-roam buffer in spacemacs (alternate-buffer switching).

###### Motivation for this change
