### PR TITLE
(fix): tags: fix vanilla option

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -749,6 +749,7 @@ tag."
 (defun org-roam--extract-tags-vanilla (_file)
   "Extract vanilla `org-mode' tags.
 This includes all tags used in the buffer."
+  (org-set-regexps-and-options 'tags-only)
   (-flatten (org-get-buffer-tags)))
 
 (defun org-roam--extract-tags (&optional file)


### PR DESCRIPTION
###### Motivation for this change

Set `org-file-tags` before pulling tags from buffer. Should fix the
'vanilla option in `org-roam-tag-sources`