### PR TITLE
Adjusted configuration examples for backlinks buffer.

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -519,11 +519,11 @@ the user. The author's recommended configuration is as follows:
 
 #+begin_src emacs-lisp
   (add-to-list 'display-buffer-alist
-               '(("\\*org-roam\\*"
-                  (display-buffer-in-direction)
-                  (direction . right)
-                  (window-width . 0.33)
-                  (window-height . fit-window-to-buffer))))
+               '("\\*org-roam\\*"
+                 (display-buffer-in-direction)
+                 (direction . right)
+                 (window-width . 0.33)
+                 (window-height . fit-window-to-buffer)))
 #+end_src
 
 Crucially, the window is a regular window (not a side-window), and this allows
@@ -532,6 +532,20 @@ for predictable navigation:
 - ~RET~ navigates to thing-at-point in the current window, replacing the
   Org-roam buffer.
 - ~C-u RET~ navigates to thing-at-point in the other window.
+
+For users that prefer using a side-window for the org-roam buffer, the following
+example configuration should provide a good starting point:
+
+#+begin_src emacs-lisp
+  (add-to-list 'display-buffer-alist
+               '("\\*org-roam\\*"
+                 (display-buffer-in-side-window)
+                 (side . right)
+                 (slot . 0)
+                 (window-width . 0.33)
+                 (window-parameters . ((no-other-window . t)
+                                       (no-delete-other-windows . t)))))
+#+end_src
 
 ** TODO Styling the Org-roam buffer
 * Node Properties

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -818,11 +818,11 @@ the user. The author's recommended configuration is as follows:
 
 @lisp
 (add-to-list 'display-buffer-alist
-             '(("\\*org-roam\\*"
-                (display-buffer-in-direction)
-                (direction . right)
-                (window-width . 0.33)
-                (window-height . fit-window-to-buffer))))
+             '("\\*org-roam\\*"
+               (display-buffer-in-direction)
+               (direction . right)
+               (window-width . 0.33)
+               (window-height . fit-window-to-buffer)))
 @end lisp
 
 Crucially, the window is a regular window (not a side-window), and this allows
@@ -836,6 +836,20 @@ Org-roam buffer.
 @item
 @code{C-u RET} navigates to thing-at-point in the other window.
 @end itemize
+
+For users that prefer using a side-window for the org-roam buffer, the following
+example configuration should provide a good starting point:
+
+@lisp
+  (add-to-list 'display-buffer-alist
+               '("\\*org-roam\\*"
+                 (display-buffer-in-side-window)
+                 (side . right)
+                 (slot . 0)
+                 (window-width . 0.33)
+                 (window-parameters . ((no-other-window . t)
+                                       (no-delete-other-windows . t)))))
+@end lisp
 
 @node Styling the Org-roam buffer
 @section @strong{TODO} Styling the Org-roam buffer


### PR DESCRIPTION
 - Fixed the original example's extra parenthesis, which broke the alist.
 - Added a second example for configuring the buffer as a side window.

###### Motivation for this change

When migrating to v2 I found that the configuration example for the backlinks buffer (both in the wiki and official documentation) had an extra parenthesis, which would work if `setq` was being used instead of `add-to-list`.

This pull request fixes the original example and adds a second example for using the buffer as a side window.