### PR TITLE
(internal): remove error-checking for olp

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -529,14 +529,7 @@ This function is used solely in Org-roam's capture templates: see
         (org-roam-capture--put prop val)))
     (set-buffer (org-capture-target-buffer file-path))
     (widen)
-    (if-let* ((olp (--> (org-roam-capture--get :olp)
-                        (pcase it
-                          ((pred listp)
-                           it)
-                          (wrong-type
-                           (signal 'wrong-type-argument
-                                   `((stringp listp)
-                                     ,wrong-type)))))))
+    (if-let* ((olp (org-roam-capture--get :olp)))
         (condition-case err
             (when-let ((marker (org-roam-capture-find-or-create-olp olp)))
               (goto-char marker)


### PR DESCRIPTION
The `org-roam-capture-find-or-create-olp` function will throw the same
error, so we don't have to explicitly catch and throw.