### PR TITLE
Adding :info &key to org-roam-(capture|node-insert)

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -403,17 +403,19 @@ TEMPLATES is a list of org-roam templates."
     (org-capture goto keys)))
 
 ;;;###autoload
-(cl-defun org-roam-capture (&optional goto keys &key filter-fn templates)
+(cl-defun org-roam-capture (&optional goto keys &key filter-fn templates info)
   "Launches an `org-capture' process for a new or existing node.
 This uses the templates defined at `org-roam-capture-templates'.
 Arguments GOTO and KEYS see `org-capture'.
 FILTER-FN is a function to filter out nodes: it takes an `org-roam-node',
 and when nil is returned the node will be filtered out.
 The TEMPLATES, if provided, override the list of capture templates (see
-`org-roam-capture-'.)"
+`org-roam-capture-'.)
+The INFO, if provided, is passed along to the underlying `org-roam-capture-'."
   (interactive "P")
   (let ((node (org-roam-node-read nil filter-fn)))
     (org-roam-capture- :goto goto
+                       :info info
                        :keys keys
                        :templates templates
                        :node node

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -528,12 +528,13 @@ COMPLETION-A and COMPLETION-B are items in the form of (node-title org-roam-node
 ;;;; Linkage
 ;;;;; [id:] link
 ;;;###autoload
-(cl-defun org-roam-node-insert (&optional filter-fn &key templates)
+(cl-defun org-roam-node-insert (&optional filter-fn &key templates info)
   "Find an Org-roam node and insert (where the point is) an \"id:\" link to it.
 FILTER-FN is a function to filter out nodes: it takes an `org-roam-node',
 and when nil is returned the node will be filtered out.
 The TEMPLATES, if provided, override the list of capture templates (see
-`org-roam-capture-'.)"
+`org-roam-capture-'.)
+The INFO, if provided, is passed to the underlying `org-roam-capture-'."
   (interactive)
   (unwind-protect
       ;; Group functions together to avoid inconsistent state on quit
@@ -558,6 +559,7 @@ The TEMPLATES, if provided, override the list of capture templates (see
                          description)))
             (org-roam-capture-
              :node node
+             :info info
              :templates templates
              :props (append
                      (when (and beg end)


### PR DESCRIPTION
In adding this parameter, the external facing methods expose another
point of parameterization for the inner `org-roam-capture-` method.

This is most useful for the `org-roam-node-insert` method which has a
complicated inner logic; By adding the `:info` `&key` parameter, we
reduce the likelyhood of needing to duplicate that inner logic.

This relates to work done for #1693.

Closes #1740