### PR TITLE
Make org-roam-plist-map! more efficient & really modifying in place

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -60,17 +60,15 @@ Like `string-equal', but case-insensitive."
            (string-equal (downcase s1) (downcase s2)))))
 
 ;;; List utilities
-(defmacro org-roam-plist-map! (fn plist)
-  "Map FN over PLIST, modifying it in-place."
-  (declare (indent 1))
-  (let ((plist-var (make-symbol "plist"))
-        (k (make-symbol "k"))
-        (v (make-symbol "v")))
-    `(let ((,plist-var (copy-sequence ,plist)))
-       (while ,plist-var
-         (setq ,k (pop ,plist-var))
-         (setq ,v (pop ,plist-var))
-         (setq ,plist (plist-put ,plist ,k (funcall ,fn ,k ,v)))))))
+(defun org-roam-plist-map! (fn plist)
+  "Map FN over PLIST, modifying it in-place and returning it.
+FN must take two arguments: the key and the value."
+  (let ((plist-index plist))
+    (while plist-index
+      (let ((key (pop plist-index)))
+        (setf (car plist-index) (funcall fn key (car plist-index))
+              plist-index (cdr plist-index)))))
+  plist)
 
 ;;; File utilities
 (defmacro org-roam-with-file (file keep-buf-p &rest body)


### PR DESCRIPTION
The old implementation
- did not handle duplicate keys well (the function would be applied to each value, but only the first value would be updated with the last value's result):
```
(let ((a (list :a 1 :a 2)))
  (org-roam-plist-map! 'list a) a)
;; => (:a (:a 2) :a 2)
;; I expected (:a (:a 1) :a (:a 2))
```
- was quadratic in the length of the input list (for each key, `plist-put` would search for the first occurrence of the key by going through all previous elements again)
- copied the input sequence even though this was not really needed
- did not provide a result value that could be useful, thus encouraging imperative programming
- did not need to be a macro, and the macro implementation was evaluating `fn` multiple times and causing warnings in the native compiler because `k` and `v` were not bound.  If you really want it to be a macro, consider rewriting the macro as follows:
```
(defmacro org-roam-plist-map! (fn plist)
  "Map FN over PLIST, modifying it in-place."
  (declare (indent 1))
  (let ((plist-head (gensym "plist-head"))
        (plist-var (gensym "plist"))
        (k (gensym "k"))
        (fn-var (gensym "fn")))
    `(let* ((,plist-head ,plist)
            (,plist-var ,plist-head)
            (,fn-var ,fn))
       (while ,plist-var
         (let ((,k (pop ,plist-var)))
           (setf (car ,plist-var) (funcall ,fn-var ,k (car ,plist-var))
                 ,plist-var (cdr ,plist-var))))
       ,plist-head)))
```
