### PR TITLE
Stop point moving when visiting node if point already at node

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -355,12 +355,14 @@ GROUP BY id")))
 
 ;;;; Finders
 (defun org-roam-node-find-noselect (node)
-  "Navigate to the point for NODE, and return the buffer."
+  "Navigate to the point for NODE if point is not already at NODE, and return the buffer."
   (unless (org-roam-node-file node)
     (user-error "Node does not have corresponding file"))
   (let ((buf (find-file-noselect (org-roam-node-file node))))
     (with-current-buffer buf
-      (goto-char (org-roam-node-point node)))
+      (unless (equal (org-roam-node-id node)
+                     (org-roam-id-at-point))
+        (goto-char (org-roam-node-point node))))
     buf))
 
 (defun org-roam-node-visit (node &optional other-window)


### PR DESCRIPTION
When a buffer is buried and then brought up again, it is unexpected for
point to move. Currently, org-roam-node-find-noselect always sets point
to the pos column from the database, which corresponds to the very
beginning of the node in its file.

This patch extracts the logic in org-roam-node-at-point that finds the
node id associated with point into a new function,
org-roam-node--id-at-point. Then, org-roam-node-find-noselect is
modified to check whether point for the buffer associated with the node
is already at the target node. Only if it is not, is point moved to the
target node.
