### PR TITLE
Fix typo in default value of org-roam-graph-node-extra-config

### DIFF
--- a/extensions/org-roam-graph.el
+++ b/extensions/org-roam-graph.el
@@ -81,7 +81,7 @@ Example:
                ("fillcolor"  . "#EEEEEE")
                ("color"      . "#C9C9C9")
                ("fontcolor"  . "#0A97A6")))
-    ("https" . (("shape"      . "rounded,filled")
+    ("https" . (("style"      . "rounded,filled")
                 ("fillcolor"  . "#EEEEEE")
                 ("color"      . "#C9C9C9")
                 ("fontcolor"  . "#0A97A6"))))


### PR DESCRIPTION
This affects the graphviz graph output:
Now https nodes display with the proper styling by default.