### PR TITLE
org-roam-db--insert-file: use file contents for hash

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -260,7 +260,7 @@ If UPDATE-P is non-nil, first remove the file in the database."
          (attr (file-attributes file))
          (atime (file-attribute-access-time attr))
          (mtime (file-attribute-modification-time attr))
-         (hash (org-roam-db--file-hash)))
+         (hash (org-roam-db--file-hash file)))
     (org-roam-db-query
      [:insert :into files
       :values $v1]


### PR DESCRIPTION
Use file contents for hash instead of buffer contents.
In case of encrypted files both ways lead to different results.
Otherwise encrypted files will need to be indexed each time
the cache will be updated/synced.
