### PR TITLE
(feat): Support file-property drawers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 - [#1270](https://github.com/org-roam/org-roam/pull/1270) capture: create OLP if it does not exist. Removes need for OLP setup in `:head`.
+- [#1353](https://github.com/org-roam/org-roam/pull/1353) support file-level property drawers
 
 ### Changed
 - [#1352](https://github.com/org-roam/org-roam/pull/1352) prefer lower-case for roam_tag and roam_alias in interactive commands

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -52,23 +52,6 @@
         (nconc new-lst (list separator it)))
       new-lst)))
 
-(defun org-roam--merge-alist (alist)
-  "Merge elements of ALIST with the same key.
-Keys that appear again later take precedence. For example, in this alist:
-
-\(org-roam--merge-alist \\='((a 1) (b 2) (a 3)))
-  => \\='((a 3) (b 2))
-
-merge (a 1) and (a 3), preferring (a 3).
-
-The function returns the new ALIST."
-  (let (rtn)
-    (dolist (e alist rtn)
-      (if (not (assoc (car e) rtn))
-          (push e rtn)
-        (setq rtn (assq-delete-all  (car e) rtn))
-        (push e rtn)))))
-
 (defmacro org-roam-with-file (file keep-file-p &rest body)
   "Execute BODY within FILE.
 If KEEP-FILE-P or FILE is already visited, do not kill the

--- a/org-roam-macs.el
+++ b/org-roam-macs.el
@@ -52,6 +52,23 @@
         (nconc new-lst (list separator it)))
       new-lst)))
 
+(defun org-roam--merge-alist (alist)
+  "Merge elements of ALIST with the same key.
+Keys that appear again later take precedence. For example, in this alist:
+
+\(org-roam--merge-alist \\='((a 1) (b 2) (a 3)))
+  => \\='((a 3) (b 2))
+
+merge (a 1) and (a 3), preferring (a 3).
+
+The function returns the new ALIST."
+  (let (rtn)
+    (dolist (e alist rtn)
+      (if (not (assoc (car e) rtn))
+          (push e rtn)
+        (setq rtn (assq-delete-all  (car e) rtn))
+        (push e rtn)))))
+
 (defmacro org-roam-with-file (file keep-file-p &rest body)
   "Execute BODY within FILE.
 If KEEP-FILE-P or FILE is already visited, do not kill the

--- a/org-roam.el
+++ b/org-roam.el
@@ -513,7 +513,7 @@ Use external shell commands if defined in `org-roam-list-files-commands'."
           (push (cons prop v) ret))))))
 
 (defun org-roam--collect-keywords (keywords)
-  "Collect all Org keywords in the current buffer."
+  "Collect all Org KEYWORDS in the current buffer."
   (if (functionp 'org-collect-keywords)
       (org-collect-keywords keywords)
     (let ((buf (org-element-parse-buffer))
@@ -539,10 +539,9 @@ Use external shell commands if defined in `org-roam-list-files-commands'."
   "Extract PROPS from the current Org buffer.
 Props are extracted from both the file-level property drawer (if
 any), and Org keywords. Org keywords take precedence."
-  (org-roam--merge-alist
-   (append
-    (org-roam--extract-global-props-drawer props)
-    (org-roam--extract-global-props-keyword props))))
+  (append
+   (org-roam--extract-global-props-keyword props)
+   (org-roam--extract-global-props-drawer props)))
 
 
 (defun org-roam--get-outline-path ()

--- a/org-roam.el
+++ b/org-roam.el
@@ -531,8 +531,9 @@ Use external shell commands if defined in `org-roam-list-files-commands'."
   "Extract KEYWORDS from the current Org buffer."
   (let (ret)
     (pcase-dolist (`(,key . ,values) (org-roam--collect-keywords keywords))
-      (dolist (value values ret)
-        (push (cons key value) ret)))))
+      (dolist (value values)
+        (push (cons key value) ret)))
+    ret))
 
 (defun org-roam--extract-global-props (props)
   "Extract PROPS from the current Org buffer.

--- a/org-roam.el
+++ b/org-roam.el
@@ -504,31 +504,46 @@ Use external shell commands if defined in `org-roam-list-files-commands'."
   (org-roam--list-files (expand-file-name org-roam-directory)))
 
 ;;;; Org extraction functions
+(defun org-roam--extract-global-props-drawer (props)
+  "Extract PROPS from the file-level property drawer in Org."
+  (let (ret)
+    (org-with-point-at 1
+      (dolist (prop props ret)
+        (when-let ((v (org-entry-get (point) prop)))
+          (push (cons prop v) ret))))))
+
+(defun org-roam--collect-keywords (keywords)
+  "Collect all Org keywords in the current buffer."
+  (if (functionp 'org-collect-keywords)
+      (org-collect-keywords keywords)
+    (let ((buf (org-element-parse-buffer))
+          res)
+      (dolist (k keywords)
+        (let ((p (org-element-map buf 'keyword
+                   (lambda (kw)
+                     (when (string-equal (org-element-property :key kw) k)
+                       (org-element-property :value kw)))
+                   :first-match nil)))
+          (push (cons k p) res)))
+      res)))
+
+(defun org-roam--extract-global-props-keyword (keywords)
+  "Extract PROPS from the keywords in the current Org buffer."
+  (let (ret)
+    (pcase-dolist (`(,key . ,values) (org-roam--collect-keywords keywords))
+      (dolist (value values)
+        (push (cons key value) ret)))
+    ret))
+
 (defun org-roam--extract-global-props (props)
-  "Extract PROPS from the current org buffer."
-  (let ((collected
-         ;; Collect the raw props first
-         ;; It'll be returned in the form of
-         ;; (("PROP" "value" ...) ("PROP2" "value" ...))
-         (if (functionp 'org-collect-keywords)
-             (org-collect-keywords props)
-           (let ((buf (org-element-parse-buffer))
-                 res)
-             (dolist (prop props)
-               (let ((p (org-element-map buf 'keyword
-                          (lambda (kw)
-                            (when (string-equal (org-element-property :key kw) prop)
-                              (org-element-property :value kw)))
-                          :first-match nil)))
-                 (push (cons prop p) res)))
-             res))))
-    ;; convert (("TITLE" "a" "b") ("Another" "c"))
-    ;; to (("TITLE" . "a") ("TITLE" . "b") ("Another" . "c"))
-    (let (ret)
-      (pcase-dolist (`(,key . ,values) collected)
-        (dolist (value values)
-          (push (cons key value) ret)))
-      ret)))
+  "Extract PROPS from the current Org buffer.
+Props are extracted from both the file-level property drawer (if
+any), and Org keywords. Org keywords take precedence."
+  (org-roam--merge-alist
+   (append
+    (org-roam--extract-global-props-drawer props)
+    (org-roam--extract-global-props-keyword props))))
+
 
 (defun org-roam--get-outline-path ()
   "Return the outline path to the current entry.

--- a/org-roam.el
+++ b/org-roam.el
@@ -528,12 +528,11 @@ Use external shell commands if defined in `org-roam-list-files-commands'."
       res)))
 
 (defun org-roam--extract-global-props-keyword (keywords)
-  "Extract PROPS from the keywords in the current Org buffer."
+  "Extract KEYWORDS from the current Org buffer."
   (let (ret)
     (pcase-dolist (`(,key . ,values) (org-roam--collect-keywords keywords))
-      (dolist (value values)
-        (push (cons key value) ret)))
-    ret))
+      (dolist (value values ret)
+        (push (cons key value) ret)))))
 
 (defun org-roam--extract-global-props (props)
   "Extract PROPS from the current Org buffer.


### PR DESCRIPTION
Add support for file-property drawers in property extraction. This means
the following is now supported:

:PROPERTIES:
:ROAM_ALIAS: alias
:ROAM_TAGS: tag1 tag2
:END:

Closes #1185, #1296