### PR TITLE
(minor)db: make check for property drawers case-insensitive

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -344,7 +344,7 @@ If UPDATE-P is non-nil, first remove the file in the database."
           (setq link element))
          ;; Prevent self-referencing links in ROAM_REFS
          ((and (eq type 'node-property)
-               (string-equal (org-element-property :key element) "ROAM_REFS"))
+               (org-roam-string-equal (org-element-property :key element) "ROAM_REFS"))
           nil)
          ;; Links in property drawers and lines starting with #+. Recall that, as for Org Mode v9.4.4, the
          ;; org-element-type of links within properties drawers is "node-property" and for lines starting with

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -52,6 +52,13 @@
     (org-roam-replace-string "\\" "\\\\")
     (org-roam-replace-string "\"" "\\\"")))
 
+(defun org-roam-string-equal (s1 s2)
+  "Return t if S1 and S2 are equal.
+Like `string-equal', but case-insensitive."
+  (and (= (length s1) (length s2))
+       (or (string-equal s1 s2)
+           (string-equal (downcase s1) (downcase s2)))))
+
 ;;; List utilities
 (defmacro org-roam-plist-map! (fn plist)
   "Map FN over PLIST, modifying it in-place."


### PR DESCRIPTION
As per title cc @nobiot 

I think other uses of `string-equal` are fine.