### PR TITLE
(fix): files not excluded when org-roam-list-files-commands is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#1375](https://github.com/org-roam/org-roam/pull/1375) fix org-roam-protocol to use existing ref file 
 - [#1403](https://github.com/org-roam/org-roam/issues/1403) fixed inconsistency between how we write and read props like alias and tags
 - [#1409](https://github.com/org-roam/org-roam/issues/1398) prevent inclusion of non-org-roam files in `org-roam-dailies--list-files`
+- [#1542](https://github.com/org-roam/org-roam/issues/1542) fix files not excluded when `org-roam-list-files-commands` is nil
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -485,7 +485,8 @@ recursion."
   (let ((regex (concat "\\.\\(?:"(mapconcat #'regexp-quote org-roam-file-extensions "\\|" )"\\)\\(?:\\.gpg\\)?\\'"))
         result)
     (dolist (file (org-roam--directory-files-recursively dir regex nil nil t) result)
-      (when (and (file-readable-p file) (org-roam--org-file-p file))
+      (when (and (file-readable-p file)
+                 (org-roam--org-roam-file-p file))
         (push file result)))))
 
 (defun org-roam--list-files (dir)


### PR DESCRIPTION
###### Motivation for this change

When `org-roam-list-files-commands` is nil and `org-roam--list-files-elisp` is used to list files, files excluded via `org-roam-file-exclude-regexp` still show up.

When using `rg` or `find` this doesn't happen, as `org-roam--list-files` filters their results with `org-roam--org-roam-file-p`.