### PR TITLE
(fix) allow to insert with no active region

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -826,11 +826,12 @@ which takes as its argument an alist of path-completions."
                          description)))
             (org-roam-capture-
              :node node
-             :props (list :region (when (and beg end)
-                                    (cons beg end))
-                          :insert-at (point-marker)
-                          :link-description description
-                          :finalize 'insert-link)))))
+             :props (append
+                     (when (and beg end)
+                       (list :region (cons beg end)))
+                     (list :insert-at (point-marker)
+                           :link-description description
+                           :finalize 'insert-link))))))
     (deactivate-mark)))
 
 ;;;###autoload


### PR DESCRIPTION
###### Motivation for this change

Seems like I love to cause issues in this repository. I am sorry! 

Fix looks ugly, there might be a better solution (e.g. by having optional/nil-able values). This just to stop the bleeding :) 

See https://github.com/org-roam/org-roam/pull/1536#issuecomment-851036487 for explanation. Found in https://github.com/d12frosted/vulpea/runs/2705470297. 