### PR TITLE
Display roam buffer after setting current node

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -222,9 +222,9 @@ Valid states are 'visible, 'exists and 'none."
        (remove-hook 'post-command-hook #'org-roam-buffer--post-command-h)))
     ((or 'exists 'none)
      (progn
-       (display-buffer (get-buffer-create org-roam-buffer))
        (setq org-roam-current-node (org-roam-node-at-point)
              org-roam-current-directory org-roam-directory)
+       (display-buffer (get-buffer-create org-roam-buffer))
        (org-roam-buffer-persistent-redisplay)))))
 
 (defun org-roam-buffer-persistent-redisplay ()


### PR DESCRIPTION
First call to `org-roam-buffer-toggle` would display the buffer empty, forcing to switch back to the note buffer to see any backlinks. Just swapping lines to set the current node while we're still in the note buffer, and then display the roam buffer.