### PR TITLE
fix: filetags in capture #1470

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -279,8 +279,8 @@ If UPDATE-P is non-nil, first remove the file in the database."
              (level 0)
              (aliases (org-entry-get (point) "ROAM_ALIASES"))
              (tags (or org-file-tags
-                       (list (cadr (assoc "FILETAGS" (org-collect-keywords '("filetags"))
-                                    #'string-equal)))))
+                       (cdr (assoc "FILETAGS" (org-collect-keywords '("filetags"))
+                                    #'string-equal))))
              (refs (org-entry-get (point) "ROAM_REFS")))
         (org-roam-db-query
          [:insert :into nodes

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -278,7 +278,9 @@ If UPDATE-P is non-nil, first remove the file in the database."
              (deadline nil)
              (level 0)
              (aliases (org-entry-get (point) "ROAM_ALIASES"))
-             (tags org-file-tags)
+             (tags (or org-file-tags
+                       (list (cadr (assoc "FILETAGS" (org-collect-keywords '("filetags"))
+                                    #'string-equal)))))
              (refs (org-entry-get (point) "ROAM_REFS")))
         (org-roam-db-query
          [:insert :into nodes


### PR DESCRIPTION
###### Motivation for this change
See issue #1470 

Actually... This commit probably does not deal with multiple tags (sorry -- bad implementation).
Please use it as a clarification of the issue #1470; I am sure you have a better way to deal with it.
Thank you.

These functions didn't populate filetags during the capture process
- org-get-tags
- org-set-regexps-and-options 
