### PR TITLE
Feature/completing read tag position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 1.2.4 (TBD)
 
 ### Added
+- [#1396](https://github.com/org-roam/org-roam/pull/1396) add option to choose between prepending, appending, and omitting `roam_tags` in file completion
 - [#1270](https://github.com/org-roam/org-roam/pull/1270) capture: create OLP if it does not exist. Removes need for OLP setup in `:head`.
 - [#1353](https://github.com/org-roam/org-roam/pull/1353) support file-level property drawers
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -851,29 +851,20 @@ file."
           (format org-roam-link-title-format description)))
   (org-link-make-string (concat type ":" target) description))
 
-(defun org-roam--prepend-tag-string (str tags)
-  "Prepend TAGS to STR."
-  (concat
-   (when tags
-     (propertize (format "(%s) " (s-join org-roam-tag-separator tags))
-                 'face 'org-roam-tag))
-   str))
-
-(defun org-roam--append-tag-string (str tags)
-  "Append TAGS to STR."
-  (concat
-   str
-   (when tags
-     (propertize (format " (%s)" (s-join org-roam-tag-separator tags))
-                 'face 'org-roam-tag))))
-
 (defun org-roam--add-tag-string (str tags)
   "Add TAGS to STR.
 
-Either prepends or appends TAGS to STR, depending on the value of `org-roam-file-completion-tag-position'."
+Depending on the value of `org-roam-file-completion-tag-position', this function
+prepends TAGS to STR, appends TAGS to STR or omits TAGS from STR."
   (pcase org-roam-file-completion-tag-position
-    ('prepend (org-roam--prepend-tag-string str tags))
-    ('append (org-roam--append-tag-string str tags))
+    ('prepend (concat
+               (when tags (propertize (format "(%s) " (s-join org-roam-tag-separator tags))
+                                      'face 'org-roam-tag))
+               str))
+    ('append (concat
+              str
+              (when tags (propertize (format " (%s)" (s-join org-roam-tag-separator tags))
+                                     'face 'org-roam-tag))))
     ('omit str)))
 
 


### PR DESCRIPTION
Hi,

Thanks for your work on this great package.

This PR adds the `org-roam-file-completion-tag-position` option, which can
be used to control the position of `roam_tags` during file completion. It can
take one of the following values

  - `prepend`: Prepends tags to the file title
  - `append`: Appends tags to the file title
  - `omit`: Omits tags during completion.

I prefer to have the tags appended, but `prepend` is left as the default option.