### PR TITLE
fix(#1575): fix display of non-ASCII in unlinked references section

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -410,7 +410,7 @@ If ROW, move to the row, and if COL move to the COL."
   "Return the preview line from FILE.
 This is the ROW within FILE."
   (with-temp-buffer
-    (insert-file-contents-literally file)
+    (insert-file-contents file)
     (forward-line (1- row))
     (buffer-substring-no-properties
      (save-excursion


### PR DESCRIPTION
Non-ASCII characters are displayed incorrectly because `org-roam-unlinked-references-preview-line` uses `insert-file-contents-literally` which ignores the encoding.

Use `insert-file-contents` which does the right thing.

fixes #1575
