### PR TITLE
Add autoload cookies for missing global entry points

### DIFF
--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -127,6 +127,7 @@ See `org-roam-capture-templates' for the template documentation."
                                          ((const :format "%v " :table-line-pos) (string))
                                          ((const :format "%v " :kill-buffer) (const t))))))))
 
+;;;###autoload
 (defun org-roam-dailies-find-directory ()
   "Find and open `org-roam-dailies-directory'."
   (interactive)
@@ -157,18 +158,21 @@ When GOTO is non-nil, go the note without creating an entry."
 
 ;;;; Commands
 ;;; Today
+;;;###autoload
 (defun org-roam-dailies-capture-today (&optional goto)
   "Create an entry in the daily-note for today.
 When GOTO is non-nil, go the note without creating an entry."
   (interactive "P")
   (org-roam-dailies--capture (current-time) goto))
 
+;;;###autoload
 (defun org-roam-dailies-goto-today ()
   "Find the daily-note for today, creating it if necessary."
   (interactive)
   (org-roam-dailies-capture-today t))
 
 ;;; Tomorrow
+;;;###autoload
 (defun org-roam-dailies-capture-tomorrow (n &optional goto)
   "Create an entry in the daily-note for tomorrow.
 
@@ -179,6 +183,7 @@ creating an entry."
   (interactive "p")
   (org-roam-dailies--capture (time-add (* n 86400) (current-time)) goto))
 
+;;;###autoload
 (defun org-roam-dailies-goto-tomorrow (n)
   "Find the daily-note for tomorrow, creating it if necessary.
 
@@ -188,6 +193,7 @@ future."
   (org-roam-dailies-capture-tomorrow n t))
 
 ;;; Yesterday
+;;;###autoload
 (defun org-roam-dailies-capture-yesterday (n &optional goto)
   "Create an entry in the daily-note for yesteday.
 
@@ -197,6 +203,7 @@ When GOTO is non-nil, go the note without creating an entry."
   (interactive "p")
   (org-roam-dailies-capture-tomorrow (- n) goto))
 
+;;;###autoload
 (defun org-roam-dailies-goto-yesterday (n)
   "Find the daily-note for yesterday, creating it if necessary.
 
@@ -230,6 +237,7 @@ Return (MONTH DAY YEAR)."
         (calendar-mark-visible-date date 'org-roam-dailies-calendar-note)))))
 
 ;;; Date
+;;;###autoload
 (defun org-roam-dailies-capture-date (&optional goto prefer-future)
   "Create an entry in the daily-note for a date using the calendar.
 Prefer past dates, unless PREFER-FUTURE is non-nil.
@@ -242,6 +250,7 @@ creating an entry."
                                          "Capture to daily-note: ")))))
     (org-roam-dailies--capture time goto)))
 
+;;;###autoload
 (defun org-roam-dailies-goto-date (&optional prefer-future)
   "Find the daily-note for a date using the calendar, creating it if necessary.
 Prefer past dates, unless PREFER-FUTURE is non-nil."

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -451,6 +451,7 @@ If UPDATE-P is non-nil, first remove the file in the database."
      (secure-hash 'sha1 (current-buffer)))))
 
 ;;;;; Updating
+;;;###autoload
 (defun org-roam-db-sync (&optional force)
   "Synchronize the cache state with the current Org files on-disk.
 If FORCE, force a rebuild of the cache from scratch."

--- a/org-roam-migrate.el
+++ b/org-roam-migrate.el
@@ -64,6 +64,7 @@ To your init file.
 
 "))
 
+;;;###autoload
 (defun org-roam-migrate-wizard ()
   "Migrate all notes from to be compatible with Org-roam v2.
 1. Convert all notes from v1 format to v2.

--- a/org-roam.el
+++ b/org-roam.el
@@ -350,6 +350,7 @@ If BUFFER is not specified, use the current buffer."
 (defvar org-roam-find-file-hook nil
   "Hook run when an Org-roam file is visited.")
 
+;;;###autoload
 (defun org-roam-setup ()
   "Setup Org-roam."
   (interactive)
@@ -871,6 +872,7 @@ If OTHER-WINDOW, visit the NODE in another window."
        :node node
        :props '(:finalize find-file)))))
 
+;;;###autoload
 (defun org-roam-node-insert (&optional filter-fn)
   "Find an Org-roam file, and insert a relative org link to it at point.
 Return selected file if it exists.
@@ -1087,6 +1089,7 @@ REF is assumed to be a propertized string."
     (when title
       (concat " " title))))
 
+;;;###autoload
 (defun org-roam-ref-find (&optional initial-input filter-fn)
   "Find and open and Org-roam file from REF if it exists.
 REF should be the value of '#+roam_key:' without any


### PR DESCRIPTION
So the user wouldn't have the need declare them on their own side if they want to lazy load the package.
