### PR TITLE
(feat): replace `org-roam-{setup,teardown}` with `org-roam-db-autosync-mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here's a sample configuration with `use-package`:
              ;; Dailies
              ("C-c n j" . org-roam-dailies-capture-today))
       :config
-      (org-roam-setup)
+      (org-roam-db-autosync-mode)
       ;; If using org-roam-protocol
       (require 'org-roam-protocol))
 ```

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -308,7 +308,7 @@ is to use [[https://www.msys2.org/][MSYS2]] as at the time of this writing:
    Note that you do not need to manually set the PATH for MSYS2; the
 installer automatically takes care of it for you.
 
-4. Open Emacs and call ~M-x org-roam-setup~
+4. Open Emacs and call ~M-x org-roam-db-autosync-mode~
 
    This will automatically start compiling ~emacsql-sqlite~; you should see a
 message in minibuffer. It may take a while until compilation completes. Once
@@ -376,12 +376,12 @@ The ~file-truename~ function is only necessary when you use symbolic links
 inside ~org-roam-directory~: Org-roam does not resolve symbolic links.
 
 Next, we setup Org-roam to run functions on file changes to maintain cache
-consistency. This is achieved by running ~M-x org-roam-setup~. To ensure that
-Org-roam is available on startup, place this in your Emacs configuration:
+consistency. This is achieved by running ~M-x org-roam-db-autosync-mode~. To
+ensure that Org-roam is available on startup, place this in your Emacs
+configuration:
 
 #+begin_src emacs-lisp
-  (require 'org-roam)
-  (org-roam-setup)
+(org-roam-db-autosync-mode)
 #+end_src
 
 To build the cache manually, run ~M-x org-roam-db-sync~. Cache builds may

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -550,7 +550,7 @@ installer automatically takes care of it for you.
 
 @itemize
 @item
-Open Emacs and call @code{M-x org-roam-setup}
+Open Emacs and call @code{M-x org-roam-db-autosync-mode}
 
 This will automatically start compiling @code{emacsql-sqlite}; you should see a
 @end itemize
@@ -637,12 +637,12 @@ The @code{file-truename} function is only necessary when you use symbolic links
 inside @code{org-roam-directory}: Org-roam does not resolve symbolic links.
 
 Next, we setup Org-roam to run functions on file changes to maintain cache
-consistency. This is achieved by running @code{M-x org-roam-setup}. To ensure that
-Org-roam is available on startup, place this in your Emacs configuration:
+consistency. This is achieved by running @code{M-x org-roam-db-autosync-mode~}.
+To ensure that Org-roam is available on startup, place this in your Emacs
+configuration:
 
 @lisp
-(require 'org-roam)
-(org-roam-setup)
+(org-roam-db-autosync-mode)
 @end lisp
 
 To build the cache manually, run @code{M-x org-roam-db-sync}. Cache builds may

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -96,6 +96,13 @@ recursion."
     (nconc result (nreverse files))))
 
 ;;; Obsolete aliases (remove after next major release)
+(define-obsolete-function-alias
+  'org-roam-setup
+  'org-roam-db-autosync-enable "org-roam 2.0")
+(define-obsolete-function-alias
+  'org-roam-teardown
+  'org-roam-db-autosync-disable "org-roam 2.0")
+
 (define-obsolete-variable-alias
   'org-roam-current-node
   'org-roam-buffer-current-node "org-roam 2.0")

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -54,7 +54,7 @@
     (org-roam-db-sync))
 
   (after-all
-    (org-roam-teardown)
+    (org-roam-db--close)
     (delete-file org-roam-db-location))
 
   (it "has the correct number of files"


### PR DESCRIPTION
Comply with the principle of least astonishment, where in Emacs having a global minor mode for this purpose would be the most expected thing to have.

