### PR TITLE
(docs): add note on encryption

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -682,6 +682,10 @@ extension in your Org-roam capture templates. For example:
      :unnarrowed t)))
 #+end_src
 
+Note that the Org-roam database stores metadata information in plain-text
+(headline text, for example), so if this information is private to you then you
+should also ensure the database is encrypted.
+
 * Org-roam Protocol
 
 Org-roam provides extensions for capturing content from external applications

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1030,6 +1030,10 @@ extension in your Org-roam capture templates. For example:
      :unnarrowed t)))
 @end lisp
 
+Note that the Org-roam database stores metadata information in plain-text
+(headline text, for example), so if this information is private to you then you
+should also ensure the database is encrypted.
+
 @node Org-roam Protocol
 @chapter Org-roam Protocol
 


### PR DESCRIPTION
Just adding a note on encrypting the org-roam db itself.

Closes #835 