### PR TITLE
org-roam-node-visit: fix typo

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -393,7 +393,7 @@ If NODE is already visited, this won't automatically move the
 point to the beginning of the NODE, unless FORCE is non-nil. In
 interactive calls FORCE always set to t."
   (interactive (list (org-roam-node-at-point t) current-prefix-arg t))
-  (let ((buf (org-roam-node-find-noselect node 'force))
+  (let ((buf (org-roam-node-find-noselect node force))
         (display-buffer-fn (if other-window
                                #'switch-to-buffer-other-window
                              #'pop-to-buffer-same-window)))


### PR DESCRIPTION
This function ignored the `force' optional argument because it always
quoted it, resulting in a non-nil value every time.

This makes the suggested code snippet in
https://github.com/org-roam/org-roam/issues/597#issuecomment-907743125
work as expected (not resetting point to the beginning of the "Index"
buffer on every invocation).
