### PR TITLE
auto refresh for org-roam-buffer-toggle

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -224,6 +224,7 @@ Valid states are 'visible, 'exists and 'none."
      (progn
        (setq org-roam-current-node (org-roam-node-at-point)
              org-roam-current-directory org-roam-directory)
+       (add-hook 'post-command-hook #'org-roam-buffer--post-command-h)
        (display-buffer (get-buffer-create org-roam-buffer))
        (org-roam-buffer-persistent-redisplay)))))
 


### PR DESCRIPTION
###### Motivation for this change

The guide says:

> To enable the org-roam to refresh based on the current node your point is at, use `org-roam-buffer-toggle`. You should see the backlink buffer refresh by just moving around in a file across different nodes.

However, if I call `org-roam-buffer-toggle` directly, it won't refresh automatically since `org-roam-buffer--post-command-h` is added to `post-command-hook` in some place not been touched.

So I add the `add-hook` in `org-roam-buffer-toggle` directly and make this global, because I think it's more convenient to refresh backlink buffer automatically when switching multiple org files.