### PR TITLE
Use org-link-display-format in org-roam-insert

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1623,7 +1623,7 @@ If DESCRIPTION is provided, use this as the link label.  See
                (_ (when (region-active-p)
                     (setq beg (set-marker (make-marker) (region-beginning)))
                     (setq end (set-marker (make-marker) (region-end)))
-                    (setq region-text (buffer-substring-no-properties beg end))))
+                    (setq region-text (org-link-display-format (buffer-substring-no-properties beg end)))))
                (completions (--> (or completions
                                      (org-roam--get-title-path-completions))
                                  (if filter-fn


### PR DESCRIPTION
So that, like org-store-link, the computed description does not
contain the links that were captured.