### PR TITLE
(fix): close files intelligently after modifying.

### DIFF
--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -94,40 +94,41 @@ noabbrev  Absolute path, no abbreviation of home directory."
 If FILE, return outline headings for passed FILE instead.
 If WITH-MARKER, return a cons cell of (headline . marker).
 If USE-STACK, include the parent paths as well."
-  (let* ((buf (or (and file
-                       (or (find-buffer-visiting file)
-                           (find-file-noselect file)))
-                  (current-buffer)))
-         (outline-level-fn outline-level)
-         (path-separator "/")
-         (stack-level 0)
-         stack cands name level marker)
-    (with-current-buffer buf
-      (save-excursion
-        (goto-char (point-min))
-        (while (re-search-forward org-complex-heading-regexp nil t)
-          (save-excursion
-            (setq name (substring-no-properties (or (match-string 4) "")))
-            (setq marker (point-marker))
-            (when use-stack
-              (goto-char (match-beginning 0))
-              (setq level (funcall outline-level-fn))
-              ;; Update stack.  The empty entry guards against incorrect
-              ;; headline hierarchies, e.g. a level 3 headline
-              ;; immediately following a level 1 entry.
-              (while (<= level stack-level)
-                (pop stack)
-                (cl-decf stack-level))
-              (while (> level stack-level)
-                (push name stack)
-                (cl-incf stack-level))
-              (setq name (mapconcat #'identity
-                                    (reverse stack)
-                                    path-separator)))
-            (push (if with-marker
-                      (cons name marker)
-                    name) cands)))))
-    (nreverse cands)))
+  (org-roam--handle-file file
+    (let* ((buf (or (and file
+                         (or (find-buffer-visiting file)
+                             (find-file-noselect file)))
+                    (current-buffer)))
+           (outline-level-fn outline-level)
+           (path-separator "/")
+           (stack-level 0)
+           stack cands name level marker)
+      (with-current-buffer buf
+        (save-excursion
+          (goto-char (point-min))
+          (while (re-search-forward org-complex-heading-regexp nil t)
+            (save-excursion
+              (setq name (substring-no-properties (or (match-string 4) "")))
+              (setq marker (point-marker))
+              (when use-stack
+                (goto-char (match-beginning 0))
+                (setq level (funcall outline-level-fn))
+                ;; Update stack.  The empty entry guards against incorrect
+                ;; headline hierarchies, e.g. a level 3 headline
+                ;; immediately following a level 1 entry.
+                (while (<= level stack-level)
+                  (pop stack)
+                  (cl-decf stack-level))
+                (while (> level stack-level)
+                  (push name stack)
+                  (cl-incf stack-level))
+                (setq name (mapconcat #'identity
+                                      (reverse stack)
+                                      path-separator)))
+              (push (if with-marker
+                        (cons name marker)
+                      name) cands)))))
+      (nreverse cands))))
 
 (defun org-roam-link--get-file-from-title (title &optional no-interactive)
   "Return the file path corresponding to TITLE.
@@ -147,16 +148,17 @@ When NO-INTERACTIVE, return nil if there are multiple options."
 If FILE, get headline from FILE instead.
 If there is no corresponding headline, return nil."
   (save-excursion
-    (with-current-buffer (or (and file
-                                  (or (find-buffer-visiting file)
-                                      (find-file-noselect file)))
-                             (current-buffer))
-      (let ((headlines (org-roam-link--get-headlines file 'with-markers)))
-        (when-let ((marker (cdr (assoc-string headline headlines))))
-          (goto-char marker)
-          (cons marker
-                (when org-roam-link-auto-replace
-                  (org-id-get-create))))))))
+    (org-roam--handle-file file
+      (with-current-buffer (or (and file
+                                    (or (find-buffer-visiting file)
+                                        (find-file-noselect file)))
+                               (current-buffer))
+        (let ((headlines (org-roam-link--get-headlines file 'with-markers)))
+          (when-let ((marker (cdr (assoc-string headline headlines))))
+            (goto-char marker)
+            (cons marker
+                  (when org-roam-link-auto-replace
+                    (org-id-get-create)))))))))
 
 ;;; Path-related functions
 (defun org-roam-link-get-path (path &optional type)

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -54,7 +54,7 @@
 
 (defmacro org-roam--with-file (file &rest body)
   "Execute BODY within a FILE and save it.
-      Closes the FILE if the FILE is not yet visited.
+      Keeps the FILE if the FILE is currently visited.
   existing-buf in org-roam--handle-file-condition."
   `(org-roam--handle-file ,file (with-current-buffer (or existing-buf
                                                         (find-file-noselect ,file))
@@ -63,19 +63,19 @@
 
 (defmacro org-roam--handle-file (file &rest body)
   "Handle FILE after executing BODY.
-      Closes the FILE if the FILE is not yet visited."
+      Keeps the FILE if the FILE is currently visited."
   `(org-roam--handle-file-condition ,file 't ,@body))
 
 (defmacro org-roam--handle-file-condition (file condition &rest body)
   "Handle FILE after executing BODY.
-      Closes the FILE if the FILE is not yet visited and if CONDITION is p."
+      Keeps the FILE if the FILE is currently visited or if CONDITION is p."
   (declare (indent 1) (debug t))
   `(let* ((existing-buf (find-buffer-visiting ,file))
           (res     ,@body))
      ;; find-buffer-visiting needs to be recomputed because it was created by
      ;; @body
-     (unless (and existing-buf
-                  ,condition)
+     (unless (or existing-buf
+                 ,condition)
        (kill-buffer (find-buffer-visiting ,file)))
      res))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1079,12 +1079,8 @@ When STRICT is non-nil, only consider Org-roam’s database.
 When KEEP-BUFFER-P is non-nil, keep the buffers navigated by Org-roam open."
   (let ((file (org-roam-id-get-file id strict)))
     (when file
-      (let ((existing-buf (find-buffer-visiting file))
-            (res (org-id-find-id-in-file id file markerp)))
-        (when (and (not keep-buffer-p)
-                   (not existing-buf))
-          (kill-buffer (find-buffer-visiting file)))
-        res))))
+      (org-roam--handle-file-condition file keep-buffer-p
+        (org-id-find-id-in-file id file markerp)))))
 
 (defun org-roam-id-open (id-or-marker &optional strict)
   "Go to the entry with ID-OR-MARKER.

--- a/org-roam.el
+++ b/org-roam.el
@@ -1382,11 +1382,8 @@ To be added to `org-roam-title-change-hook'."
                                              :where (= dest $s1)]
                                             current-path)))
     (dolist (file files-affected)
-      (org-roam--handle-file (car file)
-        (with-current-buffer (or (find-buffer-visiting (car file))
-                                 (find-file-noselect (car file)))
-          (org-roam--replace-link current-path current-path old-title new-title)
-          (save-buffer))))))
+      (org-roam--with-file (car file)
+          (org-roam--replace-link current-path current-path old-title new-title)))))
 
 (defun org-roam--update-file-name-on-title-change (old-title new-title)
   "Update the file name on title change.
@@ -1435,22 +1432,17 @@ When NEW-FILE-OR-DIR is a directory, we use it to compute the new file path."
               (setq file (if (string-equal (car file) old-file)
                              new-file
                            (car file)))
-              (org-roam--handle-file file
-                (with-current-buffer (or (find-buffer-visiting file)
-                                         (find-file-noselect file))
+              (org-roam--with-file file
                   (org-roam--replace-link old-file new-file)
                   (save-buffer)
-                  (org-roam-db--update-file))))
+                  (org-roam-db--update-file)))
             files-affected)
       ;; If the new path is in a different directory, relative links
       ;; will break. Fix all file-relative links:
       (unless (string= (file-name-directory old-file)
                        (file-name-directory new-file))
-        (org-roam--handle-file new-file
-          (with-current-buffer (or (find-buffer-visiting new-file)
-                                 (find-file-noselect new-file))
-            (org-roam--fix-relative-links old-file)
-            (save-buffer))))
+        (org-roam--with-file new-file
+            (org-roam--fix-relative-links old-file)))
       (when (org-roam--org-roam-file-p new-file)
         (org-roam-db--update-file new-file)))))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1079,7 +1079,7 @@ When STRICT is non-nil, only consider Org-roam’s database.
 When KEEP-BUFFER-P is non-nil, keep the buffers navigated by Org-roam open."
   (let ((file (org-roam-id-get-file id strict)))
     (when file
-      (org-roam--handle-file-condition file keep-buffer-p
+      (org-roam-with-file file keep-buffer-p
         (org-id-find-id-in-file id file markerp)))))
 
 (defun org-roam-id-open (id-or-marker &optional strict)
@@ -1378,8 +1378,8 @@ To be added to `org-roam-title-change-hook'."
                                              :where (= dest $s1)]
                                             current-path)))
     (dolist (file files-affected)
-      (org-roam--with-file (car file)
-          (org-roam--replace-link current-path current-path old-title new-title)))))
+      (org-roam-with-file (car file) nil
+        (org-roam--replace-link current-path current-path old-title new-title)))))
 
 (defun org-roam--update-file-name-on-title-change (old-title new-title)
   "Update the file name on title change.
@@ -1428,17 +1428,17 @@ When NEW-FILE-OR-DIR is a directory, we use it to compute the new file path."
               (setq file (if (string-equal (car file) old-file)
                              new-file
                            (car file)))
-              (org-roam--with-file file
-                  (org-roam--replace-link old-file new-file)
-                  (save-buffer)
-                  (org-roam-db--update-file)))
+              (org-roam-with-file file nil
+                (org-roam--replace-link old-file new-file)
+                (save-buffer)
+                (org-roam-db--update-file)))
             files-affected)
       ;; If the new path is in a different directory, relative links
       ;; will break. Fix all file-relative links:
       (unless (string= (file-name-directory old-file)
                        (file-name-directory new-file))
-        (org-roam--with-file new-file
-            (org-roam--fix-relative-links old-file)))
+        (org-roam-with-file new-file nil
+          (org-roam--fix-relative-links old-file)))
       (when (org-roam--org-roam-file-p new-file)
         (org-roam-db--update-file new-file)))))
 


### PR DESCRIPTION
functions `org-roam--update-links-on-title-change`, `org-roam--rename-file-advice`, `org-roam-link--get-id-from-headline`, and ` rg-roam-link--get-headlines` don't close files after modifying them if they weren't already open.
there has been a long standing issue with org-roam where some operations leave files open when they shouldn't.
This PR ameliorates the issue.
refer to  #1171