### PR TITLE
Encrypt specific capture templates

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -618,7 +618,8 @@ the default template, reproduced below.
        "%?"
        :file-name "%<%Y%m%d%H%M%S>-${slug}"
        :head "#+title: ${title}\n"
-       :unnarrowed t)
+       :unnarrowed t
+       :encrypt-file t)
 #+END_SRC
 
 1. The template has short key ~"d"~. If you have only one template, org-roam
@@ -640,6 +641,8 @@ the default template, reproduced below.
    inserted.
 8. ~:unnarrowed t~ tells org-capture to show the contents for the whole
    file, rather than narrowing to just the entry.
+9. ~:encrypt-file t~ tells to encrypt file if doesn't exist. This is useful to
+   encrypt only specific capture template files.
 
 Other options you may want to learn about include ~:immediate-finish~.
 
@@ -912,6 +915,9 @@ GPG), which can be enabled for all new files by setting ~org-roam-encrypt-files~
 to ~t~. When enabled, new files are created with the ~.org.gpg~ extension and
 decryption are handled automatically by EasyPG.
 
+If you want to encrypt, specific capture templates, you can also set
+~:encrypt-file~ to ~t~ in the org-roam-capture-templates list.
+
 Note that Emacs will prompt for a password for encrypted files during cache
 updates if it requires reading the encrypted file. To reduce the number of
 password prompts, you may wish to cache the password.
@@ -919,6 +925,11 @@ password prompts, you may wish to cache the password.
 - User Option: org-roam-encrypt-files
 
   Whether to encrypt new files. If true, create files with .org.gpg extension.
+
+- Capture Template Keyword: :encrypt-file
+
+  Whether to encrypt new files for specified capture template. If true, create
+  files with .org.gpg extension.
 
 * Graphing
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -77,7 +77,7 @@ note with the given `ref'.")
 (defvar org-roam-capture-additional-template-props nil
   "Additional props to be added to the Org-roam template.")
 
-(defconst org-roam-capture--template-keywords '(:file-name :head :olp)
+(defconst org-roam-capture--template-keywords '(:file-name :head :olp :encrypt-file)
   "Keywords used in `org-roam-capture-templates' specific to Org-roam.")
 
 (defcustom org-roam-capture-templates
@@ -391,13 +391,13 @@ The file is saved if the original value of :no-save is not t and
     (with-current-buffer (org-capture-get :buffer)
       (save-buffer)))))
 
-(defun org-roam-capture--get-file-path (basename)
+(defun org-roam-capture--get-file-path (basename encrypt-file)
   "Return path for Org-roam file with BASENAME."
   (let* ((ext (or (car org-roam-file-extensions)
                   "org"))
          (file (concat basename "." ext)))
     (expand-file-name
-     (if org-roam-encrypt-files
+     (if encrypt-file
          (concat file ".gpg")
        file)
      org-roam-directory)))
@@ -426,7 +426,8 @@ the file if the original value of :no-save is not t and
                          (user-error "Template needs to specify `:file-name'")))
          (new-id (s-trim (org-roam-capture--fill-template
                           name-templ)))
-         (file-path (org-roam-capture--get-file-path new-id))
+         (file-path (org-roam-capture--get-file-path new-id (or org-roam-encrypt-files
+                                                                (org-roam-capture--get :encrypt-file))))
          (roam-head (or (org-roam-capture--get :head)
                         ""))
          (org-template (org-capture-get :template))


### PR DESCRIPTION
###### Motivation for this change

Currently encryption behavior is globally controlled via org-roam-encrypt-files, and there isn't flexibility to control encryption for specific capture templates.

This change introduces a `:encrypt-file` keyword in org-roam-capture-templates, which can configure encryption for specific capture templates. 

