### PR TITLE
(fix): issue #1627 s-trim formatted candidates

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -706,9 +706,7 @@ GROUP BY id")))
   "Return a minibuffer completion candidate given NODE."
   (let ((candidate-main (org-roam-node--format-entry node (1- (frame-width))))
         (tag-str (org-roam--tags-to-str (org-roam-node-tags node))))
-    (cons (propertize (concat candidate-main
-                              (propertize tag-str 'invisible t))
-                      'node node)
+    (cons (propertize (s-trim candidate-main) 'node node)
           node)))
 
 (defun org-roam-node--completions ()


### PR DESCRIPTION
- Remove adding tag as an invisible string (redundant)
- Trimming  spaces left and right of each candidate

Please treat this as representation of an possible
"fix". This formatting seems more complex than I
can imagine. You may have a better idea on how to
tackle this from other angles.

Thanks.

###### Motivation for this change
Refer to issue #1627  