### PR TITLE
(fix): preserve existing description in a roam: link on replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Fixed
 - [#1281](https://github.com/org-roam/org-roam/pull/1281) fixed idle-timer not instantiated on `org-roam-mode`
 - [#1308](https://github.com/org-roam/org-roam/pull/1308) fixed file renames corrupting database
-- [#1325](https://github.com/org-roam/org-roam/pull/1325) make titles and tags extracted unique per note 
+- [#1325](https://github.com/org-roam/org-roam/pull/1325) make titles and tags extracted unique per note
+- [#1327](https://github.com/org-roam/org-roam/pull/1327) preserve existing link description during automatic replacement
 
 ## 1.2.3 (13-11-2020)
 
@@ -26,7 +27,7 @@ Org-roam-dailies has also been revamped to include new features, see [this video
 - [#1264](https://github.com/org-roam/org-roam/pull/1264) add `org-roam-db-update-method` to control when the cache is rebuilt.
 
 ### Changed
-- [#1264](https://github.com/org-roam/org-roam/pull/1264) renamed `org-roam-update-db-idle-seconds` to `org-roam-db-idle-idle-seconds` 
+- [#1264](https://github.com/org-roam/org-roam/pull/1264) renamed `org-roam-update-db-idle-seconds` to `org-roam-db-idle-idle-seconds`
 
 ### Fixed
 - [#1074](https://github.com/org-roam/org-roam/issues/1074) fix `org-roam--extract-links` to handle content boundaries.
@@ -70,7 +71,7 @@ This change requires you to set `org-roam-directory` to the resolved path of a f
 - [#974](https://github.com/org-roam/org-roam/pull/974) Protect region targeted by `org-roam-insert`
 - [#994](https://github.com/org-roam/org-roam/pull/994) Simplify org-roam-store-link
 - [#1062](https://github.com/org-roam/org-roam/pull/1062) Variable `org-roam-completions-everywhere` allows for completions everywhere from word at point
-- [#910](https://github.com/org-roam/org-roam/pull/910), [#1105](https://github.com/org-roam/org-roam/pull/1105) Support fuzzy links of the form [[roam:Title]], [[roam:*Headline]] and [[roam:Title*Headline]]
+- [#910](https://github.com/org-roam/org-roam/pull/910), [#1105](https://github.com/org-roam/org-roam/pull/1105) Support fuzzy links of the form `[[roam:Title]]`, `[[roam:*Headline]]` and `[[roam:Title*Headline]]`
 
 ### Bugfixes
 

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -206,7 +206,7 @@ marker is a marker to the headline, if applicable.
 desc is either the the description of the link under point, or
 the target of LINK (title or heading content)."
   (let ((context (org-element-context))
-        path mkr link-type desc loc)
+        mkr link-type desc loc)
     (pcase (org-element-lineage context '(link) t)
       (`nil (error "Not at an Org link"))
       (link
@@ -270,7 +270,8 @@ DESC is the link description."
       (condition-case nil
           (pcase-let ((`(,link-type ,loc ,desc _) (org-roam-link--get-location)))
             (when (and link-type loc)
-              (org-roam-link--replace-link link-type loc desc)))))))
+              (org-roam-link--replace-link link-type loc desc)))
+        (error nil)))))
 
 (defun org-roam-link--replace-link-on-save ()
   "Hook to replace all roam links on save."


### PR DESCRIPTION
###### Motivation for this change

Before, `[[roam:Abc][def]]` would be replaced with `[[file:abc.org][Abc]]`; the existing description "def" is replaced with the description fetched from abc.org.

This change makes it so that the existing description will be preserved:

- `[[roam:Abc][def]]` → `[[file:path/to/abc.org][def]]`
- `[[roam:Abc]]` → `[[file:path/to/abc.org][Abc]]`

This is useful for attaching links to existing text.

A word on retrieving the existing description: `org-element-link-parser` doesn't return the description itself, relying on the caller to be in the same buffer and retrieve with `buffer-substring-no-properties` themself. This is fine in `org-roam-link-replace-all`, where current buffer is known, but in `org-roam-link-follow-link` we're relying on Org not changing `current-buffer` during the link following process. I believe this is a reasonable trade off for not deleting existing text.

Edit: (feat) → (fix), as this is more like a fix than a feature (like #1252).
