### PR TITLE
(fix) inconsistency between props writing and reading (alias, tags)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#1352](https://github.com/org-roam/org-roam/pull/1352) fixed org-roam-{tag/alias}-{add/delete} altering the original case of the Org property
 - [#1374](https://github.com/org-roam/org-roam/pull/1374) fix headline completions erroring out
 - [#1375](https://github.com/org-roam/org-roam/pull/1375) fix org-roam-protocol to use existing ref file 
+- [#1403](https://github.com/org-roam/org-roam/issues/1403) fixed inconsistency between how we write and read props like alias and tags
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -53,7 +53,6 @@
 (declare-function org-roam--get-roam-buffers "org-roam")
 (declare-function org-roam--list-all-files "org-roam")
 (declare-function org-roam--org-roam-file-p "org-roam")
-(declare-function org-roam--str-to-list "org-roam")
 (declare-function org-roam-mode "org-roam")
 
 (defvar org-roam-verbose)
@@ -122,7 +121,7 @@ AST is the org-element parse tree."
         (when (string-collate-equalp (org-element-property :key kw) "roam_tags" nil t)
           (let ((tags (org-element-property :value kw)))
             (condition-case nil
-                (org-roam--str-to-list tags)
+                (split-string-and-unquote tags)
               (error
                (push
                 `(,(org-element-property :begin kw)
@@ -142,7 +141,7 @@ AST is the org-element parse tree."
         (when (string-collate-equalp (org-element-property :key kw) "roam_alias" nil t)
           (let ((aliases (org-element-property :value kw)))
             (condition-case nil
-              (org-roam--str-to-list aliases)
+              (split-string-and-unquote aliases)
               (error
                (push
                 `(,(org-element-property :begin kw)

--- a/org-roam.el
+++ b/org-roam.el
@@ -321,30 +321,6 @@ descriptive warnings when certain operations fail (e.g. parsing).")
         (push (cons prop val) res)))
     res))
 
-(defun org-roam--str-to-list (str)
-  "Transform string STR into a list of strings.
-If STR is nil, return nil.
-
-This function can throw an error if STR is not a string, or if
-str is malformed (e.g. missing a closing quote). Callers of this
-function are expected to catch the error."
-  (when str
-    (unless (stringp str)
-      (signal 'wrong-type-argument `(stringp ,str)))
-    (let* ((str (org-trim str))
-           (format-str ":dummy '(%s)") ;The :dummy key is discarded in the `lst' var below.
-           (items (cdar (org-babel-parse-header-arguments (format format-str str)))))
-      (mapcar (lambda (item)
-                (cond
-                 ((stringp item)
-                  item)
-                 ((symbolp item)
-                  (symbol-name item))
-                 ((numberp item)
-                  (number-to-string item))
-                 (t
-                  (signal 'wrong-type-argument `((stringp numberp symbolp) ,item))))) items))))
-
 (defun org-roam--url-p (path)
   "Check if PATH is a URL.
 Assume the protocol is not present in PATH; e.g. URL `https://google.com' is
@@ -661,7 +637,7 @@ Reads from the \"roam_alias\" property."
   (let* ((prop (org-roam--extract-global-props '("ROAM_ALIAS")))
          (aliases (cdr (assoc "ROAM_ALIAS" prop))))
     (condition-case nil
-        (org-roam--str-to-list aliases)
+        (split-string-and-unquote aliases)
       (error
        (progn
          (lwarn '(org-roam) :error
@@ -727,7 +703,7 @@ tag."
   "Extract tags from the current buffer's \"#roam_tags\" global property."
   (let* ((prop (cdr (assoc "ROAM_TAGS" (org-roam--extract-global-props '("ROAM_TAGS"))))))
     (condition-case nil
-        (org-roam--str-to-list prop)
+        (split-string-and-unquote prop)
       (error
        (progn
          (lwarn '(org-roam) :error

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -52,25 +52,6 @@
   (delete-file org-roam-db-location)
   (org-roam-db--close))
 
-(describe "org-roam--str-to-list"
-  (it "nil"
-    (expect (org-roam--str-to-list nil)
-            :to-be
-            nil))
-  (it "\"multi word\" prop 123"
-    (expect (org-roam--str-to-list "\"multi word\" prop 123")
-            :to-equal
-            '("multi word" "prop" "123")))
-  (it "prop \"multi word\" 123"
-    (expect (org-roam--str-to-list "\"multi word\" prop 123")
-            :to-equal
-            '("multi word" "prop" "123")))
-  (it "errors on bad input"
-    (expect (org-roam--str-to-list 1)
-            :to-throw)
-    (expect (org-roam--str-to-list "\"hello")
-            :to-throw)))
-
 (describe "Ref extraction"
   (before-all
     (test-org-roam--init))


### PR DESCRIPTION
Fixes #1403

###### Motivation for this change

Right noow we have an inconsistency between how we write and read props like tags and aliases. I might be missing the rasons for using `org-roam--str-to-list`, but it seems that it's purpose was to just handle not balanced quotation marks `"`. If my understand is correct, I think we should use `split-string-and-unquote` (opposite to `combine-and-quote-strings` that we are using for writing props). It has simple implementation and there is no need to convert between other types to string.

But again, I might be missing something.

```
ELISP> (split-string-and-unquote "hello my friends")
("hello" "my" "friends")

ELISP> (split-string-and-unquote "hello \"my friends")
*** Eval error ***  End of file during parsing

ELISP> (split-string-and-unquote "hello \"my\" friends")
("hello" "my" "friends")

ELISP> (split-string-and-unquote "hello ;tag friends")
("hello" ";tag" "friends")

ELISP> (org-roam--str-to-list "hello my friends")
("hello" "my" "friends")

ELISP> (org-roam--str-to-list "hello \"my friends")
*** Eval error ***  End of file during parsing

ELISP> (org-roam--str-to-list "hello \"my\" friends")
("hello" "my" "friends")

ELISP> (org-roam--str-to-list "hello ;tag friends")
*** Eval error ***  End of file during parsing
```

Some benchmarks:

```
ELISP> (benchmark-run 100 (split-string-and-unquote "hello \"my\" friends"))
(0.000531 0 0.0)

ELISP> (benchmark-run 100 (org-roam--str-to-list "hello \"my\" friends"))
(0.003681 0 0.0)
```