### PR TITLE
(fix): Fix invalid cutomization types

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -320,13 +320,13 @@ streamlined user experience in Org-roam."
                                                         (const :format "" file+olp)
                                                         (string :tag "  File")
                                                         (list :tag "Outline path"
-                                                              (repeat string :tag "Headline")))
+                                                              (repeat (string :tag "Headline"))))
                                                   (list :tag "File & Head Content & Outline path"
                                                         (const :format "" file+head+olp)
                                                         (string :tag "  File")
                                                         (string :tag "  Head Content")
                                                         (list :tag "Outline path"
-                                                              (repeat string :tag "Headline")))))
+                                                              (repeat (string :tag "Headline"))))))
                                          ((const :format "%v " :prepend) (const t))
                                          ((const :format "%v " :immediate-finish) (const t))
                                          ((const :format "%v " :jump-to-captured) (const t))
@@ -391,13 +391,13 @@ See `org-roam-capture-templates' for the template documentation."
                                                         (const :format "" file+olp)
                                                         (string :tag "  File")
                                                         (list :tag "Outline path"
-                                                              (repeat string :tag "Headline")))
+                                                              (repeat (string :tag "Headline"))))
                                                   (list :tag "File & Head Content & Outline path"
                                                         (const :format "" file+head+olp)
                                                         (string :tag "  File")
                                                         (string :tag "  Head Content")
                                                         (list :tag "Outline path"
-                                                              (repeat string :tag "Headline")))))
+                                                              (repeat (string :tag "Headline"))))))
                                          ((const :format "%v " :prepend) (const t))
                                          ((const :format "%v " :immediate-finish) (const t))
                                          ((const :format "%v " :jump-to-captured) (const t))

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -105,13 +105,13 @@ See `org-roam-capture-templates' for the template documentation."
                                                         (const :format "" file+olp)
                                                         (string :tag "  File")
                                                         (list :tag "Outline path"
-                                                              (repeat string :tag "Headline")))
+                                                              (repeat (string :tag "Headline"))))
                                                   (list :tag "File & Head Content & Outline path"
                                                         (const :format "" file+head+olp)
                                                         (string :tag "  File")
                                                         (string :tag "  Head Content")
                                                         (list :tag "Outline path"
-                                                              (repeat string :tag "Headline")))))
+                                                              (repeat (string :tag "Headline"))))))
                                          ((const :format "%v " :prepend) (const t))
                                          ((const :format "%v " :immediate-finish) (const t))
                                          ((const :format "%v " :jump-to-captured) (const t))


### PR DESCRIPTION
This commit fixes the currently invalid definitions of the customization types.

The current error can be reproduced by:

1. Running `org-roam-setup`
2. Starting `M-x customize`
3. Searching for "org-roam"

The error (truncated) should look like this:
``` emacs-lisp
Debugger entered--Lisp error: (wrong-type-argument listp "Headline")
  widget-convert("Headline")
  mapcar(widget-convert (string :tag "Headline"))
  widget-types-convert-widget((repeat :args (string :tag "Headline")))
  widget-convert((repeat string :tag "Headline"))
  mapcar(widget-convert ((repeat string :tag "Headline")))
  widget-types-convert-widget((list :tag "Outline path" :args ((repeat string :tag "Headline"))))
  widget-convert((list :tag "Outline path" (repeat string :tag "Headline")))
  ...
```