### PR TITLE
(fix)buffer: skip backlinks where file no longer exists

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -345,6 +345,8 @@ the same time:
    from SOURCE-NODE's file for the link (that references the
    other node) at POINT. Acts a child section of the previous
    one."
+  (unless (file-exists-p (org-roam-node-file source-node))
+    (cl-return-from org-roam-node-insert-section))
   (magit-insert-section section (org-roam-node-section)
     (let ((outline (if-let ((outline (plist-get properties :outline)))
                        (mapconcat #'org-link-display-format outline " > ")


### PR DESCRIPTION
This is a fix to #1763, and an alternative to #1765. The rationale for
not running a db-sync on buffer redisplay is that this is run on
`post-command-hook` and needs to be fast. 

When the file is missing, silently skipping seems like an okay option.