### PR TITLE
(fix)capture: ignore file template upon capture goto

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -466,8 +466,11 @@ capture target."
   (let ((id (cond ((run-hook-with-args-until-success 'org-roam-capture-preface-hook))
                   (t (org-roam-capture--setup-target-location)))))
     (org-roam-capture--adjust-point-for-capture-type)
-    (org-capture-put :template
-                     (org-roam-capture--fill-template (org-capture-get :template)))
+    (let ((template (org-capture-get :template)))
+      (when (stringp template)
+        (org-capture-put
+         :template
+         (org-roam-capture--fill-template template))))
     (org-roam-capture--put :id id)
     (org-roam-capture--put :finalize (or (org-capture-get :finalize)
                                          (org-roam-capture--get :finalize)))))


### PR DESCRIPTION
Currently, roam allows file template *nominally*, but, if one tries to set up, it causes trouble.

`goto` functions, like `org-roam-dailies-goto-*`, tries to expand file template with `org-roam-format-template`, which assumes template is string. Hence, complains about it.

This commit suppress such malfunctions by do nothing for non-string template.

Currently, this only affects a handful of quirks, like me, who wanting to exploit file templates for dailies; nevertheless, should work without trouble.