### PR TITLE
(fix): fix org-roam-protocol--open-ref creating new files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#1347](https://github.com/org-roam/org-roam/pull/1347) allow use of `%a` element in regular Org-roam captures
 - [#1352](https://github.com/org-roam/org-roam/pull/1352) fixed org-roam-{tag/alias}-{add/delete} altering the original case of the Org property
 - [#1374](https://github.com/org-roam/org-roam/pull/1374) fix headline completions erroring out
+- [#1375](https://github.com/org-roam/org-roam/pull/1375) fix org-roam-protocol to use existing ref file 
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -47,6 +47,7 @@
 (declare-function  org-roam--get-ref-path-completions   "org-roam")
 (declare-function  org-roam--find-file                  "org-roam")
 (declare-function  org-roam-format-link                "org-roam")
+(declare-function  org-roam--split-ref                 "org-roam")
 (declare-function  org-roam-mode                        "org-roam")
 (declare-function  org-roam-completion--completing-read "org-roam-completion")
 
@@ -405,7 +406,7 @@ The file is saved if the original value of :no-save is not t and
 This function reads the file-name attribute of the currently
 active Org-roam template.
 
-If the file path already exists, it throw an error.
+If the file path already exists, throw an error.
 
 Else, to insert the header content in the file, `org-capture'
 prepends the `:head' property of the Org-roam capture template.
@@ -429,8 +430,13 @@ the file if the original value of :no-save is not t and
                         ""))
          (org-template (org-capture-get :template))
          (roam-template (concat roam-head org-template)))
-    (unless (or (file-exists-p file-path)
-                (find-buffer-visiting file-path))
+    (if (or (file-exists-p file-path)
+            (find-buffer-visiting file-path))
+      (lwarn '(org-roam) :warning
+             "Attempted to recreate existing file: %s.
+This can happen when your org-roam db is not in sync with your notes.
+Using existing file..."
+             file-path)
       (make-directory (file-name-directory file-path) t)
       (org-roam-capture--put :orig-no-save (org-capture-get :no-save)
                              :new-file t)
@@ -446,9 +452,9 @@ the file if the original value of :no-save is not t and
          (org-capture-put :template org-template))
         (_
          (org-capture-put :template roam-template
-           :type 'plain)))
+                          :type 'plain)))
       (org-capture-put :no-save t))
-    file-path))
+      file-path))
 
 (defun org-roam-capture-find-or-create-olp (olp)
   "Return a marker pointing to the entry at OLP in the current buffer.
@@ -494,6 +500,16 @@ you can catch it with `condition-case'."
              end (save-excursion (org-end-of-subtree t t))))
      (point-marker))))
 
+(defun org-roam-capture--get-ref-path (type path)
+  "Get the file path to the ref with TYPE and PATH."
+  (caar (org-roam-db-query
+         [:select [file]
+          :from refs
+          :where (= type $s1)
+          :and (= ref $s2)
+          :limit 1]
+         type path)))
+
 (defun org-roam-capture--get-point ()
   "Return exact point to file for org-capture-template.
 The file to use is dependent on the context:
@@ -520,11 +536,13 @@ This function is used solely in Org-roam's capture templates: see
                        (org-capture-put :default-time (cdr (assoc 'time org-roam-capture--info)))
                        (org-roam-capture--new-file))
                       ('ref
-                       (let ((completions (org-roam--get-ref-path-completions))
-                             (ref (cdr (assoc 'ref org-roam-capture--info))))
-                         (if-let ((pl (cdr (assoc ref completions))))
-                             (plist-get pl :path)
-                           (org-roam-capture--new-file))))
+                       (if-let ((ref (cdr (assoc 'ref org-roam-capture--info))))
+                           (pcase (org-roam--split-ref )
+                             (`(,type . ,path)
+                              (or (org-roam-capture--get-ref-path type path)
+                                  (org-roam-capture--new-file)))
+                             (_ (user-error "%s is not a valid ref" ref)))
+                         (error "ref not found in `org-roam-capture--info'")))
                       (_ (error "Invalid org-roam-capture-context")))))
     (org-capture-put :template
       (org-roam-capture--fill-template (org-capture-get :template)))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -32,6 +32,7 @@
 ;;;; Library Requires
 (require 'org-capture)
 (require 'org-roam-macs)
+(require 'org-roam-db)
 (require 'dash)
 (require 's)
 (require 'cl-lib)

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -543,7 +543,7 @@ This function is used solely in Org-roam's capture templates: see
                               (or (org-roam-capture--get-ref-path type path)
                                   (org-roam-capture--new-file)))
                              (_ (user-error "%s is not a valid ref" ref)))
-                         (error "ref not found in `org-roam-capture--info'")))
+                         (error "Ref not found in `org-roam-capture--info'")))
                       (_ (error "Invalid org-roam-capture-context")))))
     (org-capture-put :template
       (org-roam-capture--fill-template (org-capture-get :template)))

--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -65,18 +65,18 @@ It opens or creates a note with the given ref.
       (push (cons 'slug (funcall org-roam-title-to-slug-function title)) decoded-alist))
     (let-alist decoded-alist
       (let* ((ref (org-protocol-sanitize-uri .ref))
-             (type (and (string-match "^\\([a-z]+\\):" ref)
+             (type (and (string-match org-link-plain-re ref)
                         (match-string 1 ref)))
              (title (or .title ""))
              (body (or .body ""))
              (orglink
               (org-link-make-string ref (or (org-string-nw-p title) ref))))
         (when org-roam-protocol-store-links
-          (push (list ref title) org-stored-links))
-        (org-link-store-props :type type
-                              :link ref
-                              :annotation orglink
-                              :initial body)))
+          (push (list ref title) org-stored-links)
+          (org-link-store-props :type type
+                                :link ref
+                                :annotation orglink
+                                :initial body))))
     (let* ((org-roam-capture-templates org-roam-capture-ref-templates)
            (org-roam-capture--context 'ref)
            (org-roam-capture--info decoded-alist)

--- a/org-roam.el
+++ b/org-roam.el
@@ -779,6 +779,14 @@ backlinks."
          "website")
         (t type)))
 
+(defun org-roam--split-ref (ref)
+  "Processes REF into its type and path.
+Returns a cons cell of type and path if ref is a valid ref."
+  (save-match-data
+    (when (string-match org-link-plain-re ref)
+      (cons (org-roam--collate-types (match-string 1 ref))
+            (match-string 2 ref)))))
+
 (defun org-roam--extract-refs ()
   "Extract all refs (ROAM_KEY statements) from the current buffer.
 
@@ -787,17 +795,13 @@ Each ref is returned as a cons of its type and its key."
     (pcase-dolist
         (`(,_ . ,roam-key)
          (org-roam--extract-global-props '("ROAM_KEY")))
-      (let (type path)
-        (pcase roam-key
+      (pcase roam-key
           ('nil nil)
           ((pred string-empty-p)
            (user-error "Org property #+roam_key cannot be empty"))
           (ref
-           (when (string-match org-link-plain-re ref)
-             (setq type (org-roam--collate-types (match-string 1 ref))
-                   path (match-string 2 ref)))))
-        (when (and type path)
-          (push (cons type path) refs))))
+           (when-let ((r (org-roam--split-ref ref)))
+             (push r refs)))))
     refs))
 
 (defun org-roam--extract-ref ()


### PR DESCRIPTION
We need to split the ref into its type/file before querying the db for a
match. Throw a warning when `org-roam--capture-new-file` tries to
recreate an existing file.

Fixes #1371 
