### PR TITLE
(fix): allow link captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#1325](https://github.com/org-roam/org-roam/pull/1325) make titles and tags extracted unique per note
 - [#1327](https://github.com/org-roam/org-roam/pull/1327) preserve existing link description during automatic replacement
 - [#1346](https://github.com/org-roam/org-roam/pull/1346) prevent malformed path to `org-roam-index-file`
+- [#1347](https://github.com/org-roam/org-roam/pull/1347) allow use of `%a` element in regular Org-roam captures
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -579,8 +579,7 @@ GOTO and KEYS argument have the same functionality as
 `org-capture'."
   (let* ((org-capture-templates (mapcar #'org-roam-capture--convert-template org-roam-capture-templates))
          (one-template-p (= (length org-capture-templates) 1))
-         org-capture-templates-contexts
-         (org-capture-link-is-already-stored t))
+         org-capture-templates-contexts)
     (when one-template-p
       (setq keys (caar org-capture-templates)))
     (if (or one-template-p

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -80,6 +80,7 @@ It opens or creates a note with the given ref.
     (let* ((org-roam-capture-templates org-roam-capture-ref-templates)
            (org-roam-capture--context 'ref)
            (org-roam-capture--info decoded-alist)
+           (org-capture-link-is-already-stored t)
            (template (cdr (assoc 'template decoded-alist))))
       (raise-frame)
       (org-roam-capture--capture nil template)


### PR DESCRIPTION
Previously we had set `org-capture-link-is-already-stored` to `t` in
org-roam captures, because org-roam-protocol stores links. This
prevented regular captures from utilizing the %a element in the
templates.

Instead, only set `org-capture-link-is-already-stored` in the
org-roam-protocol capture command.

Fixes #1341.