### PR TITLE
fix: org-roam-node--completions #1467

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -613,7 +613,7 @@ is the `org-roam-node'."
                                   (candidate-main (org-roam-node--format-entry node (1- (frame-width))))
                                   (tag-str (org-roam--tags-to-str (org-roam-node-tags node))))
                        (cons (concat (propertize tag-str 'invisible t)
-                                     candidate-main
+                                     (propertize candidate-main 'node node)
                                      (propertize alias 'invisible t))
                              node)))))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -612,9 +612,9 @@ is the `org-roam-node'."
                                                               :tags (gethash id tags-table)))
                                   (candidate-main (org-roam-node--format-entry node (1- (frame-width))))
                                   (tag-str (org-roam--tags-to-str (org-roam-node-tags node))))
-                       (cons (concat (propertize tag-str 'invisible t)
+                       (cons (concat (propertize tag-str 'node node 'invisible t)
                                      (propertize candidate-main 'node node)
-                                     (propertize alias 'invisible t))
+                                     (propertize alias 'node node 'invisible t))
                              node)))))
 
 (defun org-roam-node-read (&optional initial-input filter-fn require-match)


### PR DESCRIPTION
###### Motivation for this change
@jethrokuan 

Thank you for f52c3a4.
`candidate-main` string also needs to pass node as `node` text-property.

I get the following error -- the error should not be vertico specific.

> post-command-hook (vertico--exhibit): (wrong-type-argument org-roam-node nil)

EDIT: The node prop needed for invisible text strings, too.