### PR TITLE
Remove f dependency

### DIFF
--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -37,7 +37,6 @@
 ;; scratch notes and whatever else you can came up with.
 ;;
 ;;; Code:
-(require 'f)
 (require 'dash)
 (require 'org-roam)
 
@@ -266,7 +265,7 @@ If FILE is not specified, use the current buffer's file-path."
     (save-match-data
       (and
        (org-roam-file-p path)
-       (f-descendant-of-p path directory)))))
+       (file-in-directory-p path directory)))))
 
 ;;;###autoload
 (defun org-roam-dailies-find-directory ()

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -677,7 +677,7 @@ References from FILE are excluded."
                     col (string-to-number (match-string 3 line))
                     match (match-string 4 line))
               (when (and match
-                         (not (f-equal-p (org-roam-node-file node) f))
+                         (not (file-equal-p (org-roam-node-file node) f))
                          (member (downcase match) (mapcar #'downcase titles)))
                 (magit-insert-section section (org-roam-grep-section)
                   (oset section file f)

--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.1.0
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (f "0.17.2") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "3.0.0") (emacsql-sqlite "1.0.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -71,7 +71,6 @@
 ;; majority of them can be found at https://github.com/org-roam and MELPA.
 ;;
 ;;; Code:
-(require 'f)
 (require 'dash)
 
 (require 'rx)
@@ -195,7 +194,7 @@ FILE is an Org-roam file if:
        (member ext org-roam-file-extensions)
        (not (and org-roam-file-exclude-regexp
                  (string-match-p org-roam-file-exclude-regexp path)))
-       (f-descendant-of-p path (expand-file-name org-roam-directory))))))
+       (file-in-directory-p path (expand-file-name org-roam-directory))))))
 
 (defun org-roam-list-files ()
   "Return a list of all Org-roam files under `org-roam-directory'.


### PR DESCRIPTION
The f library is being used, even though all the functionality you need is already built in to Emacs itself. This patch replaces f.el with the built-in analogues, removing an unnecessary dependency.

If interested, this could also serve as the basis to add org-roam to [NonGNU ELPA](https://elpa.nongnu.org).