### PR TITLE
(fix)compat: resolve all the missing compile-time dependencies

### DIFF
--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -31,6 +31,8 @@
 ;; Emacsen and Org-roam versions.
 ;;
 ;;; Code:
+(require 'org-roam)
+
 ;;; Backports
 ;; REVIEW Remove when 26.x support is dropped. This is exact the same as
 ;; `directory-files-recursively' from Emacs 26, but with FOLLOW-SYMLINKS
@@ -155,12 +157,11 @@ nodes." org-id-locations-file)
 
 ;;;; Deprecated :if-new capture template keyword
 (with-eval-after-load 'org-roam-capture
-  (add-to-list 'org-roam-capture--template-keywords :if-new))
+  (add-to-list 'org-roam-capture--template-keywords :if-new)
 
-(advice-add 'org-roam-capture--get-target :around #'org-roam-capture--get-if-new-target-a)
-(defalias 'org-roam-capture--get-if-new-target-a
   (let ((inhibit-warning-p t)) ; REVIEW Set this to nil close to next major release
-    (lambda (fn &rest args)
+    (advice-add 'org-roam-capture--get-target :around #'org-roam-capture--get-if-new-target-a)
+    (defun org-roam-capture--get-if-new-target-a (fn &rest args)
       "Get the current capture target using deprecated :if-new property."
       (if-let ((target (org-roam-capture--get :if-new)))
           (prog1 target

--- a/org-roam.el
+++ b/org-roam.el
@@ -94,8 +94,6 @@
 (eval-when-compile
   (require 'subr-x))
 
-(require 'org-roam-compat)
-
 ;;; Options
 (defgroup org-roam nil
   "A database abstraction layer for Org-mode."
@@ -309,6 +307,7 @@ E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
 (provide 'org-roam)
 
 (cl-eval-when (load eval)
+  (require 'org-roam-compat)
   (require 'org-roam-utils)
   (require 'org-roam-db)
   (require 'org-roam-node)


### PR DESCRIPTION
48a5d017267af was wrong, and the closure wasn't the cause. The source of
the issue stems from a missing compile-time dependency on subr-x.

Emacs 28 doesn't seem to require it for the needed functions anymore,
while older Emacsen still do. What even worse, the byte compiler doesn't
seem to complain about such thing on older Emacsen and the error message
produced at the run-time isn't helpful to identify the cause.

Fixes #1814.
