### PR TITLE
Optimize filename normalize

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -234,6 +234,15 @@ Function should return a filename string based on title."
   :type 'function
   :group 'org-roam)
 
+(defcustom org-roam-slug--preserve-chars-from-normalization
+  '(;; For Japanese charecters
+    12441 ; U+3099 COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK
+    12442 ; U+309A COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+    )
+  "Characters to preserve from Unicode normalization for slug."
+  :type '(repeat character)
+  :group 'org-roam)
+
 (defcustom org-roam-title-sources '((title headline) alias)
   "The list of sources from which to retrieve a note title.
 Each element in the list is either:
@@ -794,7 +803,8 @@ Each ref is returned as a cons of its type and its key."
 (defun org-roam--title-to-slug (title)
   "Convert TITLE to a filename-suitable slug."
   (cl-flet* ((nonspacing-mark-p (char)
-                                (eq 'Mn (get-char-code-property char 'general-category)))
+                                (and (eq 'Mn (get-char-code-property char 'general-category))
+                                     (not (memq char org-roam-slug-preserve-chars-from-normalization))))
              (strip-nonspacing-marks (s)
                                      (ucs-normalize-NFC-string
                                       (apply #'string (seq-remove #'nonspacing-mark-p

--- a/org-roam.el
+++ b/org-roam.el
@@ -796,8 +796,9 @@ Each ref is returned as a cons of its type and its key."
   (cl-flet* ((nonspacing-mark-p (char)
                                 (eq 'Mn (get-char-code-property char 'general-category)))
              (strip-nonspacing-marks (s)
-                                     (apply #'string (seq-remove #'nonspacing-mark-p
-                                                                 (ucs-normalize-NFD-string s))))
+                                     (ucs-normalize-NFC-string
+                                      (apply #'string (seq-remove #'nonspacing-mark-p
+                                                                  (ucs-normalize-NFD-string s)))))
              (cl-replace (title pair)
                          (replace-regexp-in-string (car pair) (cdr pair) title)))
     (let* ((pairs `(("[^[:alnum:][:digit:]]" . "_")  ;; convert anything not alphanumeric

--- a/org-roam.el
+++ b/org-roam.el
@@ -234,12 +234,32 @@ Function should return a filename string based on title."
   :type 'function
   :group 'org-roam)
 
-(defcustom org-roam-slug--preserve-chars-from-normalization
-  '(;; For Japanese charecters
-    12441 ; U+3099 COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK
-    12442 ; U+309A COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+(defcustom org-roam-slug-trim-chars
+  '(;; Combining Diacritical Marks https://www.unicode.org/charts/PDF/U0300.pdf
+    768 ; U+0300 COMBINING GRAVE ACCENT
+    769 ; U+0301 COMBINING ACUTE ACCENT
+    770 ; U+0302 COMBINING CIRCUMFLEX ACCENT
+    771 ; U+0303 COMBINING TILDE
+    772 ; U+0304 COMBINING MACRON
+    774 ; U+0306 COMBINING BREVE
+    775 ; U+0307 COMBINING DOT ABOVE
+    776 ; U+0308 COMBINING DIAERESIS
+    777 ; U+0309 COMBINING HOOK ABOVE
+    778 ; U+030A COMBINING RING ABOVE
+    780 ; U+030C COMBINING CARON
+    795 ; U+031B COMBINING HORN
+    803 ; U+0323 COMBINING DOT BELOW
+    804 ; U+0324 COMBINING DIAERESIS BELOW
+    805 ; U+0325 COMBINING RING BELOW
+    807 ; U+0327 COMBINING CEDILLA
+    813 ; U+032D COMBINING CIRCUMFLEX ACCENT BELOW
+    814 ; U+032E COMBINING BREVE BELOW
+    816 ; U+0330 COMBINING TILDE BELOW
+    817 ; U+0331 COMBINING MACRON BELOW
     )
-  "Characters to preserve from Unicode normalization for slug."
+  "Characters to trim from Unicode normalization for slug.
+
+By default, the characters are specified to remove Diacritical Marks from the Latin alphabet."
   :type '(repeat character)
   :group 'org-roam)
 
@@ -803,8 +823,7 @@ Each ref is returned as a cons of its type and its key."
 (defun org-roam--title-to-slug (title)
   "Convert TITLE to a filename-suitable slug."
   (cl-flet* ((nonspacing-mark-p (char)
-                                (and (eq 'Mn (get-char-code-property char 'general-category))
-                                     (not (memq char org-roam-slug-preserve-chars-from-normalization))))
+                                (memq char org-roam-slug-trim-chars))
              (strip-nonspacing-marks (s)
                                      (ucs-normalize-NFC-string
                                       (apply #'string (seq-remove #'nonspacing-mark-p


### PR DESCRIPTION
The purpose of this patch is follows:

 1. Instead of removing all `Mn` (Non-spacing mark) letters, trim only the [diacritical characters](https://en.wikipedia.org/wiki/Diacritic) for the [Latin script](https://en.wikipedia.org/wiki/Latin-script_alphabet).
 2. After trimming the file name, normalize it again as NFC.

This patch is functionally compatible for users of English and European languages. This is an important improvement for Korean and Japanese users to use org-roam in their native language.

Fixes #1423

## Why

### About diacritical marks

The `Mn` category contains not only the Latin script (also known as the Roman alphabet) for European languages, but also the combining characters for so many languages. (See [List of Unicode Characters of Category “Nonspacing Mark”](https://www.compart.com/en/unicode/category/Mn))

For example, if we remove the [dakuten sign](https://en.wikipedia.org/wiki/Dakuten_and_handakuten) from "パンダ" (means "panda") in Japanese language, it becomes "ハンタ" (similar to "hunter").  The conversion is not completely incomprehensible, but it is more likely to be confused with other words and is so uncomfortable that the Japanese hesitate to use org-roam.

I have no knowledge other than Japanese, so I can't determine what kind of cognitive discomfort it will cause to speakers in other languages. 

Signs that should be omitted in other languages have to wait for user contributions, but are safer for us than the risk of breaking strings in unknown languages.

### About NFC

Unicode contains Latin alphabets as well as both [precomposed](https://en.wikipedia.org/wiki/Precomposed_character) and decomposed Korean and Japanese characters.  NFD normalization looks like ideal Unicode normalization, but today's popular operating systems assume that filenames entered for users are normalized by NFC. The biggest victim is [Hangul(Korean alphabet)](https://en.wikipedia.org/wiki/Hangul).

APFS, the file system for macOS, is called case-sensitive, but it's actually normalized by a variant of NFD.

```sh
% mkdir -p /tmp/unicode
% cd /tmp/unicode
% echo 'AAA' > a.txt
% cat A.TXT
AAA
% echo 'BBB' > 한글테스트.txt # use NFD file name
% cat 한글테스트.txt # use NFC file name
BBB
% ls
a.txt                                    한글테스트.txt
```

NFD filenames render nicely in the browser, but they look strange in terminals and Emacs.

<img width="474" alt="スクリーンショット 2021-04-05 4 52 12" src="https://user-images.githubusercontent.com/822086/113519963-c373a300-95ca-11eb-9a8b-b50e53201b5c.png">

In Korean, Japanese and other languages, creating a file with NFD-decomposed strings produces a strange looking file. The result depends on the file system and OS, but it is inconvenient for the user and it is desirable to normalize with NFC or NFKC.

Also, if we remove the Diacritical Marks used in European languages and Vietnamese that use the Latin alphabet, you can create concise filenames in ASCII, but not for other languages.  