### PR TITLE
fix(org-roam-db-map-links): Consider link in properties drawers

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -298,17 +298,18 @@ If UPDATE-P is non-nil, first remove the file in the database."
       ;; `re-search-forward' let the cursor one character after the link, we need to go backward one char to
       ;; make the point be on the link.
       (backward-char)
-      (let (element link bounds)
-        (setq element (org-element-context))
+      (let* ((element (org-element-context))
+             (type (org-element-type element))
+             link bounds)
         (cond
          ;; Links correctly recognized by Org Mode
-         ((eq (org-element-type element) 'link)
+         ((eq type 'link)
           (setq link element))
          ;; Links in property drawers. Recall that, as for Org Mode
          ;; v9.4.4, the org-element-type of links within properties
          ;; drawers is node-property.
-         ((and (or (eq (org-element-type element) 'node-property)
-                   (eq (org-element-type element) 'keyword))
+         ((and (or (eq type 'node-property)
+                   (eq type 'keyword))
                (setq bounds (org-in-regexp org-link-any-re))
                (setq link (buffer-substring-no-properties
                            (car bounds)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -313,7 +313,7 @@ If UPDATE-P is non-nil, first remove the file in the database."
                            (car bounds)
                            (cdr bounds))))
           (with-temp-buffer
-            (org-mode)
+            (delay-mode-hooks (org-mode))
             (insert link)
             (goto-char 1)
             (setq link (org-element-context)))))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -305,9 +305,9 @@ If UPDATE-P is non-nil, first remove the file in the database."
          ;; Links correctly recognized by Org Mode
          ((eq type 'link)
           (setq link element))
-         ;; Links in property drawers. Recall that, as for Org Mode
-         ;; v9.4.4, the org-element-type of links within properties
-         ;; drawers is node-property.
+         ;; Links in property drawers and lines starting with #+. Recall that, as for Org Mode v9.4.4, the
+         ;; org-element-type of links within properties drawers is "node-property" and for lines starting with
+         ;; #+ is "keyword".
          ((and (or (eq type 'node-property)
                    (eq type 'keyword))
                (setq bounds (org-in-regexp org-link-any-re))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -307,7 +307,8 @@ If UPDATE-P is non-nil, first remove the file in the database."
          ;; Links in property drawers. Recall that, as for Org Mode
          ;; v9.4.4, the org-element-type of links within properties
          ;; drawers is node-property.
-         ((and (eq (org-element-type element) 'node-property)
+         ((and (or (eq (org-element-type element) 'node-property)
+                   (eq (org-element-type element) 'keyword))
                (setq bounds (org-in-regexp org-link-any-re))
                (setq link (buffer-substring-no-properties
                            (car bounds)


### PR DESCRIPTION
###### Description

The current implementation uses `org-element-map` to iterate through all links in the current buffer. This function doesn't consider links within properties drawer. This implementation does consider such links.

###### Additional information

This pull request solves #1464 and #1859 .

A minimal working example that proves that `org-element-map` doesn't consider links in properties drawer can be found below.

```lisp
(let ((lines '("* John Doe"
               ":PROPERTIES:"
               ":FOO: [[1]]"
               ":END:"
               "[[2]]"
               "[[3]]")))
  (with-temp-buffer
    (org-mode)
    (insert (string-join lines "\n"))
    (org-element-map (org-element-parse-buffer)
        'link
      (lambda (link) (org-element-property :raw-link link)))))
```

```
("2" "3")
```

Another solution would be to make a patch for `org-element-map` so that this get fixed in the Org Mode codebase, but I think this would take much more time. For this reason, I created this pull request as a temporary workaround.

###### Motivation for this change

Some people, as me, store links in properties drawers. A use case of doing is shown below

```
* John Doe
:PROPERTIES:
:ID: 1daaebf6-f12b-449b-97d7-f56b57eee605
:KNOWS_OF+: [[id:303e7f25-21b1-4b40-81ab-8e4190fea512][GNU Emacs]]
:KNOWS_OF+: [[id:58893012-6137-4a9a-88c6-87098affe775][Guix]]
:LANGUAGE_NATIVE+: [[id:e4c3ad8c-fe23-4560-916c-52481b4ac4d7][Spanish]]
:LANGUAGE_FLUENT+: [[id:2333b842-0b0c-44f3-be19-eec8fbf4bdff][Russian]]
:END:
```