### PR TITLE
(feat) Make roam headline link completion robust #1472

### DIFF
--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -318,7 +318,7 @@ DESC is the link description."
                                 (if headline-only-p 1 0)))
                 (insert (concat (unless (string= link-type "roam") "roam:")
                                 (when headline-only-p "*")
-                                str))))))))
+                                (org-link-escape str)))))))))
 
 (provide 'org-roam-link)
 ;;; org-roam-link.el ends here


### PR DESCRIPTION
Fixes  #1472

###### Motivation for this change

Headlines that includes links to others should be handled properly.