### PR TITLE
(fix): dailies: prevent inclusion of non-org-roam files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#1374](https://github.com/org-roam/org-roam/pull/1374) fix headline completions erroring out
 - [#1375](https://github.com/org-roam/org-roam/pull/1375) fix org-roam-protocol to use existing ref file 
 - [#1403](https://github.com/org-roam/org-roam/issues/1403) fixed inconsistency between how we write and read props like alias and tags
+- [#1409](https://github.com/org-roam/org-roam/issues/1398) prevent inclusion of non-org-roam files in `org-roam-dailies--list-files`
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -42,6 +42,7 @@
 ;;;; Declarations
 (defvar org-roam-mode)
 (defvar org-roam-directory)
+(defvar org-roam-file-extensions)
 (declare-function org-roam--org-file-p        "org-roam")
 (declare-function org-roam--find-file         "org-roam")
 (declare-function org-roam-mode               "org-roam")
@@ -277,13 +278,14 @@ Prefer past dates, unless PREFER-FUTURE is non-nil."
 (defun org-roam-dailies--list-files (&rest extra-files)
   "List all files in `org-roam-dailies-directory'.
 EXTRA-FILES can be used to append extra files to the list."
-  (let ((dir (org-roam-dailies-directory--get-absolute-path)))
+  (let ((dir (org-roam-dailies-directory--get-absolute-path))
+	(regexp (rx-to-string `(and "." (or ,@org-roam-file-extensions)))))
     (append (--remove (let ((file (file-name-nondirectory it)))
                         (when (or (auto-save-file-name-p file)
                                   (backup-file-name-p file)
                                   (string-match "^\\." file))
                           it))
-                      (directory-files-recursively dir ""))
+                      (directory-files-recursively dir regexp))
             extra-files)))
 
 (defun org-roam-dailies-find-next-note (&optional n)


### PR DESCRIPTION
Fixes #1398


