### PR TITLE
Save before link updates when renaming notes

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -227,7 +227,8 @@ Template string   :\n%v")
      :head "#+title: ${title}\n#+roam_key: ${ref}"
      :unnarrowed t))
   "The Org-roam templates used during a capture from the roam-ref protocol.
-Details on how to specify for the template is given in `org-roam-capture-templates'."
+Details on how to specify for the template is given in
+`org-roam-capture-templates'."
   :group 'org-roam
   ;; Adapted from `org-capture-templates'
   :type

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -101,7 +101,8 @@ so that multi-directories are updated.")
   Update the database immediately upon file changes.
 
 `idle-timer'
-  Updates the database if dirty, if Emacs idles for `org-roam-db-update-idle-seconds'."
+  Updates the database if dirty, if Emacs idles for
+  `org-roam-db-update-idle-seconds'."
   :type '(choice (const :tag "idle-timer" idle-timer)
 		 (const :tag "immediate" immediate))
   :group 'org-roam)

--- a/org-roam-faces.el
+++ b/org-roam-faces.el
@@ -67,7 +67,7 @@ during an `org-roam-capture'."
 
 (defface org-roam-dailies-calendar-note
   '((t :inherit (org-roam-link) :underline nil))
-  "Face for dates with a daily-note in the calendar"
+  "Face for dates with a daily-note in the calendar."
   :group 'org-roam-faces)
 
 ;;; _

--- a/org-roam-link.el
+++ b/org-roam-link.el
@@ -48,7 +48,7 @@
 (declare-function org-roam-format-link                  "org-roam")
 
 (defcustom org-roam-link-auto-replace t
-  "When non-nil, replace Org-roam's roam links with file or id links whenever possible."
+  "When non-nil, replace Org-roam's roam links with file/id equivalents."
   :group 'org-roam
   :type 'boolean)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -259,7 +259,8 @@ Function should return a filename string based on title."
     )
   "Characters to trim from Unicode normalization for slug.
 
-By default, the characters are specified to remove Diacritical Marks from the Latin alphabet."
+By default, the characters are specified to remove Diacritical
+Marks from the Latin alphabet."
   :type '(repeat character)
   :group 'org-roam)
 
@@ -305,7 +306,9 @@ The currently supported symbols are:
   :group 'org-roam)
 
 (defcustom org-roam-enable-headline-linking t
-  "Enable linking to headlines, which includes automatic :ID: creation and scanning of :ID:s for org-roam database."
+  "Enable linking to headlines.
+This includes automatic :ID: creation and scanning of :ID:s for
+org-roam database."
   :type 'boolean
   :group 'org-roam)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1400,6 +1400,8 @@ OLD-TITLE, and replace the link descriptions with the NEW-TITLE
 if applicable.
 
 To be added to `org-roam-title-change-hook'."
+  (when (save-some-buffers nil #'org-roam--org-roam-buffer-p)
+    (org-roam-db-update))
   (let* ((current-path (buffer-file-name (buffer-base-buffer)))
          (files-affected (org-roam-db-query [:select :distinct [source]
                                              :from links

--- a/org-roam.el
+++ b/org-roam.el
@@ -387,6 +387,16 @@ If FILE is not specified, use the current buffer's file-path."
                  (string-match-p org-roam-file-exclude-regexp path)))
        (f-descendant-of-p path (expand-file-name org-roam-directory))))))
 
+(defun org-roam--org-roam-buffer-p (&optional buffer)
+  "Return t if BUFFER is accessing a part of Org-roam system.
+If BUFFER is not specified, use the current buffer."
+  (let* ((buffer (or buffer
+                    (current-buffer)))
+         (path (-> buffer
+                   (buffer-base-buffer)
+                   (buffer-file-name))))
+    (org-roam--org-roam-file-p path)))
+
 (defun org-roam--shell-command-files (cmd)
   "Run CMD in the shell and return a list of files. If no files are found, an empty list is returned."
   (--> cmd

--- a/org-roam.el
+++ b/org-roam.el
@@ -1390,7 +1390,7 @@ OLD-TITLE, and replace the link descriptions with the NEW-TITLE
 if applicable.
 
 To be added to `org-roam-title-change-hook'."
-  (let* ((current-path (buffer-file-name))
+  (let* ((current-path (buffer-file-name (buffer-base-buffer)))
          (files-affected (org-roam-db-query [:select :distinct [source]
                                              :from links
                                              :where (= dest $s1)]

--- a/org-roam.el
+++ b/org-roam.el
@@ -1009,6 +1009,13 @@ If BUFFER is not specified, use the current buffer."
   (--filter (org-roam--org-roam-buffer-p it)
             (buffer-list)))
 
+(defun org-roam--save-buffers (&optional ask update)
+  "Save all Org-roam buffers.
+When ASK is non-nil, ask whether the buffers should be saved.
+When UPDATE is non-nil, update the database after."
+  (save-some-buffers (not ask) #'org-roam--org-roam-buffer-p)
+  (when update (org-roam-db-update)))
+
 ;;; org-roam-backlinks-mode
 (define-minor-mode org-roam-backlinks-mode
   "Minor mode for the `org-roam-buffer'.
@@ -1398,8 +1405,6 @@ OLD-TITLE, and replace the link descriptions with the NEW-TITLE
 if applicable.
 
 To be added to `org-roam-title-change-hook'."
-  (when (save-some-buffers nil #'org-roam--org-roam-buffer-p)
-    (org-roam-db-update))
   (let* ((current-path (buffer-file-name (buffer-base-buffer)))
          (files-affected (org-roam-db-query [:select :distinct [source]
                                              :from links
@@ -1417,6 +1422,7 @@ current filename, the new slug is computed with NEW-TITLE, and
 that portion of the filename is renamed.
 
 To be added to `org-roam-title-change-hook'."
+  (org-roam--save-buffers)
   (when org-roam-rename-file-on-title-change
     (let* ((old-slug (funcall org-roam-title-to-slug-function old-title))
            (file (buffer-file-name (buffer-base-buffer)))


### PR DESCRIPTION
`org-roam-title-change-hook` conks out when links are added to an unsaved buffer.

Reproducible steps:
1. Go to an existing note `foo`
2. `org-roam-insert` → Create a new file `bar`
3. Validate the capture; notice that the link was added in `foo`, but the the buffer was not saved.
4. Go to `bar`
5. Rename the note to `baz` (via the title)
6. Link in `foo` is not updated

This is because we're retrieving `files-affected` from the db:
https://github.com/org-roam/org-roam/blob/89944230798e4a63b8ce5c345ac22c337414b734/org-roam.el#L1425

The db is updated prior to that, but it only includes what was saved:
https://github.com/org-roam/org-roam/blob/02e35e3b01914a0dceb39a116a978f523d5f4272/org-roam.el#L1436

I've elected to save the modified org-roam buffers prior to updating the db:
https://github.com/org-roam/org-roam/blob/89944230798e4a63b8ce5c345ac22c337414b734/org-roam.el#L1425

I've modularised the code to avoid repetitions elsewhere:
https://github.com/org-roam/org-roam/blob/89944230798e4a63b8ce5c345ac22c337414b734/org-roam.el#L1007-L1010

Also fixed a couple of docstrings which `checkdoc` didn't like.