### PR TITLE
(fix): uniqify title and tag extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - [#1281](https://github.com/org-roam/org-roam/pull/1281) fixed idle-timer not instantiated on `org-roam-mode`
 - [#1308](https://github.com/org-roam/org-roam/pull/1308) fixed file renames corrupting database
+- [#1325](https://github.com/org-roam/org-roam/pull/1325) make titles and tags extracted unique per note 
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -687,7 +687,7 @@ If NESTED, return the first successful result from SOURCES."
              (setq coll (nconc coll res))
            (setq coll res)
            (cl-return))))
-     coll)))
+     (-uniq coll))))
 
 (defun org-roam--extract-tags-all-directories (file)
   "Extract tags from using the directory path FILE.
@@ -738,11 +738,12 @@ Tags are obtained via:
    path is considered a tag.
 2. The key #+roam_tags."
   (let* ((file (or file (buffer-file-name (buffer-base-buffer))))
-         (tags (mapcan (lambda (source)
-                         (funcall (intern (concat "org-roam--extract-tags-"
-                                                  (symbol-name source)))
-                                  file))
-                       org-roam-tag-sources)))
+         (tags (-uniq
+                (mapcan (lambda (source)
+                          (funcall (intern (concat "org-roam--extract-tags-"
+                                                   (symbol-name source)))
+                                   file))
+                        org-roam-tag-sources))))
     (pcase org-roam-tag-sort
       ('nil tags)
       ((pred booleanp) (cl-sort tags 'string-lessp :key 'downcase))


### PR DESCRIPTION
Remove duplicates from title and tag extraction, arising from
multiple (or the same) sources.

Fixes #1324