### PR TITLE
fix org-roam-db-insert-aliases

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -373,13 +373,12 @@ If UPDATE-P is non-nil, first remove the file in the database."
 
 (defun org-roam-db-insert-aliases ()
   "Insert aliases for node at point into Org-roam cache."
-  (when-let ((file (buffer-file-name (buffer-base-buffer)))
-             (node-id (org-id-get))
+  (when-let ((node-id (org-id-get))
              (aliases (org-entry-get (point) "ROAM_ALIASES")))
     (org-roam-db-query [:insert :into aliases
                         :values $v1]
                        (mapcar (lambda (alias)
-                                 (vector file node-id alias))
+                                 (vector node-id alias))
                                (split-string-and-unquote aliases)))))
 
 (defun org-roam-db-insert-tags ()


### PR DESCRIPTION
###### Motivation for this change

1. Add an alias to a headline node by `org-roam-alias-add`
2. Save the buffer with `debug-on-error` enabled

=> error "table aliases has 2 columns but 3 values were supplied"
