### PR TITLE
Fix minor warnings by native compiler

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -205,7 +205,8 @@ be replaced with content and expanded:
               introduced with %[pathname] are expanded this way.  Since this
               happens after expanding non-interactive %-escapes, those can
               be used to fill the expression.
-  %<...>      The result of `format-time-string' on the ... format specification.
+  %<...>      The result of `format-time-string' on the ... format
+              specification.
   %t          Time stamp, date only.  The time stamp is the current time,
               except when called from agendas with `\\[org-agenda-capture]' or
               with `org-capture-use-agenda-date' set.

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -48,7 +48,7 @@ tool, which is not recommended because it is not suitable to be
 used like this, but has the advantage that you likely don't need
 a compiler. See https://nullprogram.com/blog/2014/02/06/."
   :package-version '(org-roam . "2.2.0")
-  :group 'forge
+  :group 'org-roam
   :type '(choice (const sqlite)
                  (const libsqlite3)
                  (const sqlite3)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -116,6 +116,10 @@ slow."
   (gethash (expand-file-name (file-name-as-directory org-roam-directory))
            org-roam-db--connection))
 
+(declare-function emacsql-sqlite "ext:emacsql-sqlite")
+(declare-function emacsql-libsqlite3 "ext:emacsql-libsqlite3")
+(declare-function emacsql-sqlite3 "ext:emacsql-sqlite3")
+
 (defun org-roam-db--conn-fn ()
   "Return the function for creating the database connection."
   (cl-case org-roam-database-connector

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -160,7 +160,8 @@ value shows the current node in the persistent `org-roam-buffer'.")
 
 (defvar org-roam-buffer-current-directory nil
   "The `org-roam-directory' value of `org-roam-buffer-current-node'.
-Set both, locally and globally in the same way as `org-roam-buffer-current-node'.")
+Set both, locally and globally in the same way as
+`org-roam-buffer-current-node'.")
 
 (put 'org-roam-buffer-current-directory 'permanent-local t)
 

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -109,7 +109,9 @@ has the entry (\"tags\" . \"#\"), these will appear as
 
 (defcustom org-roam-ref-annotation-function #'org-roam-ref-read--annotation
   "This function used to attach annotations for `org-roam-ref-read'.
-It takes a single argument REF, which is a propertized string.")
+It takes a single argument REF, which is a propertized string."
+  :group 'org-roam
+  :type  '(function))
 
 ;;;; Completion-at-point
 (defcustom org-roam-completion-everywhere nil
@@ -594,7 +596,8 @@ TEMPLATE is the processed template used to format the entry."
 
 (defun org-roam-node-read-sort-by-file-mtime (completion-a completion-b)
   "Sort files such that files modified more recently are shown first.
-COMPLETION-A and COMPLETION-B are items in the form of (node-title org-roam-node-struct)"
+COMPLETION-A and COMPLETION-B are items in the form of
+\(node-title org-roam-node-struct)"
   (let ((node-a (cdr completion-a))
         (node-b (cdr completion-b)))
     (time-less-p (org-roam-node-file-mtime node-b)
@@ -602,7 +605,8 @@ COMPLETION-A and COMPLETION-B are items in the form of (node-title org-roam-node
 
 (defun org-roam-node-read-sort-by-file-atime (completion-a completion-b)
   "Sort files such that files accessed more recently are shown first.
-COMPLETION-A and COMPLETION-B are items in the form of (node-title org-roam-node-struct)"
+COMPLETION-A and COMPLETION-B are items in the form of
+\(node-title org-roam-node-struct)"
   (let ((node-a (cdr completion-a))
         (node-b (cdr completion-b)))
     (time-less-p (org-roam-node-file-atime node-b)
@@ -940,7 +944,7 @@ links to headings/files within the current `org-roam-directory'
 that are excluded from identification in Org-roam as
 `org-roam-node's, e.g. with \"ROAM_EXCLUDE\" property."
   (interactive)
-  (cl-loop with files for dir in (cons org-roam-directory directories)
+  (cl-loop for dir in (cons org-roam-directory directories)
            for org-roam-directory = dir
            nconc (org-roam-list-files) into files
            finally (org-id-update-id-locations files org-roam-verbose)))
@@ -1084,7 +1088,7 @@ and when nil is returned the node will be filtered out."
   (let ((node (org-roam-node-at-point 'assert)))
     (save-excursion
       (goto-char (org-roam-node-point node))
-      (org-roam-add-property alias "ROAM_ALIASES"))))
+      (org-roam-property-add "ROAM_ALIASES" alias))))
 
 (defun org-roam-alias-remove (&optional alias)
   "Remove an ALIAS from the node at point."
@@ -1092,7 +1096,7 @@ and when nil is returned the node will be filtered out."
   (let ((node (org-roam-node-at-point 'assert)))
     (save-excursion
       (goto-char (org-roam-node-point node))
-      (org-roam-remove-property "ROAM_ALIASES" alias))))
+      (org-roam-property-remove "ROAM_ALIASES" alias))))
 
 
 (provide 'org-roam-node)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -152,6 +152,8 @@ value (possibly nil). Adapted from `s-format'."
       (set-match-data saved-match-data))))
 
 ;;; Fontification
+(defvar org-ref-buffer-hacked)
+
 (defun org-roam-fontify-like-in-org-mode (s)
   "Fontify string S like in Org mode.
 Like `org-fontify-like-in-org-mode', but supports `org-ref'."

--- a/org-roam.el
+++ b/org-roam.el
@@ -292,6 +292,8 @@ E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
                                              ,@(mapcar (lambda (glob) (concat "-g " glob)) globs)) " ")))
     (org-roam--shell-command-files command)))
 
+(declare-function org-roam--directory-files-recursively "org-roam-compat")
+
 (defun org-roam--list-files-elisp (dir)
   "Return all Org-roam files under DIR, using Elisp based implementation."
   (let ((regex (concat "\\.\\(?:"(mapconcat


### PR DESCRIPTION
After fixing #1958, there are more compiler warnings remaining, fixed in the first commit of this branch.  Note that

    (declare-function org-roam--directory-files-recursively "org-roam-compat")

is a bit of a band-aid: I think (but failed) that the dependency structure of the various parts of org-roam should be reorganised to avoid the circular imports (currently "hidden" by `cl-eval-when` at the end of `org-roam.el`).  Then `org-roam.el` could simply `(require 'org-roam-compat)` at the beginning, if `org-roam-compat.el` could be rewritten not to have to `(require 'org-roam)`.

Apologies for not creating a separate branch for the drive-by fix of the `:group` value of `org-roam-database-connector` but I felt it was not worth it.