### PR TITLE
Fix candidate display.

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -481,13 +481,21 @@ Uses `org-roam-node-display-template' to format the entry."
          (if (not field-width)
              field-value
            (setq field-width (string-to-number field-width))
-           (propertize field-value
-                       'display (truncate-string-to-width
-                                 field-value
-                                 (if (> field-width 0)
-                                     field-width
-                                   (- width (cdr fmt)))
-                                 0 ?\s))))))))
+           (let ((display-string (truncate-string-to-width
+                                  field-value
+                                  (if (> field-width 0)
+                                      field-width
+                                    (- width (cdr fmt)))
+                                  0 ?\s)))
+             ;; Setting the display (which would be padded out to the field length) for an
+             ;; empty string results in an empty string and misalignment for candidates that
+             ;; don't have some field. This uses the actual display string, made of spaces
+             ;; when the field-value is "" so that we actually take up space.
+             (if (not (equal field-value ""))
+                 ;; Remove properties from the full candidate string, otherwise the display
+                 ;; formatting with pre-prioritized field-values gets messed up.
+                 (propertize (substring-no-properties field-value) 'display display-string)
+               display-string))))))))
 
 (defun org-roam-node-read--process-display-format (format)
   "Pre-calculate minimal widths needed by the FORMAT string."


### PR DESCRIPTION
Recent changes to how candidates are formatted (using a display property
to allow for searching in the full candidate while only showing enough
to fit in the frame), #1754, causes problems when the field value is already
preformatted (a user function, like the one provided in doom emacs,
already applies some faces with `propertize`). Generally the display
string get messed up and formatting gets applied to the whole display.
This PR updates the `propertize` call that adds the display property to the candidate
to remove all properties from the candidate before the styled (and
truncated) display string is added as a property. This allows the
display string to look correct according to the properties a user has
already assigned.

This PR also fixes another bug from this change, where if a
`field-value` is and empty string `""` it would not get padded out to
the `field-width` causing misalignment between candidates.

###### Motivation for this change
