### PR TITLE
(fix)autoloads: Point autoloads to org-roam.el file

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -791,7 +791,7 @@ properties to be added to the template."
     (_
      (signal 'invalid-template template))))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-capture- "org-roam" nil t)
 (cl-defun org-roam-capture- (&key goto keys node info props templates)
   "Main entry point.
 GOTO and KEYS correspond to `org-capture' arguments.
@@ -811,7 +811,7 @@ TEMPLATES is a list of org-roam templates."
       (setq keys (caar org-capture-templates)))
     (org-capture goto keys)))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-capture "org-roam" nil t)
 (defun org-roam-capture (&optional goto keys)
   "Launches an `org-capture' process for a new or existing note.
 This uses the templates defined at `org-roam-capture-templates'.

--- a/org-roam-dailies.el
+++ b/org-roam-dailies.el
@@ -129,7 +129,7 @@ See `org-roam-capture-templates' for the template documentation."
                                          ((const :format "%v " :table-line-pos) (string))
                                          ((const :format "%v " :kill-buffer) (const t))))))))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-find-directory "org-roam" nil t)
 (defun org-roam-dailies-find-directory ()
   "Find and open `org-roam-dailies-directory'."
   (interactive)
@@ -160,21 +160,21 @@ When GOTO is non-nil, go the note without creating an entry."
 
 ;;;; Commands
 ;;; Today
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-capture-today "org-roam" nil t)
 (defun org-roam-dailies-capture-today (&optional goto)
   "Create an entry in the daily-note for today.
 When GOTO is non-nil, go the note without creating an entry."
   (interactive "P")
   (org-roam-dailies--capture (current-time) goto))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-goto-today "org-roam" nil t)
 (defun org-roam-dailies-goto-today ()
   "Find the daily-note for today, creating it if necessary."
   (interactive)
   (org-roam-dailies-capture-today t))
 
 ;;; Tomorrow
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-capture-tomorrow "org-roam" nil t)
 (defun org-roam-dailies-capture-tomorrow (n &optional goto)
   "Create an entry in the daily-note for tomorrow.
 
@@ -185,7 +185,7 @@ creating an entry."
   (interactive "p")
   (org-roam-dailies--capture (time-add (* n 86400) (current-time)) goto))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-goto-tomorrow "org-roam" nil t)
 (defun org-roam-dailies-goto-tomorrow (n)
   "Find the daily-note for tomorrow, creating it if necessary.
 
@@ -195,7 +195,7 @@ future."
   (org-roam-dailies-capture-tomorrow n t))
 
 ;;; Yesterday
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-capture-yesterday "org-roam" nil t)
 (defun org-roam-dailies-capture-yesterday (n &optional goto)
   "Create an entry in the daily-note for yesteday.
 
@@ -205,7 +205,7 @@ When GOTO is non-nil, go the note without creating an entry."
   (interactive "p")
   (org-roam-dailies-capture-tomorrow (- n) goto))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-goto-yesterday "org-roam" nil t)
 (defun org-roam-dailies-goto-yesterday (n)
   "Find the daily-note for yesterday, creating it if necessary.
 
@@ -241,7 +241,7 @@ Return (MONTH DAY YEAR) or nil if not an Org time-string."
         (calendar-mark-visible-date date 'org-roam-dailies-calendar-note)))))
 
 ;;; Date
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-capture-date "org-roam" nil t)
 (defun org-roam-dailies-capture-date (&optional goto prefer-future)
   "Create an entry in the daily-note for a date using the calendar.
 Prefer past dates, unless PREFER-FUTURE is non-nil.
@@ -254,7 +254,7 @@ creating an entry."
                                          "Capture to daily-note: ")))))
     (org-roam-dailies--capture time goto)))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-dailies-goto-date "org-roam" nil t)
 (defun org-roam-dailies-goto-date (&optional prefer-future)
   "Find the daily-note for a date using the calendar, creating it if necessary.
 Prefer past dates, unless PREFER-FUTURE is non-nil."

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -460,7 +460,7 @@ If UPDATE-P is non-nil, first remove the file in the database."
      (secure-hash 'sha1 (current-buffer)))))
 
 ;;;;; Updating
-;;;###autoload
+;;;###autoload (autoload 'org-roam-db-sync "org-roam" nil t)
 (defun org-roam-db-sync (&optional force)
   "Synchronize the cache state with the current Org files on-disk.
 If FORCE, force a rebuild of the cache from scratch."

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -256,7 +256,7 @@ CALLBACK is passed the graph file as its sole argument."
     (_ (signal 'wrong-type-argument `((functionp stringp null) ,org-roam-graph-viewer)))))
 
 ;;;; Commands
-;;;###autoload
+;;;###autoload (autoload 'org-roam-graph "org-roam" nil t)
 (defun org-roam-graph (&optional arg node)
   "Build and possibly display a graph for NODE.
 ARG may be any of the following values:

--- a/org-roam-migrate.el
+++ b/org-roam-migrate.el
@@ -73,7 +73,7 @@ To your init file.
 
 "))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-migrate-wizard "org-roam" nil t)
 (defun org-roam-migrate-wizard ()
   "Migrate all notes from to be compatible with Org-roam v2.
 1. Convert all notes from v1 format to v2.

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -189,7 +189,7 @@ buffer."
     (goto-char 0)))
 
 ;;; Dedicated buffer
-;;;###autoload
+;;;###autoload (autoload 'org-roam-buffer-display-dedicated "org-roam" nil t)
 (defun org-roam-buffer-display-dedicated (node)
   "Launch NODE dedicated Org-roam buffer.
 Unlike the persistent `org-roam-buffer', the contents of this

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -259,7 +259,7 @@ If the buffer is associated with an in-process capture operation, abort the oper
     (kill-buffer (current-buffer))))
 
 ;;; Diagnostics
-;;;###autoload
+;;;###autoload (autoload 'org-roam-version "org-roam" nil t)
 (defun org-roam-version (&optional message)
   "Return `org-roam' version.
 Interactively, or when MESSAGE is non-nil, show in the echo area."
@@ -276,7 +276,7 @@ Interactively, or when MESSAGE is non-nil, show in the echo area."
         (message "%s" version)
       version)))
 
-;;;###autoload
+;;;###autoload (autoload 'org-roam-diagnostics "org-roam" nil t)
 (defun org-roam-diagnostics ()
   "Collect and print info for `org-roam' issues."
   (interactive)


### PR DESCRIPTION
At the current state autoloads from non `org-roam.el` unable to start
loading of the package from their own file. See the following to learn
more about the problem:

  https://github.com/org-roam/org-roam/issues/1590#issuecomment-885817825

This is no more than a workaround to bandage a more deeper underlying
problem. Until the more fundamental problem won't be fixed, all autoload
cookies from non "org-roam.el" file will need to manually point to the
main entry point of the package -- "org-roam.el" file, to load it
without causing errors.

Fixes #1590, fixes #1620, #1600 and other similar issues.

###### Motivation for this change
Hey @jethrokuan, since you didn't response to my comment I don't really know what's your plan to move forward with this problem. Meanwhile, I don't think the status quo (with regards to the issue) is acceptable, so for the time being this bandage is better than nothing.