### PR TITLE
Adding parameters to three core functions

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -807,14 +807,19 @@ TEMPLATES is a list of org-roam templates."
     (org-capture goto keys)))
 
 ;;;###autoload (autoload 'org-roam-capture "org-roam" nil t)
-(defun org-roam-capture (&optional goto keys)
+(cl-defun org-roam-capture (&optional goto keys &key filter-fn templates)
   "Launches an `org-capture' process for a new or existing note.
 This uses the templates defined at `org-roam-capture-templates'.
-Arguments GOTO and KEYS see `org-capture'."
+Arguments GOTO and KEYS see `org-capture'.
+FILTER-FN is a function to filter out nodes: it takes an `org-roam-node',
+and when nil is returned the node will be filtered out.
+The TEMPLATES, if provided, override the list of capture templates (see
+`org-roam-capture-'.)"
   (interactive "P")
-  (let ((node (org-roam-node-read)))
+  (let ((node (org-roam-node-read nil filter-fn)))
     (org-roam-capture- :goto goto
                        :keys keys
+                       :templates templates
                        :node node
                        :props '(:immediate-finish nil))))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -905,25 +905,30 @@ This section is made out of the next 2 `magit-section's:
       (insert ?\n))))
 
 ;;;###autoload
-(defun org-roam-node-find (&optional other-window initial-input filter-fn)
+(cl-defun org-roam-node-find (&optional other-window initial-input filter-fn &key templates)
   "Find and open an Org-roam node by its title or alias.
 INITIAL-INPUT is the initial input for the prompt.
 FILTER-FN is a function to filter out nodes: it takes an `org-roam-node',
 and when nil is returned the node will be filtered out.
-If OTHER-WINDOW, visit the NODE in another window."
+If OTHER-WINDOW, visit the NODE in another window.
+The TEMPLATES, if provided, override the list of capture templates (see
+`org-roam-capture-'.)"
   (interactive current-prefix-arg)
   (let ((node (org-roam-node-read initial-input filter-fn)))
     (if (org-roam-node-file node)
         (org-roam-node-visit node other-window)
       (org-roam-capture-
        :node node
+       :templates templates
        :props '(:finalize find-file)))))
 
 ;;;###autoload
-(defun org-roam-node-insert (&optional filter-fn)
+(cl-defun org-roam-node-insert (&optional filter-fn &key templates)
   "Find an Org-roam node and insert (where the point is) an \"id:\" link to it.
 FILTER-FN is a function to filter out nodes: it takes an `org-roam-node',
-and when nil is returned the node will be filtered out."
+and when nil is returned the node will be filtered out.
+The TEMPLATES, if provided, override the list of capture templates (see
+`org-roam-capture-'.)"
   (interactive)
   (unwind-protect
       ;; Group functions together to avoid inconsistent state on quit
@@ -948,6 +953,7 @@ and when nil is returned the node will be filtered out."
                          description)))
             (org-roam-capture-
              :node node
+             :templates templates
              :props (append
                      (when (and beg end)
                        (list :region (cons beg end)))


### PR DESCRIPTION
The rationale for this change is to allow context-specific capture
consideration.  That is to say, in my experience, when I'm working on a
project, I often want to scope my note finding and creation to that
project.  By adding `filter-fn` and `templates` I can easily craft
context-aware functions for my note-taking.

I chose to switch these to `cl-defun` to expose `&key` parameters, which I
find more useful as the method signature grows.

Closes #1681

From the Github Issue:

> Adding a `filter-fn` parameter to `org-roam-capture` and a `templates`
> parameter to `org-roam-capture` , `org-roam-node-insert`,
> `org-roam-node-find` would improve their general utility, and reduce
> fiddling with the more inner functionality of `org-roam-capture-` and
> `org-roam-node-read`
