### PR TITLE
(feat)capture: support template in OLP nodes.

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -611,9 +611,11 @@ you can catch it with `condition-case'."
     (org-with-wide-buffer
      (goto-char start)
      (dolist (heading olp)
-       (let ((re (format org-complex-heading-regexp-format
-                         (regexp-quote heading)))
-             (cnt 0))
+       (let* ((heading  (replace-regexp-in-string
+                         "\n$" "" (org-roam-capture--fill-template heading t)))
+              (re (format org-complex-heading-regexp-format
+                          (regexp-quote heading)))
+              (cnt 0))
          (while (re-search-forward re end t)
            (setq level (- (match-end 1) (match-beginning 1)))
            (when (and (>= level lmin) (<= level lmax))


### PR DESCRIPTION
###### Motivation for this change

I wanted to create weeklies capture as it was discussed in https://github.com/org-roam/org-roam/issues/1411#issuecomment-788238542 already but didn't manage to do it too.

Here is example:
``` elisp
(setq org-roam-dailies-capture-templates
      '(("d" "default" entry "** %?" :if-new
        (file+head+olp "%<%G-W%V>.org" "#+title: %<%G-W%V>\n"
                       ("%<%A %Y-%m-%d>")))))
```
