### PR TITLE
(fix): index file: prevent malformed absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1308](https://github.com/org-roam/org-roam/pull/1308) fixed file renames corrupting database
 - [#1325](https://github.com/org-roam/org-roam/pull/1325) make titles and tags extracted unique per note
 - [#1327](https://github.com/org-roam/org-roam/pull/1327) preserve existing link description during automatic replacement
+- [#1346](https://github.com/org-roam/org-roam/pull/1346) prevent malformed path to `org-roam-index-file`
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -868,17 +868,14 @@ plist containing the path and title for the file."
 The path to the index can be defined in `org-roam-index-file'.
 Otherwise, it is assumed to be a note in `org-roam-directory'
 whose title is 'Index'."
-  (let* ((index org-roam-index-file)
-         (path (pcase index
-                 ((pred functionp) (funcall index))
-                 ((pred stringp) index)
-                 ('nil (user-error "You need to set `org-roam-index-file' before you can jump to it"))
-                 (wrong-type (signal 'wrong-type-argument
-                                     `((functionp stringp)
-                                       ,wrong-type))))))
-    (if (f-relative-p index)
-        (expand-file-name index org-roam-directory)
-      index)))
+  (let ((path (pcase org-roam-index-file
+                ((pred functionp) (funcall org-roam-index-file))
+                ((pred stringp) org-roam-index-file)
+                ('nil (user-error "You need to set `org-roam-index-file' before you can jump to it"))
+                (wrong-type (signal 'wrong-type-argument
+                                    `((functionp stringp)
+                                      ,wrong-type))))))
+    (expand-file-name path org-roam-directory)))
 
 ;;;; dealing with file-wide properties
 (defun org-roam--set-global-prop (name value)

--- a/org-roam.el
+++ b/org-roam.el
@@ -877,7 +877,7 @@ whose title is 'Index'."
                                      `((functionp stringp)
                                        ,wrong-type))))))
     (if (f-relative-p index)
-        (concat (expand-file-name org-roam-directory) path)
+        (expand-file-name index org-roam-directory)
       index)))
 
 ;;;; dealing with file-wide properties


### PR DESCRIPTION
When `org-roam-directory` doesn't end with trailing slash and
`org-roam-index-file` contains relative filename, absolute path
to org-roam index file returned by `org-roam--get-index-path` is
malformed and invalid.

This commit removes redundant string concatenation and leverages
`expand-file-name` ability to construct valid absolute file path
when it is provided with directory as its 2nd argument.

###### Motivation for this change
