### PR TITLE
When capturing a file, check if it exists on disk too

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -525,10 +525,10 @@ also run Org-capture's template expansion."
   (when-let ((ref (plist-get org-roam-capture--info :ref)))
     (org-roam-ref-add ref)))
 
-(defun new-file-p (path)
-  "Return T if the file at PATH exists or has a live buffer if unsaved."
-  (not (or (org-find-base-buffer-visiting path)
-           (file-exists-p path))))
+(defun org-roam-capture--new-file-p (path)
+  "Return t if PATH is for a new file with no visiting buffer."
+  (not (or (file-exists-p path)
+           (org-find-base-buffer-visiting path))))
 
 (defun org-roam-capture--goto-location ()
   "Initialize the buffer, and goto the location of the new capture.
@@ -540,7 +540,7 @@ Return the ID of the location."
        (setq path (expand-file-name
                    (string-trim (org-roam-capture--fill-template path t))
                    org-roam-directory))
-       (setq new-file-p (new-file-p path))
+       (setq new-file-p (org-roam-capture--new-file-p path))
        (when new-file-p (org-roam-capture--put :new-file path))
        (set-buffer (org-capture-target-buffer path))
        (widen)
@@ -549,7 +549,7 @@ Return the ID of the location."
        (setq path (expand-file-name
                    (string-trim (org-roam-capture--fill-template path t))
                    org-roam-directory))
-       (setq new-file-p (new-file-p path))
+       (setq new-file-p (org-roam-capture--new-file-p path))
        (when new-file-p (org-roam-capture--put :new-file path))
        (set-buffer (org-capture-target-buffer path))
        (setq p (point-min))
@@ -560,7 +560,7 @@ Return the ID of the location."
        (setq path (expand-file-name
                    (string-trim (org-roam-capture--fill-template path t))
                    org-roam-directory))
-       (setq new-file-p (new-file-p path))
+       (setq new-file-p (org-roam-capture--new-file-p path))
        (set-buffer (org-capture-target-buffer path))
        (when new-file-p
          (org-roam-capture--put :new-file path)
@@ -571,7 +571,7 @@ Return the ID of the location."
        (setq path (expand-file-name
                    (string-trim (org-roam-capture--fill-template path t))
                    org-roam-directory))
-       (setq new-file-p (new-file-p path))
+       (setq new-file-p (org-roam-capture--new-file-p path))
        (set-buffer (org-capture-target-buffer path))
        (widen)
        (when new-file-p

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -525,6 +525,11 @@ also run Org-capture's template expansion."
   (when-let ((ref (plist-get org-roam-capture--info :ref)))
     (org-roam-ref-add ref)))
 
+(defun new-file-p (path)
+  "Return T if the file at PATH exists or has a live buffer if unsaved."
+  (not (or (org-find-base-buffer-visiting path)
+           (file-exists-p path))))
+
 (defun org-roam-capture--goto-location ()
   "Initialize the buffer, and goto the location of the new capture.
 Return the ID of the location."
@@ -535,7 +540,7 @@ Return the ID of the location."
        (setq path (expand-file-name
                    (string-trim (org-roam-capture--fill-template path t))
                    org-roam-directory))
-       (setq new-file-p (not (org-find-base-buffer-visiting path)))
+       (setq new-file-p (new-file-p path))
        (when new-file-p (org-roam-capture--put :new-file path))
        (set-buffer (org-capture-target-buffer path))
        (widen)
@@ -544,7 +549,7 @@ Return the ID of the location."
        (setq path (expand-file-name
                    (string-trim (org-roam-capture--fill-template path t))
                    org-roam-directory))
-       (setq new-file-p (not (org-find-base-buffer-visiting path)))
+       (setq new-file-p (new-file-p path))
        (when new-file-p (org-roam-capture--put :new-file path))
        (set-buffer (org-capture-target-buffer path))
        (setq p (point-min))
@@ -555,7 +560,7 @@ Return the ID of the location."
        (setq path (expand-file-name
                    (string-trim (org-roam-capture--fill-template path t))
                    org-roam-directory))
-       (setq new-file-p (not (org-find-base-buffer-visiting path)))
+       (setq new-file-p (new-file-p path))
        (set-buffer (org-capture-target-buffer path))
        (when new-file-p
          (org-roam-capture--put :new-file path)
@@ -566,7 +571,7 @@ Return the ID of the location."
        (setq path (expand-file-name
                    (string-trim (org-roam-capture--fill-template path t))
                    org-roam-directory))
-       (setq new-file-p (not (org-find-base-buffer-visiting path)))
+       (setq new-file-p (new-file-p path))
        (set-buffer (org-capture-target-buffer path))
        (widen)
        (when new-file-p


### PR DESCRIPTION
We now check for either an unsaved buffer visiting the file path, or
the unvisited file on disk.

###### Motivation for this change

#1707 replaced checking if a file exists on disk with checking if a buffer is visiting it.

This PR combines both tests, so it is regarded as existing if either it is being visited in a buffer but is still unsaved, or is unvisited on disk.

See https://github.com/org-roam/org-roam/pull/1707#issuecomment-889415643 