### PR TITLE
Clarify behavior of capture functions

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -370,6 +370,12 @@ time by setting ~org-roam-db-update-idle-seconds~; or change the cache update
 to be triggered immediately after buffer save by setting
 ~org-roam-db-update-method~ to ~'immediate~.
 
+For experienced ~org-capture~ users, the behavior of ~M-x org-roam-find-file~ 
+may seem unfamiliar: after finishing a capture with ~C-c C-c~, you are returned  
+not to the original buffer from which you called ~M-x org-roam-find-file~, but 
+to a buffer pointing to the note you just created. For the usual ~org-capture~ 
+behavior you can call ~M-x org-roam-capture~ instead of ~M-x org-roam-find-file~. 
+
 Org-roam makes it easy to create notes, and link them together. To link notes
 together, we call ~M-x org-roam-insert~. This brings up a prompt with a list of
 title for existing notes. Selecting an existing entry will create and insert a

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -598,6 +598,12 @@ time by setting @code{org-roam-db-update-idle-seconds}; or change the cache upda
 to be triggered immediately after buffer save by setting
 @code{org-roam-db-update-method} to @code{'immediate}.
 
+For experienced @code{org-capture} users, the behavior of @code{M-x org-roam-find-file} 
+may seem unfamiliar: after finishing a capture with @code{C-c C-c}, you are returned  
+not to the original buffer from which you called @code{M-x org-roam-find-file}, but 
+to a buffer pointing to the note you just created. For the usual @code{org-capture} 
+behavior you can call @code{M-x org-roam-capture} instead of @code{M-x org-roam-find-file}. 
+
 Org-roam makes it easy to create notes, and link them together. To link notes
 together, we call @code{M-x org-roam-insert}. This brings up a prompt with a list of
 title for existing notes. Selecting an existing entry will create and insert a


### PR DESCRIPTION
###### Motivation for this change

Makes clear the difference between org-roam-find-file and org-roam-capture.  Closes #1391 