### PR TITLE
Custom graph filetype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - [#1352](https://github.com/org-roam/org-roam/pull/1352) prefer lower-case for roam_tag and roam_alias in interactive commands
+- [#1513](https://github.com/org-roam/org-roam/pull/1513) replaced hardcoded "svg" with defcustom org-roam-graph-filetype 
 
 ### Fixed
 - [#1281](https://github.com/org-roam/org-roam/pull/1281) fixed idle-timer not instantiated on `org-roam-mode`

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -61,6 +61,12 @@ It may be one of the following:
   :type 'string
   :group 'org-roam)
 
+(defcustom org-roam-graph-filetype "svg"
+  "File type to generate when producing graphs."
+  :type 'string
+  :group 'org-roam)
+
+
 (defcustom org-roam-graph-extra-config nil
   "Extra options passed to graphviz.
 Example:
@@ -238,12 +244,12 @@ CALLBACK is passed the graph file as its sole argument."
                            :group :by file]))
          (graph      (org-roam-graph--dot node-query))
          (temp-dot   (make-temp-file "graph." nil ".dot" graph))
-         (temp-graph (make-temp-file "graph." nil ".pdf")))
+         (temp-graph (make-temp-file "graph." nil (concat "." org-roam-graph-filetype))))
     (org-roam-message "building graph")
     (make-process
      :name "*org-roam-graph--build-process*"
      :buffer "*org-roam-graph--build-process*"
-     :command `(,org-roam-graph-executable ,temp-dot "-Tpdf" "-o" ,temp-graph)
+     :command `(,org-roam-graph-executable ,temp-dot "-T" ,org-roam-graph-filetype "-o" ,temp-graph)
      :sentinel (when callback
                  (lambda (process _event)
                    (when (= 0 (process-exit-status process))

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -238,12 +238,12 @@ CALLBACK is passed the graph file as its sole argument."
                            :group :by file]))
          (graph      (org-roam-graph--dot node-query))
          (temp-dot   (make-temp-file "graph." nil ".dot" graph))
-         (temp-graph (make-temp-file "graph." nil ".svg")))
+         (temp-graph (make-temp-file "graph." nil ".pdf")))
     (org-roam-message "building graph")
     (make-process
      :name "*org-roam-graph--build-process*"
      :buffer "*org-roam-graph--build-process*"
-     :command `(,org-roam-graph-executable ,temp-dot "-Tsvg" "-o" ,temp-graph)
+     :command `(,org-roam-graph-executable ,temp-dot "-Tpdf" "-o" ,temp-graph)
      :sentinel (when callback
                  (lambda (process _event)
                    (when (= 0 (process-exit-status process))


### PR DESCRIPTION
I wanted to print the graphs that are generated on multiple sheets of paper, since they were getting too large for a single sheet. I learned that one easy way to do this is to create a PDF, and then use a program like Acrobat Reader that can 'posterize' your document by printing it over n x m pages. 

Then I noticed that "svg" was hard-coded in this file, so I thought it made sense to be a customizable variable. Only 2 lines of code needed to be changed, and 6 added, to affect this change. 

The issue I'd previously posted about this:  https://github.com/org-roam/org-roam/issues/1510

The discussion on Discourse: https://org-roam.discourse.group/t/allow-graph-output-filetype-to-be-configurable-currently-svg-is-hardcoded/1552/5