### PR TITLE
(feat) add transient menu for basic org-roam commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1396](https://github.com/org-roam/org-roam/pull/1396) add option to choose between prepending, appending, and omitting `roam_tags` in file completion
 - [#1270](https://github.com/org-roam/org-roam/pull/1270) capture: create OLP if it does not exist. Removes need for OLP setup in `:head`.
 - [#1353](https://github.com/org-roam/org-roam/pull/1353) support file-level property drawers
+- add `org-roam-menu`, a transient menu for common commands
 
 ### Changed
 - [#1352](https://github.com/org-roam/org-roam/pull/1352) prefer lower-case for roam_tag and roam_alias in interactive commands

--- a/org-roam-transient.el
+++ b/org-roam-transient.el
@@ -1,0 +1,50 @@
+;;; org-roam-transient.el --- transient menu for org-roam  -*- coding: utf-8; lexical-binding: t; -*-
+
+;; Copyright © 2020 Jethro Kuan <jethrokuan95@gmail.com>
+;; Author: Jethro Kuan <jethrokuan95@gmail.com>
+;; URL: https://github.com/org-roam/org-roam
+;; Keywords: org-mode, roam, convenience
+;; Version: 1.2.3
+;; Package-Requires: ((emacs "26.1") (org "9.3") (transient "0.2.0"))
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;;
+;; Add a transient menu (https://magit.vc/manual/transient/) for
+;; org-roam. To use the menu, bind `org-roam-menu' to a key, e.g,
+;; (using the `bind-key' package from
+;; https://github.com/priyadarshan/bind-key):
+;;
+;; (bind-key "C-c n" 'org-roam-menu)
+;;
+;;; Code:
+(require 'transient)
+
+;;;###autoload
+(transient-define-prefix org-roam-menu ()
+  "Transient menu for org-roam."
+  [("l" "show/hide org-roam buffer" org-roam)
+   ("f" "open an org-roam file" org-roam-find-file)
+   ("g" "display the org-roam graph" org-roam-graph)
+   ("i" "insert org-roam link" org-roam-insert)
+   ("I" "insert org-roam link using template" org-roam-insert-immediate)])
+
+(provide 'org-roam-transient)
+
+;;; org-roam-transient.el ends here

--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 1.2.3
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.2"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (s "1.12.0") (org "9.3") (emacsql "3.0.0") (emacsql-sqlite3 "1.0.2") (transient "0.2.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -64,6 +64,7 @@
 (require 'org-roam-doctor)
 (require 'org-roam-graph)
 (require 'org-roam-link)
+(require 'org-roam-transient)
 
 ;;;; Declarations
 ;; From org-ref-core.el


### PR DESCRIPTION
This commit implements a menu that presents the commands from the
`use-package` form in `README.md`.  Show the menu via `M-x
org-roam-menu`, which can be bound e.g. to `C-c n`.

###### Motivation for this change

Sometimes it's nice to have a menu of available commands :)

At the moment this adds just a single form, but I decided to give it its own file in case it grows.

If this change doesn't fit the project, please feel free to drop the request.