### PR TITLE
(refactor)completions: simplify org-roam-node-read--format-entry

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -515,13 +515,11 @@ Uses `org-roam-node-display-template' to format the entry."
          ;; empty string results in an empty string and misalignment for candidates that
          ;; don't have some field. This uses the actual display string, made of spaces
          ;; when the field-value is "" so that we actually take up space.
-         (let ((display-string (if field-width
-                                   (truncate-string-to-width field-value field-width 0 ?\s)
-                                 field-value)))
-           (if (equal field-value "")
-               display-string
-             ;; Remove properties from the full candidate string, otherwise the display
-             ;; formatting with pre-prioritized field-values gets messed up.
+         (if (or (not field-width) (equal field-value ""))
+             field-value
+           ;; Remove properties from the full candidate string, otherwise the display
+           ;; formatting with pre-propertized field-values gets messed up.
+           (let ((display-string (truncate-string-to-width field-value field-width 0 ?\s)))
              (propertize (substring-no-properties field-value) 'display display-string))))))))
 
 (defun org-roam-node-read--process-display-format (format)


### PR DESCRIPTION
This commit simplifies the code in org-roam-node-read--format-entry,
saving the entire processing of display properties when no
field-length is specified and thus no truncation needs to happen.
Since in this case, we don't truncate, the bug fixed in #1759 won't
reappear.

This has the beneficial side-effect that existing display properties
in the field-value, e.g., display properties that replace text by
images/icon, are not overridden by us when no field-length is
specified. Note that images anyway don't need truncation of the text
they replace.

This commit also fixes a wrong word in the comment.

###### Motivation for this change
