### PR TITLE
(fix): keep id backlinks on filename change

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1422,6 +1422,14 @@ When NEW-FILE-OR-DIR is a directory, we use it to compute the new file path."
                                               old-file))
       ;; Remove database entries for old-file.org
       (org-roam-db--clear-file old-file)
+      ;; If the new path is in a different directory, relative links
+      ;; will break. Fix all file-relative links:
+      (unless (string= (file-name-directory old-file)
+                       (file-name-directory new-file))
+        (org-roam-with-file new-file nil
+          (org-roam--fix-relative-links old-file)))
+      (when (org-roam--org-roam-file-p new-file)
+        (org-roam-db--update-file new-file))
       ;; Replace links from old-file.org -> new-file.org in all Org-roam files with these links
       (mapc (lambda (file)
               (setq file (if (string-equal (car file) old-file)
@@ -1431,15 +1439,7 @@ When NEW-FILE-OR-DIR is a directory, we use it to compute the new file path."
                 (org-roam--replace-link old-file new-file)
                 (save-buffer)
                 (org-roam-db--update-file)))
-            files-affected)
-      ;; If the new path is in a different directory, relative links
-      ;; will break. Fix all file-relative links:
-      (unless (string= (file-name-directory old-file)
-                       (file-name-directory new-file))
-        (org-roam-with-file new-file nil
-          (org-roam--fix-relative-links old-file)))
-      (when (org-roam--org-roam-file-p new-file)
-        (org-roam-db--update-file new-file)))))
+            files-affected))))
 
 (defun org-roam--id-new-advice (&rest _args)
   "Update the database if a new Org ID is created."


### PR DESCRIPTION
changing filename when title of file changes drops id links. This PR fixes that by reordering operations
to allow files-affected access to the new file's id before links within them are extracted and placed in database.
###### Motivation for this change