### PR TITLE
(feat) allow to provide custom finalize functions

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -483,8 +483,10 @@ This function is to be called in the Org-capture finalization process."
           (kill-buffer (find-buffer-visiting new-file)))
         (delete-file new-file))
     (when-let ((finalize (org-roam-capture--get :finalize)))
-      (funcall (intern (concat "org-roam-capture--finalize-"
-                               (symbol-name (org-roam-capture--get :finalize)))))))
+      (if (functionp finalize)
+          (funcall finalize)
+        (funcall (intern (concat "org-roam-capture--finalize-"
+                                 (symbol-name finalize)))))))
   (remove-hook 'org-capture-after-finalize-hook #'org-roam-capture--finalize))
 
 (defun org-roam-capture--install-finalize ()


### PR DESCRIPTION
###### Motivation for this change

Unless `:immediate-finish` is non-nil, capture process is asynchronous, meaning that there is no way to do something AFTER the note is created. There is `org-roam-capture-new-node-hook`, but it's being called to early, during the capture process and the hook is not easy to configure for one specific capture.

So `org-roam` could provide a finalization hook in addition to `org-capture-after-finalize-hook`, but I still love the idea to be able to configure finalization per capture.