### PR TITLE
(fix) add :region to capture keywords

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -56,7 +56,7 @@ during the Org-roam capture process.")
 This variable is populated dynamically, and is only non-nil
 during the Org-roam capture process.")
 
-(defconst org-roam-capture--template-keywords '(:if-new :id :link-description :call-location)
+(defconst org-roam-capture--template-keywords '(:if-new :id :link-description :call-location :region)
   "Keywords used in `org-roam-capture-templates' specific to Org-roam.")
 
 (defcustom org-roam-capture-templates


### PR DESCRIPTION
###### Motivation for this change

Unless `:region` is part of this list, it's the value is not put into
the context using `org-roam-capture--put` making it inaccessible via
`org-roam-capture--get`, meaning that, for example,
`org-roam-node-insert` doesn't replace selected region, but instead
simply appends a link to selected region, which is not desired
intention.

