### PR TITLE
Force sync: close the database before removal

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -479,8 +479,8 @@ If UPDATE-P is non-nil, first remove the file in the database."
   "Synchronize the cache state with the current Org files on-disk.
 If FORCE, force a rebuild of the cache from scratch."
   (interactive "P")
-  (when force (delete-file org-roam-db-location))
   (org-roam-db--close) ;; Force a reconnect
+  (when force (delete-file org-roam-db-location))
   (org-roam-db) ;; To initialize the database, no-op if already initialized
   (let* ((gc-cons-threshold org-roam-db-gc-threshold)
          (org-agenda-files nil)


### PR DESCRIPTION
A force resync of the database does not work in Windows (Cygwin):

apply: Removing old name: Device or resource busy, /home/brschoen/.emacs.d/org-roam.db

Therefore, close the connection first and then try to remove the database file.
