### PR TITLE
Prefer mapconcat over string-join

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -419,9 +419,9 @@ References from FILE are excluded."
     (let* ((titles (cons (org-roam-node-title node)
                          (org-roam-node-aliases node)))
            (rg-command (concat "rg -o --vimgrep -P -i "
-                               (string-join (mapcar (lambda (glob) (concat "-g " glob))
-                                                    (org-roam--list-files-search-globs
-                                                     org-roam-file-extensions)) " ")
+                               (mapconcat (lambda (glob) (concat "-g " glob))
+                                          (org-roam--list-files-search-globs org-roam-file-extensions)
+                                          " ")
                                (format " '\\[([^[]]++|(?R))*\\]%s' "
                                        (mapconcat (lambda (title)
                                                     (format "|(\\b%s\\b)" (shell-quote-argument title)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -509,9 +509,7 @@ nodes."
 
 (defun org-roam--tags-to-str (tags)
   "Convert list of TAGS into a string."
-  (string-join
-   (mapcar (lambda (s) (concat "#" s)) tags)
-   " "))
+  (mapconcat (lambda (s) (concat "#" s)) tags " "))
 
 (defun org-roam-node--format-entry (node width)
   "Formats NODE for display in the results list.
@@ -698,8 +696,7 @@ POINT is the point in buffer for the link.
 PROPERTIES contains properties about the link."
   (magit-insert-section section (org-roam-node-section)
     (let ((outline (if-let ((outline (plist-get properties :outline)))
-                       (string-join (mapcar #'org-link-display-format outline)
-                                    " > ")
+                       (mapconcat #'org-link-display-format outline " > ")
                      "Top")))
       (insert (concat (propertize (org-roam-node-title source-node)
                                   'font-lock-face 'org-roam-title)


### PR DESCRIPTION
###### Motivation for this change

Haven't benchmarked (the areas I changed did not seem to warrant it), but mapconcat should be slightly more performant than string-join, as it's implemented in C. Also a little cleaner than the `(string-join (mapcar ...` idiom.