### PR TITLE
(feat): formalize node dedicated buffers

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -457,19 +457,15 @@ Org-roam provides (see [[id:70083bfd-d1e3-42b9-bf83-5b05708791c0][Completion]]).
 
 Org-roam provides the Org-roam buffer: an interface to view relationships with
 other notes (backlinks, reference links, unlinked references etc.). There are
-two main functions to use here:
+two main commands to use here:
 
-- ~org-roam-buffer~: Launch an Org-roam buffer for the current node at point.
 - ~org-roam-buffer-toggle~: Launch an Org-roam buffer that tracks the node
   currently at point. This means that the content of the buffer changes as the
   point is moved, if necessary.
-
-Use ~org-roam-buffer-toggle~ when you want wish for the Org-roam buffer to
-buffer, call ~M-x org-roam-buffer~.
-
-- Function: org-roam-buffer
-
-  Launch an Org-roam buffer for the current node at point.
+- ~org-roam-buffer-display-dedicated~: Launch an Org-roam buffer for a specific
+  node without visiting its file. Unlike ~org-roam-buffer-toggle~ you can have
+  multiple such buffers and their content won't be automatically replaced with a
+  new node at point.
 
 To bring up a buffer that tracks the current node at point, call ~M-x
 org-roam-buffer-toggle~.
@@ -477,6 +473,13 @@ org-roam-buffer-toggle~.
 - Function: org-roam-buffer-toggle
 
   Toggle display of the ~org-roam-buffer~.
+
+To bring up a buffer that's dedicated for a specific node, call ~M-x
+org-roam-buffer-display-dedicated~.
+
+- Function: org-roam-buffer-display-dedicated
+
+  Launch node dedicated Org-roam buffer without visiting the node itself.
 
 ** Navigating the Org-roam Buffer
 

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -728,21 +728,19 @@ two main functions to use here:
 
 @itemize
 @item
-@code{org-roam-buffer}: Launch an Org-roam buffer for the current node at point.
-
-@item
 @code{org-roam-buffer-toggle}: Launch an Org-roam buffer that tracks the node
 currently at point. This means that the content of the buffer changes as the
 point is moved, if necessary.
+
+@item
+@code{org-roam-buffer-display-dedicated}: Launch an Org-roam buffer for a
+specific node without visiting its file. Unlike @code{org-roam-buffer-toggle} you
+can have multiple such buffers and their content won't be automatically
+replaced with a new node at point.
 @end itemize
 
 Use @code{org-roam-buffer-toggle} when you want wish for the Org-roam buffer to
 buffer, call @code{M-x org-roam-buffer}.
-
-@defun org-roam-buffer
-
-Launch an Org-roam buffer for the current node at point.
-@end defun
 
 To bring up a buffer that tracks the current node at point, call @code{M-x
 org-roam-buffer-toggle}.
@@ -750,6 +748,14 @@ org-roam-buffer-toggle}.
 @defun org-roam-buffer-toggle
 
 Toggle display of the @code{org-roam-buffer}.
+@end defun
+
+To bring up a buffer that's dedicated for a specific node, call @code{M-x
+org-roam-buffer-display-dedicated}.
+
+@defun org-roam-buffer-display-dedicated
+
+Launch node dedicated Org-roam buffer without visiting the node itself.
 @end defun
 
 @menu

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -98,6 +98,19 @@ recursion."
     (nconc result (nreverse files))))
 
 ;;; Obsolete aliases (remove after next major release)
+(define-obsolete-variable-alias
+  'org-roam-current-node
+  'org-roam-buffer-current-node "org-roam 2.0")
+(define-obsolete-variable-alias
+  'org-roam-current-directory
+  'org-roam-buffer-current-directory "org-roam 2.0")
+(define-obsolete-function-alias
+  'org-roam-buffer-render
+  'org-roam-buffer-render-contents "org-roam 2.0")
+(define-obsolete-function-alias
+  'org-roam-buffer
+  'org-roam-buffer-display-dedicated "org-roam 2.0")
+
 (define-obsolete-function-alias
   'org-roam-dailies-find-today
   'org-roam-dailies-goto-today "org-roam 2.0")

--- a/org-roam.el
+++ b/org-roam.el
@@ -801,8 +801,8 @@ window instead."
   "Insert section for a link from SOURCE-NODE to some other node.
 
 SOURCE-NODE is an `org-roam-node' that links or references some
-other node. Normally the other node is `org-roam-current-node'
-that set in `org-roam-buffer'.
+other node. Normally the other node is
+`org-roam-buffer-current-node'.
 
 POINT is the position in SOURCE-NODE's file where the link is
 located.


### PR DESCRIPTION
###### Motivation for this change
Replaces the `org-roam-buffer` command and formalizes the concept of node dedicated Org-roam buffers (compared to the persistent one). I'm not sure about the name, so if you have a better one let me know.
