### PR TITLE
Inhibit org-capture from setting :exact-position by default

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -617,7 +617,6 @@ Return the ID of the location."
            ;; Current date, possibly corrected for late night
            ;; workers.
            (org-today)))))
-       (org-end-of-subtree t t)
        (setq p (point)))
       (`(node ,title-or-id)
        ;; first try to get ID, then try to get title/alias
@@ -626,8 +625,7 @@ Return the ID of the location."
                        (user-error "No node with title or id \"%s\" title-or-id"))))
          (set-buffer (org-capture-target-buffer (org-roam-node-file node)))
          (goto-char (org-roam-node-point node))
-         (setq p (org-roam-node-point node))
-         (org-end-of-subtree t t))))
+         (setq p (org-roam-node-point node)))))
     (save-excursion
       (goto-char p)
       (when-let* ((node org-roam-capture--node)
@@ -680,7 +678,9 @@ you can catch it with `condition-case'."
        (setq lmin (1+ flevel) lmax (+ lmin (if org-odd-levels-only 1 0)))
        (setq start found
              end (save-excursion (org-end-of-subtree t t))))
-     (copy-marker end))))
+     (if (org-at-heading-p)
+         (point-marker)
+       (copy-marker end)))))
 
 (defun org-roam-capture--get-node-from-ref (ref)
   "Return the node from reference REF."


### PR DESCRIPTION
`org-capture-set-target-location` will always try to set `:exact-position` for `function` based capture targets, which is what `org-roam-capture--get-point` is.

The problem with this is that `:exact-position` doesn't play well with various capture `type`s and it breaks `entry` based capture templates from proper insertion. The major reason for this is a conflict between `:exact-position` and `:target-entry-p` in org-capture, which conditionally compete with each other[0]. In `org-capture-set-target-location` only a very small subset of all the possible targets set `:exact-position`, and unfortunately `function` target is is one of them.

This won't prohibit org-roam's based capture targets from setting `:exact-position` for targets that would actually need it[1], but would inhibit org-capture from setting the `:exact-position` by default, when `org-roam-capture-` is running.

[0]: See `org-capture-place-{entry,item,table-line,plain-text}` and `org-capture-set-target-location` for how this is implemented.

[1]: This would be accomplished similarly to how `org-capture-set-target-location` does so.

###### Motivation for this change
This change introduces a hacky workaround for org-capture itself and hence, some tech debt. The thing is, this hack is a simplest way to tape everything to each other for a proper functionality of various combinations of `type`x`target` templates, while at the same time not requiring significant changes to the codebase. I see a 2 different paths towards a "clean" solution that can be taken in future:

- Request from `org-mode` maintainers to either, remove [this line](https://code.orgmode.org/bzg/org-mode/src/fdb98a436bbdb86834af08c168c3bcbcc73d349c/lisp/org-capture.el#L1072) with the motivation that the user should be in full-control of things whenever he uses `function` as capture target, or request them to introduce new target that would do the same thing without breaking existing target (and possibly deprecate the old one). In both of these cases `org-roam` would be able to remove the hack and keep the codebase intact.
- Rewrite a huge chunk of `org-roam-capture` to either, use an advice around `org-capture-set-target-location` or by `cl-letf`ing it from `org-roam-capture-`. The problem with both of these options is not just the cost of the rewrite, but also extra costs of maintaining this, where the newly introduced function would need to replicate what `org-capture-set-target-location` does, which can also introduce conflicts for people with different versions of org-mode.

Merging this should close #1566 and prevent similar new issues for other unreported `type`x`target` captures.
