### PR TITLE
Allow user to customize link used for graph generation.

### DIFF
--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -119,8 +119,15 @@ All other values including nil will have no effect."
 
 (defcustom org-roam-graph-link-builder 'org-roam-default-link-builder
   "Given a node name, return a string to be used for the link fed
- to the graph generation utililty."
+to the graph generation utility."
   :type 'function
+  :group 'org-roam)
+
+(defcustom org-roam-graph-generation-hook nil
+  "Hook run after the graph's been generated. Called with the
+filename containing the graph generation tool input as well
+as the generated graph."
+  :type 'hook
   :group 'org-roam)
 
 (defun org-roam-graph--dot-option (option &optional wrap-key wrap-val)
@@ -250,7 +257,9 @@ CALLBACK is passed the graph file as its sole argument."
      :sentinel (when callback
                  (lambda (process _event)
                    (when (= 0 (process-exit-status process))
-                     (funcall callback temp-graph)))))))
+                     (progn
+                       (funcall callback temp-graph)
+		       (run-hook-with-args 'org-roam-graph-generation-hook temp-dot temp-graph))))))))
 
 (defun org-roam-graph--open (file)
   "Open FILE using `org-roam-graph-viewer' with `view-file' as a fallback."

--- a/org-roam-graph.el
+++ b/org-roam-graph.el
@@ -117,6 +117,12 @@ All other values including nil will have no effect."
           (const :tag "no" nil))
   :group 'org-roam)
 
+(defcustom org-roam-graph-link-builder 'org-roam-default-link-builder
+  "Given a node name, return a string to be used for the link fed
+ to the graph generation utililty."
+  :type 'function
+  :group 'org-roam)
+
 (defun org-roam-graph--dot-option (option &optional wrap-key wrap-val)
   "Return dot string of form KEY=VAL for OPTION cons.
 If WRAP-KEY is non-nil it wraps the KEY.
@@ -194,6 +200,11 @@ If ALL-NODES, include also nodes without edges."
       (insert "}")
       (buffer-string))))
 
+(defun org-roam-default-link-builder (node)
+  "Default org-roam link builder.  Generates an org-protocol link."
+  (concat "org-protocol://roam-node?node="
+          (url-hexify-string (org-roam-node-id node))))
+
 (defun org-roam-graph--format-node (node type)
   "Return a graphviz NODE with TYPE.
 Handles both Org-roam nodes, and string nodes (e.g. urls)."
@@ -207,8 +218,7 @@ Handles both Org-roam nodes, and string nodes (e.g. urls)."
                                    (_ title)))))
           (setq node-id (org-roam-node-id node)
                 node-properties `(("label"   . ,shortened-title)
-                                  ("URL"     . ,(concat "org-protocol://roam-node?node="
-                                                        (url-hexify-string (org-roam-node-id node))))
+                                  ("URL"     . ,(funcall org-roam-graph-link-builder node))
                                   ("tooltip" . ,(xml-escape-string title)))))
       (setq node-id node
             node-properties (append `(("label" . ,(concat type ":" node)))


### PR DESCRIPTION
###### Motivation for this change

I've been using _org-publish_ to export my notes.  I'd like to include the generated graph in the sitemap created.  This allows the user to replace the _org-protocol_ links with links to files.

~~**Note:**  I haven't yet figured out how to convert a node id to a filename.~~  See below.