### PR TITLE
(fix)db: Require 'oc to get org-cite functionality.

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -512,7 +512,7 @@ If the file exists, update the cache with information."
             (org-roam-db-map-links
              info
              (list #'org-roam-db-insert-link))
-            (when (require 'org-cite nil 'noerror)
+            (when (require 'oc nil 'noerror)
               (org-roam-db-map-citations
                info
                (list #'org-roam-db-insert-citation)))))))))


### PR DESCRIPTION
The org-cite library is called [oc.el](https://code.orgmode.org/bzg/org-mode/src/master/lisp/oc.el), not `org-cite.el`.