### PR TITLE
(feat): make buffer update interactive.

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -218,6 +218,7 @@ ORIG-PATH is the path where the CONTENT originated."
 
 (defun org-roam-buffer-update ()
   "Update the `org-roam-buffer'."
+  (interactive)
   (org-roam-db--ensure-built)
   (let* ((source-org-roam-directory org-roam-directory))
     (with-current-buffer org-roam-buffer


### PR DESCRIPTION
This pr enables updating the org-roam buffer manually. It is useful when org-roam doesn't update the org-roam backlink buffer but new information is available. 
###### Motivation for this change