### PR TITLE
(fix): fix headline completions erroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#1346](https://github.com/org-roam/org-roam/pull/1346) prevent malformed path to `org-roam-index-file`
 - [#1347](https://github.com/org-roam/org-roam/pull/1347) allow use of `%a` element in regular Org-roam captures
 - [#1352](https://github.com/org-roam/org-roam/pull/1352) fixed org-roam-{tag/alias}-{add/delete} altering the original case of the Org property
+- [#1374](https://github.com/org-roam/org-roam/pull/1374) fix headline completions erroring out
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -97,7 +97,7 @@ the link."
 If FILE, return outline headings for passed FILE instead.
 If WITH-MARKER, return a cons cell of (headline . marker).
 If USE-STACK, include the parent paths as well."
-  (org-roam-with-file file 'keep
+  (org-roam-with-file file (when with-marker 'keep)
     (let* ((outline-level-fn outline-level)
            (path-separator "/")
            (stack-level 0)
@@ -128,6 +128,7 @@ If USE-STACK, include the parent paths as well."
                     name) cands))))
       (nreverse cands))))
 
+
 (defun org-roam-link--get-file-from-title (title &optional no-interactive)
   "Return the file path corresponding to TITLE.
 When NO-INTERACTIVE, return nil if there are multiple options."
@@ -142,8 +143,8 @@ When NO-INTERACTIVE, return nil if there are multiple options."
          (completing-read "Select file: " files))))))
 
 (defun org-roam-link--get-id-from-headline (headline &optional file)
-  "Return (marker . id) correspondng to HEADLINE.
-If FILE, get headline from FILE instead.
+  "Return (marker . id) correspondng to HEADLINE in FILE.
+If FILE is nil, get ID from current buffer.
 If there is no corresponding headline, return nil."
   (save-excursion
     (org-roam-with-file file 'keep


### PR DESCRIPTION
updates org-roam-with-file to accept nil FILE arg, to operate on current
buffer. Fixes org-roam-link--get-headlines to kill buffer if not
obtaining markers.

Fixes #1373

----

###### Motivation for this change