### PR TITLE
Set ROAM_REFS during capture

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -267,7 +267,8 @@ the capture)."
              (pos (org-capture-get :exact-position))
              (id (with-current-buffer capture-buf
                    (org-with-point-at pos
-                     (org-id-get-create)))))
+                     (org-id-get-create)
+                     (org-set-property "ROAM_REFS" (org-roam-capture--get :ref))))))
         (pcase (org-roam-capture--get :finalize)
           ('find-file
            (switch-to-buffer capture-buf))
@@ -487,7 +488,8 @@ This function is used solely in Org-roam's capture templates: see
                      (org-roam-capture--fill-template (org-capture-get :template)))
     (org-roam-capture--put :file-path file-path
                            :finalize (or (org-capture-get :finalize)
-                                         (org-roam-capture--get :finalize)))
+                                         (org-roam-capture--get :finalize))
+                           :ref (cdr (assoc 'ref org-roam-capture--info)))
     (while org-roam-capture-additional-template-props
       (let ((prop (pop org-roam-capture-additional-template-props))
             (val (pop org-roam-capture-additional-template-props)))


### PR DESCRIPTION
###### Motivation for this change

The below commit allows for setting ROAM_REFS in the capture buffer from `org-roam-capture--info`. This is the first step toward re-enabling `org-roam-protocol` and `org-roam-bibtex`. Since an Org Roam file can have several refs, and it is in principle possible to capture into an existing file, the property should be appended rather than overwritten. As such, this is not ready yet for merging.
