### PR TITLE
(feat) allow to override node id during capture

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -623,6 +623,9 @@ Return the ID of the location."
          (org-end-of-subtree t t))))
     (save-excursion
       (goto-char p)
+      (when-let* ((node org-roam-capture--node)
+                  (id (org-roam-node-id node)))
+        (org-entry-put p "ID" id))
       (prog1
           (org-id-get-create)
         (run-hooks 'org-roam-capture-new-node-hook)))))


### PR DESCRIPTION
###### Motivation for this change

Sometimes it is useful to provide not only the title of captured node,
but an ID:

```emacs-lisp
(org-roam-capture-
 :node (org-roam-node-create
        :id some-id
        :title some-title))
```
