### PR TITLE
(fix) fix aliases lookup in org-roam-node-from-title-or-alias

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -614,8 +614,7 @@ Throw an error if multiple choices exist."
                                        :where (= title $s1)]
                                       s)
                    (org-roam-db-query [:select [node-id] :from aliases
-                                       :left :join nodes :on (= nodes:id aliases:node-id)
-                                       :where (= aliases:node-id $s1)]
+                                       :where (= alias $s1)]
                                       s)))))
     (cond
      ((seq-empty-p matches)


### PR DESCRIPTION
###### Motivation for this change

It should match by title instead of id and the left join is not needed
here as data is not used in any case.
