### PR TITLE
(feat)db: use filenotify to trigger db updates

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.0.0
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "2.90.1"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "2.90.1") (filenotify-recursive "0.0.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -163,6 +163,9 @@ nodes." org-id-locations-file)
 (define-obsolete-function-alias
   'org-roam-teardown
   'org-roam-db-autosync-disable "org-roam 2.0")
+(define-obsolete-variable-alias
+  'org-roam-db-update-on-save
+  'org-roam-db-autosync-update-method "org-roam 2.0")
 
 (define-obsolete-variable-alias
   'org-roam-current-node
@@ -170,9 +173,6 @@ nodes." org-id-locations-file)
 (define-obsolete-variable-alias
   'org-roam-current-directory
   'org-roam-buffer-current-directory "org-roam 2.0")
-(define-obsolete-variable-alias
-  'org-roam-db-update-on-save
-  'org-roam-db-update-method "org-roam 2.0")
 (define-obsolete-function-alias
   'org-roam-buffer-render
   'org-roam-buffer-render-contents "org-roam 2.0")

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -170,6 +170,9 @@ nodes." org-id-locations-file)
 (define-obsolete-variable-alias
   'org-roam-current-directory
   'org-roam-buffer-current-directory "org-roam 2.0")
+(define-obsolete-variable-alias
+  'org-roam-db-update-on-save
+  'org-roam-db-update-method "org-roam 2.0")
 (define-obsolete-function-alias
   'org-roam-buffer-render
   'org-roam-buffer-render-contents "org-roam 2.0")

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -75,17 +75,17 @@ database."
 (defcustom org-roam-db-update-method (if file-notify--library
                                          'filenotify
                                        'on-save)
-  "How to keep Org-roam's database updated. This supports the
-following values:
+  "How to keep Org-roam's database updated.
+This supports the following values:
 
-  `on-save'
-    update the Org-roam database for the file that has changed.
+  'filenotify
+    Update Org-roam upon detecting changes from the filesystem.
 
-  `filenotify'
-   update Org-roam upon detecting changes from the filesystem.
+  'on-save
+    Update the Org-roam database for the file that has changed.
 
-  `nil'
-  Do not automatically update the Org-roam database."
+  nil
+    Do not automatically update the Org-roam database."
   :type '(choice (const :tag "On save" onsave)
                  (const :tag "Filenotify" filenotify)
                  (const :tag "Do not autoupdate" nil))
@@ -547,6 +547,9 @@ If FORCE, force a rebuild of the cache from scratch."
           (org-roam-db-update-file file))))))
 
 (defun org-roam-db-fn-callback (event)
+  "Handles filesystem EVENT.
+If Org-roam files are changed, we update the database
+accordingly."
   (pcase event
     (`(_ _ ,f)
      (when (org-roam-file-p f) (org-roam-db-update-file f)))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -31,7 +31,6 @@
 ;;
 ;;; Code:
 (require 'org-roam)
-(require 'filenotify)
 (defvar org-outline-path-cache)
 
 ;;; Options
@@ -593,6 +592,7 @@ database, see `org-roam-db-sync' command."
    (org-roam-db-autosync-mode ; enabled
     (pcase org-roam-db-autosync-update-method
       ('filenotify
+       (require 'filenotify)
        (cl-pushnew
         (cons org-roam-directory
               (file-notify-add-watch org-roam-directory '(change)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -31,6 +31,7 @@
 ;;
 ;;; Code:
 (require 'org-roam)
+(require 'filenotify)
 (defvar org-outline-path-cache)
 
 ;;; Options
@@ -592,7 +593,6 @@ database, see `org-roam-db-sync' command."
    (org-roam-db-autosync-mode ; enabled
     (pcase org-roam-db-autosync-update-method
       ('filenotify
-       (require 'filenotify)
        (cl-pushnew
         (cons org-roam-directory
               (file-notify-add-watch org-roam-directory '(change)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -597,7 +597,10 @@ database, see `org-roam-db-sync' command."
       ('filenotify
        (cl-pushnew
         (cons org-roam-directory
-              (fnr-add-watch org-roam-directory '(change) #'org-roam-db-autosync--filenotify-update))
+              (fnr-add-watch org-roam-directory
+                             '(change)
+                             #'org-roam-db-autosync--filenotify-update
+                             "\\`\\.")) ; Ignore directories that start with "."
         org-roam-db-autosync--filenotify-descriptors))
       ('on-save
        (add-hook 'org-roam-find-file-hook #'org-roam-db-autosync--setup-update-on-save-h)

--- a/org-roam-migrate.el
+++ b/org-roam-migrate.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.0.0
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "2.90.1"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "2.90.1") (filenotify-recursive "0.0.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.0.0
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "2.90.1"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "2.90.1") (filenotify-recursive "0.0.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.0.0
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "2.90.1"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "2.90.1") (filenotify-recursive "0.0.1"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
Using filenotify to trigger db updates is the most reliable way to ensure the
database is always up to date, making it resilient to changes from outside
Emacs.

This will also address issues seen in #1765, although the root cause should also be patched.