### PR TITLE
Correction in doc: Elisp code in directory local variables will not be executed

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1625,8 +1625,8 @@ variable using directory-local variables. This is what ~.dir-locals.el~ may
 contain:
 
 #+BEGIN_SRC emacs-lisp
-  ((nil . ((org-roam-directory . (expand-file-name "."))
-           (org-roam-db-location . (expand-file-name "./org-roam.db")))))
+  ((nil . ((org-roam-directory . ".")
+           (org-roam-db-location . "./org-roam.db"))))
 #+END_SRC
 
 All files within that directory will be treated as their own separate set of


### PR DESCRIPTION
`expand-file-name` will not execute and the code itself will be stored as the values of the variables, since directory local variables is just a list and not elisp code to be executed. 