### PR TITLE
(fix): remove invisible tag

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -739,12 +739,8 @@ GROUP BY id")))
 
 (defun org-roam-node--to-candidate (node)
   "Return a minibuffer completion candidate given NODE."
-  (let ((candidate-main (org-roam-node--format-entry node (1- (frame-width))))
-        (tag-str (org-roam--tags-to-str (org-roam-node-tags node))))
-    (cons (propertize (concat candidate-main
-                              (propertize tag-str 'invisible t))
-                      'node node)
-          node)))
+  (let ((candidate-main (org-roam-node--format-entry node (1- (frame-width)))))
+    (cons (propertize candidate-main 'node node) node)))
 
 (defun org-roam-node--completions ()
   "Return an alist for node completion.


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/org-roam/org-roam/issues/1640.

I'm not convinced this is the right fix for this issue because it is not solving the underlying problem of helm not respecting text properties, but it does fix the immediate problem of the default configuration of org-roam sometimes causing multiline completion candidates.

### Screenshots 
<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/4656348/126328918-15318dbd-af1d-446d-a121-848263f2b85a.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/4656348/126333666-9dfe4cd0-8dde-4ec1-9699-7f85df6b4865.png)

</details>