### PR TITLE
fix: Do not skip invisible headings when getting node at point.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1795](https://github.com/org-roam/org-roam/pull/1795) buffer: optimized reflinks fetch
 
 ### Fixed
+- [#1798](https://github.com/org-roam/org-roam/pull/1798) org-roam-node-at-point: do not skip invisible headings
 
 ## 2.1.0
 ### Added

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -180,7 +180,7 @@ populated."
                                     (magit-section-up)
                                     (org-roam-node-at-point)))
         (t (org-with-wide-buffer
-            (org-back-to-heading-or-point-min)
+            (org-back-to-heading-or-point-min t)
             (while (and (not (org-roam-db-node-p))
                         (not (bobp)))
               (org-roam-up-heading-or-point-min))
@@ -827,7 +827,7 @@ If region is active, then use it instead of the node at point."
   "Convert current subtree at point to a node, and extract it into a new file."
   (interactive)
   (save-excursion
-    (org-back-to-heading-or-point-min)
+    (org-back-to-heading-or-point-min t)
     (when (bobp) (user-error "Already a top-level node"))
     (org-id-get-create)
     (save-buffer)
@@ -865,7 +865,7 @@ If region is active, then use it instead of the node at point."
 Recursively traverses up the headline tree to find the
 first encapsulating ID."
   (org-with-wide-buffer
-   (org-back-to-heading-or-point-min)
+   (org-back-to-heading-or-point-min t)
    (while (and (not (org-roam-db-node-p))
                (not (bobp)))
      (org-roam-up-heading-or-point-min))


### PR DESCRIPTION
###### Motivation for this change
I'm using `org-roam-node-at-point` to fetch the title of the node when building the agenda. Not all my agenda-items are roam-nodes themself and I want to have access to the title of the parent node. However depending on whether the heading tree is visible or collapsed I'm getting different result. Turns out it's just a matter of `org-back-to-heading-or-point-min` which needed `invisible-ok` argument.

Example of the file that show different results depending on visibility
```
:PROPERTIES:
:ID:       dfe77ff7-7e27-4fdd-ad7c-ffd6aadc87bd
:END:
#+title: org-roam
#+startup: overview

* test
** inner
:PROPERTIES:
:ID:       4ced70aa-7b8c-41f0-b43e-3554dbbeeb10
:END:
*** item
SCHEDULED: <2021-08-21 Sat>
```

The result is either "inner" or "org-roam" depending on visibility.