### PR TITLE
(feat): add org-roam-buffer-preview-function

### DIFF
--- a/org-roam-buffer.el
+++ b/org-roam-buffer.el
@@ -36,6 +36,8 @@
 (require 's)
 (require 'f)
 (require 'ol)
+(require 'org-element)
+(require 'org-roam-macs)
 
 (defvar org-roam-directory)
 (defvar org-link-frame-setup)

--- a/org-roam.el
+++ b/org-roam.el
@@ -602,13 +602,8 @@ it as FILE-PATH."
           (goto-char (org-element-property :begin link))
           (let* ((type (org-roam--collate-types (org-element-property :type link)))
                  (path (org-element-property :path link))
-                 (element (org-element-at-point))
-                 (begin (or (org-element-property :contents-begin element)
-                            (org-element-property :begin element)))
-                 (end (or (org-element-property :contents-end element)
-                          (org-element-property :end element)))
                  (properties (list :outline (org-roam--get-outline-path)
-                                   :point begin))
+                                   :point (point)))
                  (names (pcase type
                           ("id"
                            (when-let ((file-path (org-roam-id-get-file path)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -607,11 +607,7 @@ it as FILE-PATH."
                             (org-element-property :begin element)))
                  (end (or (org-element-property :contents-end element)
                           (org-element-property :end element)))
-                 (content (or (org-element-property :raw-value element)
-                              (when (and begin end)
-                                (string-trim (buffer-substring-no-properties begin end)))))
                  (properties (list :outline (org-roam--get-outline-path)
-                                   :content content
                                    :point begin))
                  (names (pcase type
                           ("id"


### PR DESCRIPTION
Instead of storing preview content in the database, now provide a
function to fetch these on the fly. This paves the way for future
improvements (e.g. showing more lines)