### PR TITLE
(fix): dailies: avoid assuming value of org-roam-dailies-directory

### DIFF
--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -59,18 +59,19 @@
   :type 'hook)
 
 (defcustom org-roam-dailies-capture-templates
-  '(("d" "default" entry (function org-roam-capture--get-point)
+  `(("d" "default" entry (function org-roam-capture--get-point)
      "* %?"
-     :file-name "daily/%<%Y-%m-%d>"
+     :file-name ,(concat org-roam-dailies-directory "%<%Y-%m-%d>")
      :head "#+title: %<%Y-%m-%d>\n"))
   "Capture templates for daily-notes in Org-roam."
   :group 'org-roam
   ;; Adapted from `org-capture-templates'
   :type
-  '(repeat
+  `(repeat
     (choice :value ("d" "default" plain (function org-roam-capture--get-point)
                     "%?"
-                    :file-name "daily/%<%Y-%m-%d>"
+                    :file-name ,(concat org-roam-dailies-directory
+					"%<%Y-%m-%d>")
                     :head "#+title: %<%Y-%m-%d>\n"
                     :unnarrowed t)
       (list :tag "Multikey description"
@@ -94,7 +95,8 @@ Template string   :\n%v")
             (const :format "" function)
             (function :tag "Template function ")))
         (const :format "File name format  :" :file-name)
-        (string :format " %v" :value "daily/%<%Y-%m-%d>")
+        (string :format " %v" :value ,(concat org-roam-dailies-directory
+					      "%<%Y-%m-%d>"))
         (const :format "Header format     :" :head)
         (string :format " %v" :value "#+title: ${title}\n")
         (plist :inline t


### PR DESCRIPTION
###### Motivation for this change

I noticed that org-roam-dailies-capture-templates assumes that org-roam-dailies-directory has its default value, but if the latter has been tweaked, then the templates are wrong.  This should fix it so long as the user sets the variable before org-roam.el is loaded (as I believe will happen if the variable has been customized).