### PR TITLE
Allow `org-roam-buffer-position` to be a function

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -293,21 +293,11 @@ Valid states are 'visible, 'exists and 'none."
        ((< (window-height) h)
         (enlarge-window (- h (window-height))))))))
 
-(defun org-roam-buffer--check-position (position)
-  "Check that `POSITION is valid, warn and return `'right' otherwise."
-  (if (member position '(right left top bottom))
-      position
-    (let ((text-quoting-style 'grave))
-      (lwarn '(org-roam) :error
-             "Invalid org-roam-buffer-position: %s. Defaulting to \\='right"
-             org-roam-buffer-position))
-    'right))
-
 (defun org-roam-buffer--get-create ()
   "Set up the `org-roam' buffer at `org-roam-buffer-position'."
   (let ((position (if (functionp org-roam-buffer-position)
-                      (org-roam-buffer--check-position (funcall org-roam-buffer-position))
-                    (org-roam-buffer--check-position org-roam-buffer-position))))
+                      (funcall org-roam-buffer-position)
+                    org-roam-buffer-position)))
     (save-selected-window
       (-> (get-buffer-create org-roam-buffer)
           (display-buffer-in-side-window


### PR DESCRIPTION
This lets a user have a function decide, using run-time values, what
position the org-roam-buffer is placed in.

###### Motivation for this change

I frequently use both wide screens and tall screens, and want to have the org-roam buffer in different positions depending on the size of the frame it's opened in.  This provides for that, and does so in what I hope is a fairly simple manner.