### PR TITLE
Allow setting #+roam_alias and #+roam_tag on multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - [#1352](https://github.com/org-roam/org-roam/pull/1352) prefer lower-case for roam_tag and roam_alias in interactive commands
 - [#1513](https://github.com/org-roam/org-roam/pull/1513) replaced hardcoded "svg" with defcustom org-roam-graph-filetype 
+- [#1540](https://github.com/org-roam/org-roam/pull/1540) allow `roam_tag` and `roam_alias` to be specified on multiple lines
 
 ### Fixed
 - [#1281](https://github.com/org-roam/org-roam/pull/1281) fixed idle-timer not instantiated on `org-roam-mode`

--- a/tests/roam-files/tags/tag.org
+++ b/tests/roam-files/tags/tag.org
@@ -1,4 +1,5 @@
 #+roam_tags: "t1" "t2 with space" t3
+#+roam_tags: "t4 second-line"
 #+title: Tags
 
 This file is used to test functionality for =(org-roam--extract-tags)=

--- a/tests/roam-files/titles/aliases.org
+++ b/tests/roam-files/titles/aliases.org
@@ -1,1 +1,2 @@
 #+roam_alias: "roam" "alias"
+#+roam_alias: "second" "line"

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -126,7 +126,7 @@
       (expect (test #'org-roam--extract-titles-alias
                     "titles/aliases.org")
               :to-equal
-              '("roam" "alias"))
+              '("roam" "alias" "second" "line"))
       (expect (test #'org-roam--extract-titles-alias
                     "titles/headline.org")
               :to-equal
@@ -192,7 +192,7 @@
       (expect (test #'org-roam--extract-tags-prop
                     "tags/tag.org")
               :to-equal
-              '("t1" "t2 with space" "t3"))
+              '("t1" "t2 with space" "t3" "t4 second-line"))
       (expect (test #'org-roam--extract-tags-prop
                     "tags/no_tag.org")
               :to-equal
@@ -246,13 +246,13 @@
                   (test #'org-roam--extract-tags
                         "tags/tag.org"))
                 :to-equal
-                '("t1" "t2 with space" "t3")))
+                '("t1" "t2 with space" "t3" "t4 second-line")))
       (it "'(prop all-directories)"
         (expect (let ((org-roam-tag-sources '(prop all-directories)))
                   (test #'org-roam--extract-tags
                         "tags/tag.org"))
                 :to-equal
-                '("t1" "t2 with space" "t3" "tags"))))))
+                '("t1" "t2 with space" "t3" "t4 second-line" "tags"))))))
 
 (describe "ID extraction"
   (before-all


### PR DESCRIPTION
###### Motivation for this change

This brings them more in line with how other Org keywords, such as `#+PROPERTY`, are declared.

Previously

    #+roam_alias: abc def
    #+roam_alias: ghi

would result in only the last one ("ghi") being extracted. This PR makes it so that `("abc" "def" "ghi")` are all extracted.

* org-roam.el
  - (org-roam--extract-tags-prop, org-roam--extract-titles-alias): Accept and return all values in a list, not just from one line.
  - (org-roam--extract-prop-as-list): New function. List prop extraction refactored from `org-roam--extract-tags-prop` and `org-roam--extract-titles-alias`
* tests/test-org-roam.el: Add tests for defining tags and aliases in multiple lines