### PR TITLE
fix: dailies: stop asking for time, only date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1795](https://github.com/org-roam/org-roam/pull/1795) buffer: optimized reflinks fetch
 - [#1809](https://github.com/org-roam/org-roam/pull/1809) capture: the mandatory `:if-new` property of each capture template is now renamed to `:target`
 - [#1829](https://github.com/org-roam/org-roam/pull/1829) perf: file sql updates are now wrapped in a transaction
+- [#1877](https://github.com/org-roam/org-roam/pull/1877) dailies: stop asking for time, only date
 
 ### Fixed
 - [#1798](https://github.com/org-roam/org-roam/pull/1798) org-roam-node-at-point: do not skip invisible headings

--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -192,9 +192,9 @@ With a `C-u' prefix or when GOTO is non-nil, go the note without
 creating an entry."
   (interactive "P")
   (let ((time (let ((org-read-date-prefer-future prefer-future))
-                (org-read-date t t nil (if goto
-                                           "Find daily-note: "
-                                         "Capture to daily-note: ")))))
+                (org-read-date nil t nil (if goto
+                                             "Find daily-note: "
+                                           "Capture to daily-note: ")))))
     (org-roam-dailies--capture time goto)))
 
 ;;;###autoload


### PR DESCRIPTION
###### Motivation for this change

There is no reason `org-roam-dailies-capture-date` should ask for a time as only a date is necessary.

## Before

![2021-09-29-210809](https://user-images.githubusercontent.com/217543/135333038-8967bf88-e4a8-4a59-a536-62d573dda8e1.png)

## After

![2021-09-29-210751](https://user-images.githubusercontent.com/217543/135333050-4a64cd86-8661-4dfe-aebb-327dc6fa3471.png)
