### PR TITLE
(feat!)capture: unify template variables

### DIFF
--- a/extensions/org-roam-protocol.el
+++ b/extensions/org-roam-protocol.el
@@ -32,12 +32,21 @@
 ;; 1. "roam-node": This protocol simply opens the node given by the node ID
 ;; 2. "roam-ref": This protocol creates or opens the node with the given REF
 ;;
-;; You can find detailed instructions on how to setup the protocol in the
-;; documentation for Org-roam.
+;; To add new capture templates dedicated for the protocol, specify ":kind
+;; protocol" for each of such template in `org-roam-capture-templates', e.g.
+;;
+;;   (setq org-roam-capture-templates
+;;          '(("r" "ref" plain "%?" :kind protocol
+;;             :if-new (file+head "${slug}.org"
+;;                                "#+title: ${title}")
+;;             :unnarrowed t)))
+;;
+;; You can find a detailed instruction on how to setup the protocol in the
+;; manual for Org-roam.
 ;;
 ;;; Code:
 (require 'org-protocol)
-(require 'ol) ;; for org-link-decode
+(require 'ol) ; to use `org-link-decode'
 (require 'org-roam)
 
 ;;; Options
@@ -46,73 +55,12 @@
   :type 'boolean
   :group 'org-roam)
 
-(defcustom org-roam-capture-ref-templates
-  '(("r" "ref" plain "%?"
-     :if-new (file+head "${slug}.org"
-                        "#+title: ${title}")
-     :unnarrowed t))
-  "The Org-roam templates used during a capture from the roam-ref protocol.
-See `org-roam-capture-templates' for the template documentation."
-  :group 'org-roam
-  :type '(repeat
-          (choice (list :tag "Multikey description"
-                        (string :tag "Keys       ")
-                        (string :tag "Description"))
-                  (list :tag "Template entry"
-                        (string :tag "Keys           ")
-                        (string :tag "Description    ")
-                        (choice :tag "Capture Type   " :value entry
-                                (const :tag "Org entry" entry)
-                                (const :tag "Plain list item" item)
-                                (const :tag "Checkbox item" checkitem)
-                                (const :tag "Plain text" plain)
-                                (const :tag "Table line" table-line))
-                        (choice :tag "Template       "
-                                (string)
-                                (list :tag "File"
-                                      (const :format "" file)
-                                      (file :tag "Template file"))
-                                (list :tag "Function"
-                                      (const :format "" function)
-                                      (function :tag "Template function")))
-                        (plist :inline t
-                               ;; Give the most common options as checkboxes
-                               :options (((const :format "%v " :if-new)
-                                          (choice :tag "Node location"
-                                                  (list :tag "File"
-                                                        (const :format "" file)
-                                                        (string :tag "  File"))
-                                                  (list :tag "File & Head Content"
-                                                        (const :format "" file+head)
-                                                        (string :tag "  File")
-                                                        (string :tag "  Head Content"))
-                                                  (list :tag "File & Outline path"
-                                                        (const :format "" file+olp)
-                                                        (string :tag "  File")
-                                                        (list :tag "Outline path"
-                                                              (repeat (string :tag "Headline"))))
-                                                  (list :tag "File & Head Content & Outline path"
-                                                        (const :format "" file+head+olp)
-                                                        (string :tag "  File")
-                                                        (string :tag "  Head Content")
-                                                        (list :tag "Outline path"
-                                                              (repeat (string :tag "Headline"))))))
-                                         ((const :format "%v " :prepend) (const t))
-                                         ((const :format "%v " :immediate-finish) (const t))
-                                         ((const :format "%v " :jump-to-captured) (const t))
-                                         ((const :format "%v " :empty-lines) (const 1))
-                                         ((const :format "%v " :empty-lines-before) (const 1))
-                                         ((const :format "%v " :empty-lines-after) (const 1))
-                                         ((const :format "%v " :clock-in) (const t))
-                                         ((const :format "%v " :clock-keep) (const t))
-                                         ((const :format "%v " :clock-resume) (const t))
-                                         ((const :format "%v " :time-prompt) (const t))
-                                         ((const :format "%v " :tree-type) (const week))
-                                         ((const :format "%v " :unnarrowed) (const t))
-                                         ((const :format "%v " :table-line-pos) (string))
-                                         ((const :format "%v " :kill-buffer) (const t))))))))
+;;; Protocols
+(mapc (lambda (spec) (cl-pushnew spec org-protocol-protocol-alist :test #'equal))
+      '(("org-roam-ref"   :protocol "roam-ref"    :function org-roam-protocol-open-ref)
+        ("org-roam-node"  :protocol "roam-node"   :function org-roam-protocol-open-node)))
 
-;;; Handlers
+;;;; roam-ref
 (defun org-roam-protocol-open-ref (info)
   "Process an org-protocol://roam-ref?ref= style url with INFO.
 
@@ -146,29 +94,9 @@ It opens or creates a note with the given ref.
    :node (org-roam-node-create :title (plist-get info :title))
    :info (list :ref (plist-get info :ref)
                :body (plist-get info :body))
-   :templates org-roam-capture-ref-templates)
+   :props '(:kind protocol))
   nil)
 
-(defun org-roam-protocol-open-node (info)
-  "This handler simply opens the file with emacsclient.
-
-INFO is a plist containing additional information passed by the protocol URL.
-It should contain the FILE key, pointing to the path of the file to open.
-
-  Example protocol string:
-
-org-protocol://roam-node?node=uuid"
-  (when-let ((node (plist-get info :node)))
-    (raise-frame)
-    (org-roam-node-visit (org-roam-populate (org-roam-node-create :id node)) nil 'force))
-  nil)
-
-(push '("org-roam-ref"  :protocol "roam-ref"   :function org-roam-protocol-open-ref)
-      org-protocol-protocol-alist)
-(push '("org-roam-node"  :protocol "roam-node"   :function org-roam-protocol-open-node)
-      org-protocol-protocol-alist)
-
-;;; Capture implementation
 (add-hook 'org-roam-capture-preface-hook #'org-roam-protocol--try-capture-to-ref-h)
 (defun org-roam-protocol--try-capture-to-ref-h ()
   "Try to capture to an existing node that match the ref."
@@ -186,6 +114,27 @@ org-protocol://roam-node?node=uuid"
   (when-let ((ref (plist-get org-roam-capture--info :ref)))
     (org-roam-ref-add ref)))
 
+(when (org-roam-capture--load-templates-p 'org-roam-protocol)
+  (push '("r" "ref" plain "%?" :kind protocol
+          :if-new (file+head "${slug}.org"
+                             "#+title: ${title}")
+          :unnarrowed t)
+        org-roam-capture-templates))
+
+;;;; roam-node
+(defun org-roam-protocol-open-node (info)
+  "This handler simply opens the file with emacsclient.
+
+INFO is a plist containing additional information passed by the protocol URL.
+It should contain the FILE key, pointing to the path of the file to open.
+
+  Example protocol string:
+
+org-protocol://roam-node?node=uuid"
+  (when-let ((node (plist-get info :node)))
+    (raise-frame)
+    (org-roam-node-visit (org-roam-populate (org-roam-node-create :id node)) nil 'force))
+  nil)
 
 (provide 'org-roam-protocol)
 

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -202,6 +202,10 @@ nodes." org-id-locations-file)
 ;;; Obsolete functions
 (make-obsolete 'org-roam-get-keyword 'org-collect-keywords "org-roam 2.0")
 
+;;; Obsolete variables
+(make-obsolete-variable 'org-roam-dailies-capture-templates 'org-roam-capture-templates "org-roam 2.1")
+(make-obsolete-variable 'org-roam-capture-ref-templates 'org-roam-capture-templates "org-roam 2.1")
+
 (provide 'org-roam-compat)
 
 ;;; org-roam-compat.el ends here

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -105,6 +105,29 @@ If FILE, set `default-directory' to FILE's directory and insert its contents."
              (setq-local default-directory (file-name-directory ,file)))
            ,@body)))))
 
+;;; Processing options
+(defun org-roam--valid-option-p (option choice)
+  "Return t if OPTION satisfies CHOICE, else nil.
+OPTION is a symbol, while CHOICE is either, a symbol or a list of
+symbols that can optionally start with `:not' keyword.
+
+If CHOICE is a list that indicates negation, then the function
+will return t if OPTION isn't in the list. Otherwise it will
+return t is OPTION is present in the CHOICE.
+
+When CHOICE is a symbol, it will behave like `eq', except of
+special 'any value, in which case it will always return t,
+independently OPTION's value.
+
+CHOICE as a list can too contain 'any, in which case any OPTION
+value will be considered as part of the CHOICE, with respect to
+negation."
+  (let* ((choices (-list choice))
+         (intersection (-intersection (list option 'any) choices))
+         (negation (eq :not (car choices))))
+    (or (and intersection (not negation))
+        (and (not intersection) negation))))
+
 ;;; Formatting
 (defun org-roam-format-template (template replacer)
   "Format TEMPLATE with the function REPLACER.


### PR DESCRIPTION
See the first commit message of this PR about the change along with [this](https://org-roam.discourse.group/t/org-roam-bibtex-for-org-roam-v2/1574/83?u=mshevchuk) Discourse discussion. 

Here's a very simplified example of how capture templates will look like, if and when this will be merged:
```diff
- (setq org-roam-dailies-capture-templates
-       '(("d" "default" entry "* %?"
-          :if-new (file+head "%<%Y-%m-%d>.org"
-                             "#+title: %<%Y-%m-%d>\n")))

-       org-roam-capture-ref-templates
-       '(("r" "ref" plain "%?"
-          :if-new (file+head "${slug}.org"
-                             "#+title: ${title}")
-          :unnarrowed t)))
+ (setq org-roam-capture-templates
+      '(...
+        ("d" "default" entry "* %?" :kind daily
+         :if-new (file+head "%<%Y-%m-%d>.org"
+                            "#+title: %<%Y-%m-%d>\n"))
+         ...
+        ("r" "ref" plain "%?" :kind protocol
+         :if-new (file+head "${slug}.org"
+                            "#+title: ${title}")
+         :unnarrowed t)))
```

###### Motivation for this change
There's no easy way ATM to dynamically process all the available capture templates to selectively extract from them the declared information, especially from the Org-roam itself, where you can't be aware about existence of all of the extensions.  With this PR doing so should be a piece of cake.

Additionally, the users and extensions now will be able to specify contexts for their own needs, to narrow down a subset of capture templates for a specific purpose, without inventing ways to hook such things to Org-roam. For example, with this PR, #1354 can be solved as such:

```emacs-lisp
  (setq org-roam-capture-templates
        '(...
          ;; dailies
          ("d" "daily" entry "* %?" :kind daily :action any
           :if-new (file+head "%<%Y-%m-%d>.org" "#+title: %<%Y-%m-%d>\n"))
          ("x" "other daily" entry "* Something else %?" :kind daily
           :if-new (file+head "%<%Y-%m-%d>.org" "#+title: %<%Y-%m-%d>\nSomething else"))))
```
So if the user would run any of the `org-roam-dailies-goto-*` commands, the selection won't automatically popup, unless there's more than 1 `:kind daily :action goto` dedicated templates.

###### Things to get done before merging this
- [ ] Convert existing user's templates to the new format invisibly to the user.
  +  The change from this PR is breaking, but it can be soften. It won't handle all the edge cases, but will give the user time to readjust their own templates when they will have the time to do so.
- [ ] Reflect changes from this PR in the documentation and the changelog.
- [ ] Better think through the fallback behavior, e.g. what if there's no capture template for a given context? Like if there's no specified `:action goto` template, it should probably fallback to `:action capture` templates. 

Overall, it's fully working, but the code is still WIP and more like an MVP, so there will be some changes and refactors.