### PR TITLE
Require org-macs when compiling org-roam-utils.el

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -32,6 +32,8 @@
 ;;
 ;;; Code:
 
+(require 'org-roam)
+
 ;;; String utilities
 ;; TODO Refactor this.
 (defun org-roam-replace-string (old new s)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -32,6 +32,9 @@
 ;;
 ;;; Code:
 
+(eval-when-compile
+  (require 'org-macs))
+
 ;;; String utilities
 ;; TODO Refactor this.
 (defun org-roam-replace-string (old new s)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -32,9 +32,6 @@
 ;;
 ;;; Code:
 
-(eval-when-compile
-  (require 'org-macs))
-
 ;;; String utilities
 ;; TODO Refactor this.
 (defun org-roam-replace-string (old new s)

--- a/org-roam.el
+++ b/org-roam.el
@@ -94,7 +94,6 @@
 (eval-when-compile
   (require 'subr-x))
 
-(require 'org-roam-utils)
 (require 'org-roam-compat)
 
 ;;; Options

--- a/org-roam.el
+++ b/org-roam.el
@@ -310,6 +310,7 @@ E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
 (provide 'org-roam)
 
 (cl-eval-when (load eval)
+  (require 'org-roam-utils)
   (require 'org-roam-db)
   (require 'org-roam-node)
   (require 'org-roam-capture)


### PR DESCRIPTION
If org-roam-utils.el is byte-compiled when org-macs is not loaded (`org-with-point-at` macro not available), error can appear about missing `org-with-point-at`

