### PR TITLE
speed up org-roam-db-sync by wrapping db activity in a transaction

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -435,18 +435,19 @@ If FORCE, force a rebuild of the cache from scratch."
                          contents-hash)
           (push file modified-files)))
       (remhash file current-files))
-    (if (fboundp 'dolist-with-progress-reporter)
-        (dolist-with-progress-reporter (file (hash-table-keys current-files))
-            "Clearing removed files..."
-          (org-roam-db-clear-file file))
-      (dolist (file (hash-table-keys current-files))
-        (org-roam-db-clear-file file)))
-    (if (fboundp 'dolist-with-progress-reporter)
-        (dolist-with-progress-reporter (file modified-files)
-            "Processing modified files..."
-          (org-roam-db-update-file file))
-      (dolist (file modified-files)
-        (org-roam-db-update-file file)))))
+    (emacsql-with-transaction (org-roam-db)
+      (if (fboundp 'dolist-with-progress-reporter)
+          (dolist-with-progress-reporter (file (hash-table-keys current-files))
+              "Clearing removed files..."
+            (org-roam-db-clear-file file))
+        (dolist (file (hash-table-keys current-files))
+          (org-roam-db-clear-file file)))
+      (if (fboundp 'dolist-with-progress-reporter)
+          (dolist-with-progress-reporter (file modified-files)
+              "Processing modified files..."
+            (org-roam-db-update-file file))
+        (dolist (file modified-files)
+          (org-roam-db-update-file file))))))
 
 (defun org-roam-db-update-file (&optional file-path)
   "Update Org-roam cache for FILE-PATH.


### PR DESCRIPTION
###### Motivation for this change
[copying the commit comment here]
In my case of testing with 8253 zettels (available on request if
anyone wants to test with them), this improves cleanup speed by 6x
and update speed by 2x.

Improvements will be smaller for smaller batches as this really just
removes the transaction overhead.