### PR TITLE
(dev) remove irrelevant note about refs missing their type

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -743,8 +743,6 @@ GROUP BY id")))
                                                                         :olp olp
                                                                         :tags tags
                                                                         :refs refs))
-                                                ;; NOTE: refs here do not have their type
-                                                ;; (e.g. //google.com, not http://google.com)
                                                 all-titles)))
                       (mapcar #'org-roam-node--to-candidate nodes)))))
 


### PR DESCRIPTION
###### Motivation for this change
