### PR TITLE
(docs): Emphasize respect for freedom

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ solution for anyone already using Org-mode for their personal wiki.
   with the built-in graph visualization.
 - **Extensible and Powerful**: Leverage Emacs' fantastic text-editing interface,
   and the mature Emacs and Org-mode ecosystem of packages.
-- **Free and Open Source**: Org-roam is licensed under the GNU General Public
-  License version 3 or later.
+- **[Freedom-respecting](https://www.fsf.org/about/what-is-free-software) and Open Source**: Org-roam is licensed under the GNU General Public
+  License version 3 or later, protecting your right to use, modify, share, and contribute to the software.
 
 <p align="center">
   <img src="https://www.orgroam.com/img/screenshot.png" alt="Org-roam Screenshot" width="738">


### PR DESCRIPTION
###### Motivation for this change
Freedom is one of the fundamental practical and ethical advantages of org-roam and Emacs as a whole. You can always ask any programmer to add a feature. There is a guarantee that it has no surveillance. Fundamentally, it's more ethical and gives the user more control.

I wrote to Richard Stallman, original author of Emacs and author of the GPL:
>   > The word open-source is sometimes associated with the ideals of free
>   > software. So, I'll write "freedom-respecting and open-source" or "(aka open
>   > source)" or "(sometimes known as "open-source", a false flag movement by
>   > Microsoft)."

He replied with this:
> Those are subtly misleading.  How about this?
> 
>   freedom-respecting (and open source too)

Let's emphasize the control, customizability, reliability, etc. the user has by rewording the README to use the term "freedom-respecting."

Furthermore, Emacs is a flagship of the free software movement– Emacs was made to emphasize respect for freedom.