### PR TITLE
(fix)org-roam-id-at-point: ignore top-level excluded nodes

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -151,7 +151,8 @@ first encapsulating ID."
    (while (and (not (org-roam-db-node-p))
                (not (bobp)))
      (org-roam-up-heading-or-point-min))
-   (org-id-get)))
+   (when (org-roam-db-node-p)
+     (org-id-get))))
 
 ;;;; File functions and predicates
 (defun org-roam--file-name-extension (filename)


### PR DESCRIPTION
Previously if a top-level file node is excluded, it would still be
picked up by org-roam-id-at-point. This adds another org-roam-db-node-p
check before returning an ID, fixing the broken behaviour. Fixes #1635.
