### PR TITLE
Make sure org-roam-node-from-title-or-alias won't mess up with the match-data

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -628,7 +628,7 @@ Assumes that the cursor was put where the link is."
         (goto-char (org-element-property :begin link))
         (when (and (org-in-regexp org-link-any-re 1)
                    (string-equal type "roam")
-                   (setq node (org-roam-node-from-title-or-alias path)))
+                   (setq node (save-match-data (org-roam-node-from-title-or-alias path))))
           (replace-match (org-link-make-string
                           (concat "id:" (org-roam-node-id node))
                           (or desc path))))))))


### PR DESCRIPTION
It lies in between org-in-regexp and replace-match. In some situations, like
when the link looks like roam:a s'b, it changes the match-data.

###### Motivation for this change
Get file file [test.txt](https://github.com/org-roam/org-roam/files/6975458/test.txt)
It is an elisp file, but github won't allow the extension .el...
It
- installs org-roam, 
- sets up a roam directory
- adds two files,
  - one with title "a s'b"
  - one with title "other" in it the content `[[roam:a s'b]]`
- run `org-roam-link-replace-all`

This simulates the behavior when you create a note and use the completion mecanism to add a link to another note.

Run this with emacs -Q --load test.txt, you will get the following error

`org-roam-link-replace-at-point: Args out of range: 0, 0`

Try removing the "'" character, so that the first file has the title "a sb" and the roam link is now `[[roam:a sb]]`. Now the test works.

Digging a little bit, I found out that, when the title is "a s'b"
- `org-roam-link-replace-at-point` calls `org-roam-node-from-title-or-alias`
- `org-roam-node-from-title-or-alias` calls `org-roam-db-query`
- `org-roam-db-query` calls `emacsql` and `org-roam-db`
- both `emacsql` and `org-roam-db` change the match-data

I did not look further. May be some other place of the code changes the match-data.

But I can tell that nesting `org-roam-link-replace-at-point` inside `save-match-data` fixes the issue.

Moreover, I guess it is a good practice to ensure that the code between anything that sets the match data (`org-in-regexp` in this example) and anything that relies on this match-data (`replace-match` in this example) does not change the match-data. 