### PR TITLE
(feat): add org-roam-extract-subtree

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -1226,7 +1226,7 @@ Assumes that the cursor was put where the link is."
 (add-hook 'org-roam-find-file-hook #'org-roam-open-id-with-org-roam-db-h)
 
 ;;; Refiling
-(defcustom org-roam-extract-new-file-template "%<%Y%m%d%H%M%S>-${slug}.org"
+(defcustom org-roam-extract-new-file-path "%<%Y%m%d%H%M%S>-${slug}.org"
   "The file path to use when a node is extracted to its own file."
   :group 'org-roam
   :type 'string)
@@ -1324,7 +1324,7 @@ node."
     (let* (template-info
            (node (org-roam-node-at-point))
            (template (org-roam-format
-                      (s-trim (org-capture-fill-template org-roam-extract-new-file-template))
+                      (string-trim (org-capture-fill-template org-roam-extract-new-file-path))
                       (lambda (key default-val)
                         (let ((fn (intern key))
                               (node-fn (intern (concat "org-roam-node-" key)))

--- a/org-roam.el
+++ b/org-roam.el
@@ -1304,7 +1304,7 @@ node."
   (org-with-point-at 1
     (org-map-entries (lambda ()
                        (when (> (org-outline-level) 1)
-                           (org-do-promote))))
+                         (org-do-promote))))
     (let ((title (nth 4 (org-heading-components)))
           (tags (nth 5 (org-heading-components))))
       (beginning-of-line)


### PR DESCRIPTION
Adds org-roam-extract-subtree, which converts the subtree at point
into a top-level file node. This is useful for when a node you are
expanding on gets too big, and deserves its own file.

Closes #1104