### PR TITLE
(feat) Prompt user to select a template for org-roam-capture.

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -596,9 +596,10 @@ GOTO and KEYS argument have the same functionality as
       (funcall-interactively org-roam-capture-function))))
 
 (defun org-roam-capture-select-template (templates &optional keys)
-  "Prompt user to select a template for `org-roam-capture'.
-Argument TEMPLATES: org-roam-capture templates to be populated
-(`org-roam-capture-templates'). Argument KEYS: see `org-capture'."
+  "Prompt the user to select a template for `org-roam-capture'.
+Argument TEMPLATES: org-roam templates to be populated. Typically this
+should be `org-roam-capture-templates', but custom templates can be provided if
+needed. Argument KEYS: see `org-capture'."
   (interactive)
   (let ((org-capture-templates (mapcar #'org-roam-capture--convert-template templates)))
     (if keys

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -596,7 +596,9 @@ GOTO and KEYS argument have the same functionality as
       (funcall-interactively org-roam-capture-function))))
 
 (defun org-roam-capture-select-template (templates &optional keys)
-  "Prompt user to select a template for org-roam-capture."
+  "Prompt user to select a template for `org-roam-capture'.
+Argument TEMPLATES: org-roam-capture templates to be populated (`org-roam-capture-templates').
+Argument KEYS see `org-capture'"
   (interactive)
   (let ((org-capture-templates (mapcar #'org-roam-capture--convert-template templates)))
     (if keys

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -598,7 +598,7 @@ GOTO and KEYS argument have the same functionality as
 (defun org-roam-capture-select-template (templates &optional keys)
   "Prompt user to select a template for `org-roam-capture'.
 Argument TEMPLATES: org-roam-capture templates to be populated (`org-roam-capture-templates').
-Argument KEYS see `org-capture'"
+Argument KEYS: see `org-capture'."
   (interactive)
   (let ((org-capture-templates (mapcar #'org-roam-capture--convert-template templates)))
     (if keys

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -597,8 +597,8 @@ GOTO and KEYS argument have the same functionality as
 
 (defun org-roam-capture-select-template (templates &optional keys)
   "Prompt user to select a template for `org-roam-capture'.
-Argument TEMPLATES: org-roam-capture templates to be populated (`org-roam-capture-templates').
-Argument KEYS: see `org-capture'."
+Argument TEMPLATES: org-roam-capture templates to be populated
+(`org-roam-capture-templates'). Argument KEYS: see `org-capture'."
   (interactive)
   (let ((org-capture-templates (mapcar #'org-roam-capture--convert-template templates)))
     (if keys


### PR DESCRIPTION
Currently `org-roam-capture` doesn't prompt for template keys like `org-capture`. If there are multiple org-roam-capture templates, user has to pass the selection as argument manually.

To make this more user-friendly, I'm adding a prompt menu to `org-roam-capture` for user to select the template. The screen is similar to `org-capture` - it includes a menu of templates (populated from `org-roam-capture-templates`), as well as a key "C" for customization.
