### PR TITLE
(fix) setting non-blank keyword value

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -811,7 +811,7 @@ If the property is already set, it's value is replaced."
   (org-with-point-at 1
     (let ((case-fold-search t))
       (if (re-search-forward (concat "^#\\+" key ":\\(.*\\)") (point-max) t)
-          (if (= (string-blank-p value) 0)
+          (if (string-blank-p value)
               (kill-whole-line)
             (replace-match (concat " " value) 'fixedcase nil nil 1))
         (while (and (not (eobp))


### PR DESCRIPTION
###### Motivation for this change

`string-blank-p` returns a non-nil value if the string is blank, and
nil (which you can't compare to 0) otherwise.
