### PR TITLE
Doc typo: org-roam-mode-sections -> org-roam-mode-section-functions

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -500,10 +500,10 @@ There are currently 3 provided widget types:
 - Unlinked references :: View nodes that contain text that match the nodes
   title/alias but are not linked
 
-To configure what sections are displayed in the buffer, set ~org-roam-mode-sections~.
+To configure what sections are displayed in the buffer, set ~org-roam-mode-section-functions~.
 
 #+begin_src emacs-lisp
-  (setq org-roam-mode-sections
+  (setq org-roam-mode-section-functions
         (list #'org-roam-backlinks-section
               #'org-roam-reflinks-section
               ;; #'org-roam-unlinked-references-section

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -798,10 +798,10 @@ There are currently 3 provided widget types:
 title/alias but are not linked
 @end itemize
 
-To configure what sections are displayed in the buffer, set @code{org-roam-mode-sections}.
+To configure what sections are displayed in the buffer, set @code{org-roam-mode-section-functions}.
 
 @lisp
-(setq org-roam-mode-sections
+(setq org-roam-mode-section-functions
       (list #'org-roam-backlinks-section
             #'org-roam-reflinks-section
             ;; #'org-roam-unlinked-references-section


### PR DESCRIPTION
###### Motivation for this change

I believe `org-roam-mode-section` should be `org-roam-mode-section-functions`.