### PR TITLE
(feat)org-roam-format: add default-value

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -505,7 +505,7 @@ also run Org-capture's template expansion."
   (funcall (if org-capture-p #'org-capture-fill-template #'identity)
            (org-roam-format
             template
-            (lambda (key)
+            (lambda (key default-val)
               (let ((fn (intern key))
                     (node-fn (intern (concat "org-roam-node-" key)))
                     (ksym (intern (concat ":" key))))
@@ -516,7 +516,7 @@ also run Org-capture's template expansion."
                   (funcall node-fn org-roam-capture--node))
                  ((plist-get org-roam-capture--info ksym)
                   (plist-get org-roam-capture--info ksym))
-                 (t (let ((r (completing-read (format "%s: " key) nil)))
+                 (t (let ((r (completing-read (format "%s: " key) nil nil nil default-val)))
                       (plist-put org-roam-capture--info ksym r)
                       r))))))))
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -505,7 +505,7 @@ Uses `org-roam-node-display-template' to format the entry."
   (let ((fmt (org-roam--process-display-format org-roam-node-display-template)))
     (org-roam-format
      (car fmt)
-     (lambda (field)
+     (lambda (field _default-val)
        (let* ((field (split-string field ":"))
               (field-name (car field))
               (field-width (cadr field))


### PR DESCRIPTION
Allow specification of default values in org-roam-format of the form ${key=default_val}. Closes #1003.