### PR TITLE
Fix & add to Link Completion doc

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -841,10 +841,13 @@ to variable ~company-backends~.
 represents the cursor:
 
 - ~[[|]]~: completes for a file title
-- ~[[roam:]]~: completes for a file title
+- ~[[roam:|]]~: completes for a file title
 - ~[[*|]]~: completes for a headline within this file
 - ~[[foo*|]]~: completes a headline within the file with title "foo"
 - ~[[roam:foo*|]]~ completes a headline within the file with title "foo"
+
+If you don't see the literal display of your links like the above examples,
+call ~M-x org-toggle-link-display~
 
 Completions account for the current input. For example, for ~[[f|]]~, the
 completions (by default) only show for files with titles that start with "f".


### PR DESCRIPTION
- Fix missing '|' in the roam link.

- Add org-toggle-link-display to see literal link text instead of the
  description.

###### Motivation for this change
As a newbie to org-roam and a longtime user of org-mode, this was the only section of the doc that tripped me up so I'm fixing it for the next newbie.