### PR TITLE
Add a require for org-roam-protocol back in

### DIFF
--- a/org-roam-protocol.el
+++ b/org-roam-protocol.el
@@ -36,7 +36,7 @@
 ;;
 ;;; Code:
 (require 'org-protocol)
-(require 'org-roam)
+;; (require 'org-roam)
 (eval-when-compile
   (require 'org-roam-macs))
 (require 'ol) ;; for org-link-decode

--- a/org-roam.el
+++ b/org-roam.el
@@ -58,6 +58,7 @@
 (require 'org-roam-capture)
 (require 'org-roam-dailies)
 (require 'org-roam-db)
+(require 'org-roam-protocol)
 
 ;;; Declarations
 ;; From org-ref-core.el


### PR DESCRIPTION
I am probably missing something, but I couldn't get roam-ref org-protocol links to work until I added this require back in.

###### Motivation for this change

org-roam-protocol is nice and seems to work as long as it's included?