### PR TITLE
Add options for browsing a published repo via the graphviz output

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -995,6 +995,26 @@ for customizable options.
   Extra options for citation edges in the graphviz output.
   Example: ~'(("color" . "red"))~
 
+- User Option: org-roam-graph-url-extension
+
+  Change the file extension of the URLs linked to in the graphviz
+  output. Useful if you will be browsing a published repository using
+  the graph. See also: org-roam-graph-url-prefix
+
+#+BEGIN_EXAMPLE
+    (setq org-roam-graph-url-extension "html")
+#+END_EXAMPLE
+
+- User Option: org-roam-graph-url-prefix
+
+  Change the URL prefix of the URLs linked to in the graphviz
+  output. Useful if you will be browsing a published repository using
+  the graph. See also: org-roam-graph-url-extension
+
+#+BEGIN_EXAMPLE
+    (setq org-roam-graph-url-prefix "http://127.0.0.1:12345")
+#+END_EXAMPLE
+
 ** Excluding Nodes and Edges
 
 One may want to exclude certain files to declutter the graph.


### PR DESCRIPTION
###### Motivation for this change

Introduce two configuration variables to allow exporting of the graphviz output with URLs that link to a published repository.

See discussion here:
https://org-roam.discourse.group/t/script-to-convert-graph-for-offline-mobile-browsing/1674