### PR TITLE
fix: splitting and joining of multiple filetags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#1403](https://github.com/org-roam/org-roam/issues/1403) fixed inconsistency between how we write and read props like alias and tags
 - [#1409](https://github.com/org-roam/org-roam/issues/1398) prevent inclusion of non-org-roam files in `org-roam-dailies--list-files`
 - [#1542](https://github.com/org-roam/org-roam/issues/1542) fix files not excluded when `org-roam-list-files-commands` is nil
+- [#1705](https://github.com/org-roam/org-roam/pull/1705) fix for add/remove of file-level tags
 
 ## 1.2.3 (13-11-2020)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -1038,8 +1038,8 @@ If the property is already set, it's value is replaced."
       (if (= (org-outline-level) 0)
           (let ((current-tags (split-string (or (cadr (assoc "FILETAGS"
                                                              (org-collect-keywords '("filetags"))))
-                                                ""))))
-            (org-roam-set-keyword "filetags" (string-join (seq-uniq (append tags current-tags)) " ")))
+                                                "") ":" 't)))
+            (org-roam-set-keyword "filetags" (org-make-tag-string (seq-uniq (append tags current-tags)))))
         (org-set-tags (seq-uniq (append tags (org-get-tags)))))
       tags)))
 
@@ -1052,10 +1052,10 @@ If the property is already set, it's value is replaced."
       (if (= (org-outline-level) 0)
           (let* ((current-tags (split-string (or (cadr (assoc "FILETAGS"
                                                               (org-collect-keywords '("filetags"))))
-                                                 (user-error "No tag to remove"))))
+                                                 (user-error "No tag to remove")) ":" 't))
                  (tags (or tags (completing-read-multiple "Tag: " current-tags))))
             (org-roam-set-keyword "filetags"
-                                  (string-join (seq-difference current-tags tags #'string-equal) " ")))
+                                  (org-make-tag-string (seq-difference current-tags tags #'string-equal))))
         (let* ((current-tags (or (org-get-tags)
                                  (user-error "No tag to remove")))
                (tags (completing-read-multiple "Tag: " current-tags)))


### PR DESCRIPTION
###### Motivation for this change

Current, when fetching file level org tags (from the `#+filetags` property), multiple tags are split based on the default `split-string` separator. This is incorrect because the org documentation says that multiple file-level tags should be separated by `:` (like headline level tags). This results in a improper splitting (aka no split) of the tag string into multiple tags. This leads to the inability to delete tags that are there.

Similarly, when writing multiple `#+filetags`, the tags are joined by `" "` instead instead of `":"` as mentioned in the org docs. This leads to improperly added tags where newly added tags would not be recognized by org.

This PR fixes both problems, parsing is done by string splitting on `":"` (with the `OMIT-NULLS` parameter set to true so you don't get a null values from the fact tags start and end with `":"`). Joining multiple tags is now done with the `org-make-tag-string` function instead of manually joining on space. These changes result in the ability to add and remove file level tags such that the resulting value of the `#+filetags` property is a valid tag string.
