### PR TITLE
(feat) scroll node to top

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -373,7 +373,8 @@ instead."
   (let ((buf (org-roam-node-find-noselect node)))
     (funcall (if other-window
                  #'switch-to-buffer-other-window
-               #'pop-to-buffer-same-window) buf)))
+               #'pop-to-buffer-same-window) buf)
+    (recenter-top-bottom 'top)))
 
 ;;;###autoload
 (cl-defun org-roam-node-find (&optional other-window initial-input filter-fn &key templates)


### PR DESCRIPTION
###### Motivation for this change

When visit a headline node, it will display at the bottom. this PR scroll the headline to top of the buffer