### PR TITLE
(feat): allow special 'ignore key in capture template

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -767,7 +767,9 @@ properties to be added to the template."
   (pcase template
     (`(,_key ,_desc)
      template)
-    (`(,key ,desc ,type ,body . ,rest)
+    ((or `(,key ,desc ,type ignore ,body . ,rest)
+         `(,key ,desc ,type (function ignore) ,body . ,rest)
+         `(,key ,desc ,type ,body . ,rest))
      (setq rest (append rest props))
      (let (org-roam-plist options)
        (while rest


### PR DESCRIPTION
Allow 'ignore as a valid value in place of function. Closes #1699.