### PR TITLE
(fix)migration: upgrade db to v2 before conversion

### DIFF
--- a/org-roam-migrate.el
+++ b/org-roam-migrate.el
@@ -88,10 +88,14 @@ This will take a while. Are you sure you want to do this?")
       (message "Backing up files to %s" backup-dir)
       (copy-directory org-roam-directory backup-dir))
 
+    ;; Upgrade database to v2
+    (org-roam-db-sync 'force)
+
     ;; Convert v1 to v2
     (dolist (f (org-roam--list-all-files))
       (org-roam-with-file f nil
         (org-roam-migrate-v1-to-v2)))
+
     ;; Rebuild cache
     (org-roam-db-sync 'force)
 


### PR DESCRIPTION
`org-roam-migrate-v1-to-v2` requires the v2 db to already be in place,
so run `org-roam-db-sync` once first.

Fixes #1664