### PR TITLE
fix(org-roam-extract-subtree): Use file-name-as-directory

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -848,7 +848,8 @@ If region is active, then use it instead of the node at point."
                            (t (let ((r (completing-read (format "%s: " key) nil nil nil default-val)))
                                 (plist-put template-info ksym r)
                                 r)))))))
-           (file-path (read-file-name "Extract node to: " org-roam-directory template nil template)))
+           (file-path (read-file-name "Extract node to: "
+                                      (file-name-as-directory org-roam-directory) template nil template)))
       (when (file-exists-p file-path)
         (user-error "%s exists. Aborting" file-path))
       (org-cut-subtree)


### PR DESCRIPTION
###### Motivation for this change

The current implementation doesn't cover the scenario where
org-roam-directory doesn't have a trailing slash. Because of this,
users are enforced to make org-roam-directory end with a trailing
slash. If they don't do this, then the value of the prompt that is shown when executing `org-roam-extract-subtree` is

```
Extract node to: ~/org-roam2021_09_25_14_14_03.org
```

instead of (note the slash between the directory name and the file name for the new node.

```
Extract node to: ~/org-roam/2021_09_25_14_14_03.org
``