### PR TITLE
Fix auto-save buffer in org-roam-doctor

### DIFF
--- a/org-roam-doctor.el
+++ b/org-roam-doctor.el
@@ -308,7 +308,8 @@ If CHECKALL, run the check for all Org-roam files."
         (let ((buf (find-file-noselect f)))
           (org-roam-doctor--check buf checkers)
           (unless (memq buf existing-buffers)
-            (save-buffer buf)
+            (with-current-buffer buf
+              (save-buffer))
             (kill-buffer buf))))))
   (org-roam-message "Linting completed."))
 


### PR DESCRIPTION
###### Motivation for this change
`save-buffer` does not take a buffer as an argument, it always acts on the current buffer. So save was not actually taking place. This fixes that issue.