### PR TITLE
Avoid surprises when STUFF contains the same key twice

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -445,13 +445,13 @@ the capture)."
   "Get the value for KEYWORD from the `org-roam-capture-template'."
   (plist-get (plist-get org-capture-plist :org-roam) keyword))
 
-(defun org-roam-capture--put (&rest stuff)
-  "Put properties from STUFF into the `org-roam-capture-template'."
+(defun org-roam-capture--put (prop value)
+  "Set property PROP to VALUE in the `org-roam-capture-template'."
   (let ((p (plist-get org-capture-plist :org-roam)))
-    (while stuff
-      (setq p (plist-put p (pop stuff) (pop stuff))))
     (setq org-capture-plist
-          (plist-put org-capture-plist :org-roam p))))
+          (plist-put org-capture-plist
+                     :org-roam
+                     (plist-put p prop value)))))
 
 ;;;; Capture target
 (defun org-roam-capture--prepare-buffer ()


### PR DESCRIPTION
Given that this code

    (let ((org-capture-plist (list :org-roam (list :z 26 :z "ignored"))))
      (org-roam-capture--get :z))

returns 26, I would expect

    (let ((org-capture-plist nil))
      (org-roam-capture--put :z 26 :z "ignored")
      (org-roam-capture--get :z))

to return 26, too, but it returns "ignored".

This patch fixes it by "reversing" the input list before using `plist-put` on its elements.