### PR TITLE
(perf)db: wrap update-file in sql transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - [#1795](https://github.com/org-roam/org-roam/pull/1795) buffer: optimized reflinks fetch
 - [#1809](https://github.com/org-roam/org-roam/pull/1809) capture: the mandatory `:if-new` property of each capture template is now renamed to `:target`
+- [#1829](https://github.com/org-roam/org-roam/pull/1829) perf: file sql updates are now wrapped in a transaction
 
 ### Fixed
 - [#1798](https://github.com/org-roam/org-roam/pull/1798) org-roam-node-at-point: do not skip invisible headings

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -495,26 +495,27 @@ If the file exists, update the cache with information."
         info)
     (unless (string= content-hash db-hash)
       (org-roam-with-file file-path nil
-        (save-excursion
-          (org-set-regexps-and-options 'tags-only)
-          (org-roam-db-clear-file)
-          (org-roam-db-insert-file)
-          (org-roam-db-insert-file-node)
-          (setq org-outline-path-cache nil)
-          (org-roam-db-map-nodes
-           (list #'org-roam-db-insert-node-data
-                 #'org-roam-db-insert-aliases
-                 #'org-roam-db-insert-tags
-                 #'org-roam-db-insert-refs))
-          (setq org-outline-path-cache nil)
-          (setq info (org-element-parse-buffer))
-          (org-roam-db-map-links
-           info
-           (list #'org-roam-db-insert-link))
-          (when (require 'org-cite nil 'noerror)
-            (org-roam-db-map-citations
+        (emacsql-with-transaction (org-roam-db)
+          (save-excursion
+            (org-set-regexps-and-options 'tags-only)
+            (org-roam-db-clear-file)
+            (org-roam-db-insert-file)
+            (org-roam-db-insert-file-node)
+            (setq org-outline-path-cache nil)
+            (org-roam-db-map-nodes
+             (list #'org-roam-db-insert-node-data
+                   #'org-roam-db-insert-aliases
+                   #'org-roam-db-insert-tags
+                   #'org-roam-db-insert-refs))
+            (setq org-outline-path-cache nil)
+            (setq info (org-element-parse-buffer))
+            (org-roam-db-map-links
              info
-             (list #'org-roam-db-insert-citation))))))))
+             (list #'org-roam-db-insert-link))
+            (when (require 'org-cite nil 'noerror)
+              (org-roam-db-map-citations
+               info
+               (list #'org-roam-db-insert-citation)))))))))
 
 ;;;###autoload
 (defun org-roam-db-sync (&optional force)


### PR DESCRIPTION
This should lead to some performance gains on buffers with lots of
inserts required (e.g. when the buffer has a lot of links).