### PR TITLE
Remove `org-roam-with-file` dir-local indent entry

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -9,5 +9,4 @@
                               (org-with-point-at . 1)
                               (magit-insert-section . defun)
                               (magit-section-case . 0)
-                              (->> . 1)
-                              (org-roam-with-file . 2)))))
+                              (->> . 1)))))


### PR DESCRIPTION
Remove `org-roam-with-file` dir-local indent entry

This `org-rorm-with-file` indent entry is not needed.
This macro is defined by this package and already has indent of 2.

    (defmacro org-roam-with-file (file keep-buf-p &rest body)
      (declare (indent 2) (debug t))

quoted from org-roam-utils.el