### PR TITLE
(minor)db: filename title sans-extension

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -382,7 +382,8 @@ INFO is the org-element parsed buffer."
                (title (org-link-display-format
                        (or (cadr (assoc "TITLE" (org-collect-keywords '("title"))
                                         #'string-equal))
-                           (file-relative-name file org-roam-directory))))
+                           (file-name-sans-extension
+                            (file-relative-name file org-roam-directory)))))
                (pos (point))
                (todo nil)
                (priority nil)


### PR DESCRIPTION
Use the file name without extension when no TITLE is specified.