### PR TITLE
Add useful warning message to org-roam-dailies-find-next-note

### DIFF
--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -302,6 +302,8 @@ negative, find note N days in the past."
                             (string= (buffer-file-name (buffer-base-buffer)) candidate))
                           dailies))
          note)
+      (unless position
+        (user-error "Can't find current note file - have you saved it yet?"))
       (pcase n
         ((pred (natnump))
          (when (eq position (- (length dailies) 1))


### PR DESCRIPTION
If the user creates a new daily via `org-roam-dailies-find-today`, they
will get a new buffer that hasn't yet been saved to disk. If they then try
to navigate to the previous daily via
`org-roam-dailies-find-previous-note`, they will get the error:

    `Wrong type argument: number-or-marker-p, nil`

This is because the value of the local variable `position` is set only if
the current buffer exists as a file in the dailies directory. It doesn't
until the user explicitly saves it.

That's not a big problem, but the solution is not obvious from the error
message. I added a check that will provide the user with a more informative
error message, so they know how to fix the issue:

    "Can't find current note file - have you saved it yet?"

###### Motivation for this change
