### PR TITLE
(minor)org-roam-get-keyword: make-obsolete

### DIFF
--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -131,6 +131,7 @@ recursion."
   'org-roam-dailies-goto-date "org-roam 2.0")
 
 ;;; Obsolete functions
+(make-obsolete 'org-roam-get-keyword 'org-collect-keywords "org-roam 2.0")
 
 (provide 'org-roam-compat)
 


### PR DESCRIPTION
Prefer Org's org-collect-keywords over org-roam-get-keyword. This
function is not used anywhere, but perhaps some people's configurations
depend on it, so it will be left as is for now.