### PR TITLE
35% faster completion startup (on ~8300 files)

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -435,18 +435,19 @@ If FORCE, force a rebuild of the cache from scratch."
                          contents-hash)
           (push file modified-files)))
       (remhash file current-files))
-    (if (fboundp 'dolist-with-progress-reporter)
-        (dolist-with-progress-reporter (file (hash-table-keys current-files))
-            "Clearing removed files..."
-          (org-roam-db-clear-file file))
-      (dolist (file (hash-table-keys current-files))
-        (org-roam-db-clear-file file)))
-    (if (fboundp 'dolist-with-progress-reporter)
-        (dolist-with-progress-reporter (file modified-files)
-            "Processing modified files..."
-          (org-roam-db-update-file file))
-      (dolist (file modified-files)
-        (org-roam-db-update-file file)))))
+    (emacsql-with-transaction (org-roam-db)
+      (if (fboundp 'dolist-with-progress-reporter)
+          (dolist-with-progress-reporter (file (hash-table-keys current-files))
+              "Clearing removed files..."
+            (org-roam-db-clear-file file))
+        (dolist (file (hash-table-keys current-files))
+          (org-roam-db-clear-file file)))
+      (if (fboundp 'dolist-with-progress-reporter)
+          (dolist-with-progress-reporter (file modified-files)
+              "Processing modified files..."
+            (org-roam-db-update-file file))
+        (dolist (file modified-files)
+          (org-roam-db-update-file file))))))
 
 (defun org-roam-db-update-file (&optional file-path)
   "Update Org-roam cache for FILE-PATH.

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -156,20 +156,27 @@ Adapted from `s-format'."
          t t)
       (set-match-data saved-match-data))))
 
+(defvar org-roam--cached-display-format nil)
+
+(defun org-roam--clear-cached-display-format ()
+  (setq org-roam--cached-display-format nil))
+
 (defun org-roam--process-display-format (format)
   "Pre-calculate minimal widths needed by the FORMAT string."
-  (let* ((fields-width 0)
-         (string-width
-          (string-width
-           (org-roam-format
-            format
-            (lambda (field)
-              (setq fields-width
-                    (+ fields-width
-                       (string-to-number
-                        (or (cadr (split-string field ":"))
-                            "")))))))))
-    (cons format (+ fields-width string-width))))
+  (or org-roam--cached-display-format
+      (setq org-roam--cached-display-format
+            (let* ((fields-width 0)
+                   (string-width
+                    (string-width
+                     (org-roam-format
+                      format
+                      (lambda (field)
+                        (setq fields-width
+                              (+ fields-width
+                                 (string-to-number
+                                  (or (cadr (split-string field ":"))
+                                      "")))))))))
+              (cons format (+ fields-width string-width))))))
 
 ;;; Diagnostics
 ;;;###autoload

--- a/org-roam.el
+++ b/org-roam.el
@@ -621,6 +621,7 @@ Throw an error if multiple choices exist."
   "Return an alist for node completion.
 The car is the displayed title or alias for the node, and the cdr
 is the `org-roam-node'."
+  (org-roam--clear-cached-display-format)
   (let ((tags-table (org-roam--tags-table)))
     (cl-loop for row in (append
                          (org-roam-db-query [:select [file pos title title id properties olp]


### PR DESCRIPTION
Caching: make process-display-format cache its value
SQL: add index to DB, make SQL compute objects for query-nodes.
  Note that there is a dependency between the org-roam-node def and
  org-roam-query-nodes. This is indicated at both places in the code.