### PR TITLE
Correct type for INFO argument in org-roam-capture docstring

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -794,7 +794,7 @@ properties to be added to the template."
 (cl-defun org-roam-capture- (&key goto keys node info props templates)
   "Main entry point.
 GOTO and KEYS correspond to `org-capture' arguments.
-INFO is an alist for filling up Org-roam's capture templates.
+INFO is an plist for filling up Org-roam's capture templates.
 NODE is an `org-roam-node' construct containing information about the node.
 PROPS is a plist containing additional Org-roam properties for each template.
 TEMPLATES is a list of org-roam templates."

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -794,7 +794,7 @@ properties to be added to the template."
 (cl-defun org-roam-capture- (&key goto keys node info props templates)
   "Main entry point.
 GOTO and KEYS correspond to `org-capture' arguments.
-INFO is an plist for filling up Org-roam's capture templates.
+INFO is a plist for filling up Org-roam's capture templates.
 NODE is an `org-roam-node' construct containing information about the node.
 PROPS is a plist containing additional Org-roam properties for each template.
 TEMPLATES is a list of org-roam templates."


### PR DESCRIPTION
###### Motivation for this change

According to the documentation of `org-roam-capture--info` and functions working with that variable, it is a property list and not an alist, so that should be stated correctly in the documentation for the `INFO` keyword argument.

Sorry for the minor PR, just found this while stepping through the code with edebug and looking at function signatures while trying to find the cause for another bug that I have.