### PR TITLE
fix(org-roam-node-read): fix regression introduced in #1876

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -443,7 +443,8 @@ If REQUIRE-MATCH, the minibuffer prompt will require a match."
   (let* ((nodes (org-roam-node-read--completions))
          (nodes (if filter-fn
                     (cl-remove-if-not
-                     (lambda (n) (funcall filter-fn (cdr n)) t))
+                     (lambda (n) (funcall filter-fn (cdr n)))
+                     nodes)
                   nodes))
          (sort-fn (or sort-fn
                       (when org-roam-node-default-sort


### PR DESCRIPTION
Fix `filter-fn` not working like its supposed to.
