### PR TITLE
fix org-roam-capture--goto-location

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -570,8 +570,9 @@ Return the ID of the location."
          (org-end-of-subtree t t))))
     (save-excursion
       (goto-char p)
-      (org-id-get-create)
-      (run-hooks 'org-roam-capture-new-node-hook))))
+      (prog1
+          (org-id-get-create)
+        (run-hooks 'org-roam-capture-new-node-hook)))))
 
 (defun org-roam-capture-find-or-create-olp (olp)
   "Return a marker pointing to the entry at OLP in the current buffer.


### PR DESCRIPTION
Fix regression introduced in 7ed51329.
The function should return an ID.