### PR TITLE
(fix)org-roam-db--file-hash: Always compute hash of encrypted file

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -465,6 +465,8 @@ If UPDATE-P is non-nil, first remove the file in the database."
 
 (defun org-roam-db--file-hash (&optional file-path)
   "Compute the hash of FILE-PATH, a file or current buffer."
+  (when (and (not file-path) (equal "gpg" (file-name-extension (buffer-file-name))))
+    (setq file-path (buffer-file-name)))
   (if file-path
       (with-temp-buffer
         (set-buffer-multibyte nil)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -465,6 +465,8 @@ If UPDATE-P is non-nil, first remove the file in the database."
 
 (defun org-roam-db--file-hash (&optional file-path)
   "Compute the hash of FILE-PATH, a file or current buffer."
+  ;; If it is a GPG encrypted file, we always want to compute the hash
+  ;; for the GPG encrypted file (undecrypted)
   (when (and (not file-path) (equal "gpg" (file-name-extension (buffer-file-name))))
     (setq file-path (buffer-file-name)))
   (if file-path


### PR DESCRIPTION
When inserting the GPG decrypted org buffer to to DB, make sure that
the hash of the encrypted file is stored.

This prevents reparsing of GPG files over and over again when
synchronizing the database with the filesystem.

###### Motivation for this change

I use GPG encrypted org files and was wondering why every time I started Emacs, all GPG files were parsed again, even though they were not modified.