### PR TITLE
Add column "filetitle" to table "file"; adapt queries to that change

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -186,8 +186,7 @@ The query is expected to be able to fail, in this situation, run HANDLER."
 (defconst org-roam-db--table-schemata
   '((files
      [(file :unique :primary-key)
-      ;; "file-title" would be converted to "file_title"
-      filetitle
+      title
       (hash :not-null)
       (atime :not-null)
       (mtime :not-null)])

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -297,7 +297,7 @@ If FILE is nil, clear the current buffer."
 ;;;; Updating tables
 
 (defun org-roam-db--file-title ()
-  "In current org document, get the title.
+  "In current Org buffer, get the title.
 If there is no title, return the file name relative to
 `org-roam-directory'."
   (org-link-display-format

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -99,7 +99,7 @@ slow."
   :group 'org-roam)
 
 ;;; Variables
-(defconst org-roam-db-version 17)
+(defconst org-roam-db-version 18)
 
 ;; TODO Rename this
 (defconst org-roam--sqlite-available-p
@@ -186,6 +186,8 @@ The query is expected to be able to fail, in this situation, run HANDLER."
 (defconst org-roam-db--table-schemata
   '((files
      [(file :unique :primary-key)
+      ;; "file-title" would be converted to "file_title"
+      filetitle
       (hash :not-null)
       (atime :not-null)
       (mtime :not-null)])
@@ -294,10 +296,22 @@ If FILE is nil, clear the current buffer."
                      file))
 
 ;;;; Updating tables
+
+(defun org-roam-db--file-title ()
+  "In current org document, get the title.
+If there is no title, return the file name relative to
+`org-roam-directory'."
+  (org-link-display-format
+   (or (cadr (assoc "TITLE" (org-collect-keywords '("title"))))
+       (file-name-sans-extension (file-relative-name
+                                  (buffer-file-name (buffer-base-buffer))
+                                  org-roam-directory)))))
+
 (defun org-roam-db-insert-file ()
   "Update the files table for the current buffer.
 If UPDATE-P is non-nil, first remove the file in the database."
   (let* ((file (buffer-file-name))
+         (file-title (org-roam-db--file-title))
          (attr (file-attributes file))
          (atime (file-attribute-access-time attr))
          (mtime (file-attribute-modification-time attr))
@@ -305,7 +319,7 @@ If UPDATE-P is non-nil, first remove the file in the database."
     (org-roam-db-query
      [:insert :into files
       :values $v1]
-     (list (vector file hash atime mtime)))))
+     (list (vector file file-title hash atime mtime)))))
 
 (defun org-roam-db-get-scheduled-time ()
   "Return the scheduled time at point in ISO8601 format."
@@ -383,11 +397,7 @@ INFO is the org-element parsed buffer."
                (org-roam-db-node-p))
       (when-let ((id (org-id-get)))
         (let* ((file (buffer-file-name (buffer-base-buffer)))
-               (title (org-link-display-format
-                       (or (cadr (assoc "TITLE" (org-collect-keywords '("title"))
-                                        #'string-equal))
-                           (file-name-sans-extension
-                            (file-relative-name file org-roam-directory)))))
+               (title (org-roam-db--file-title))
                (pos (point))
                (todo nil)
                (priority nil)

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -146,7 +146,7 @@ It takes a single argument REF, which is a propertized string."
 (cl-defstruct (org-roam-node (:constructor org-roam-node-create)
                              (:copier nil))
   "A heading or top level file with an assigned ID property."
-  file file-hash file-atime file-mtime
+  file file-title file-hash file-atime file-mtime
   id level point todo priority scheduled deadline title properties olp
   tags aliases refs)
 
@@ -289,7 +289,7 @@ nodes."
                                                  :limit 1]
                                                 (org-roam-node-id node)))))
     (pcase-let* ((`(,file ,level ,pos ,todo ,priority ,scheduled ,deadline ,title ,properties ,olp) node-info)
-                 (`(,atime ,mtime) (car (org-roam-db-query [:select [atime mtime]
+                 (`(,atime ,mtime ,file-title) (car (org-roam-db-query [:select [atime mtime filetitle]
                                                             :from files
                                                             :where (= file $s1)]
                                                            file)))
@@ -303,6 +303,7 @@ nodes."
                                                               :where (= node-id $s1)]
                                                              (org-roam-node-id node)))))
       (setf (org-roam-node-file node) file
+            (org-roam-node-file-title node) file-title
             (org-roam-node-file-atime node) atime
             (org-roam-node-file-mtime node) mtime
             (org-roam-node-level node) level
@@ -325,6 +326,7 @@ nodes."
                "SELECT
   id,
   file,
+  filetitle,
   \"level\",
   todo,
   pos,
@@ -344,6 +346,7 @@ FROM
   SELECT
     id,
     file,
+    filetitle,
     \"level\",
     todo,
     pos,
@@ -374,6 +377,7 @@ FROM
       nodes.olp as olp,
       files.atime as atime,
       files.mtime as mtime,
+      files.filetitle as filetitle,
       tags.tag as tags,
       aliases.alias as aliases,
       '(' || group_concat(RTRIM (refs.\"type\", '\"') || ':' || LTRIM(refs.ref, '\"'), ' ') || ')' as refs
@@ -386,13 +390,14 @@ FROM
   GROUP BY id, tags )
 GROUP BY id")))
     (cl-loop for row in rows
-             append (pcase-let* ((`(,id ,file ,level ,todo ,pos ,priority ,scheduled ,deadline
+             append (pcase-let* ((`(,id ,file ,file-title ,level ,todo ,pos ,priority ,scheduled ,deadline
                                         ,title ,properties ,olp ,atime ,mtime ,tags ,aliases ,refs)
                                   row)
                                  (all-titles (cons title aliases)))
                       (mapcar (lambda (temp-title)
                                 (org-roam-node-create :id id
                                                       :file file
+                                                      :file-title file-title
                                                       :file-atime atime
                                                       :file-mtime mtime
                                                       :level level

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -289,7 +289,7 @@ nodes."
                                                  :limit 1]
                                                 (org-roam-node-id node)))))
     (pcase-let* ((`(,file ,level ,pos ,todo ,priority ,scheduled ,deadline ,title ,properties ,olp) node-info)
-                 (`(,atime ,mtime ,file-title) (car (org-roam-db-query [:select [atime mtime filetitle]
+                 (`(,atime ,mtime ,file-title) (car (org-roam-db-query [:select [atime mtime title]
                                                             :from files
                                                             :where (= file $s1)]
                                                            file)))
@@ -377,7 +377,7 @@ FROM
       nodes.olp as olp,
       files.atime as atime,
       files.mtime as mtime,
-      files.filetitle as filetitle,
+      files.title as filetitle,
       tags.tag as tags,
       aliases.alias as aliases,
       '(' || group_concat(RTRIM (refs.\"type\", '\"') || ':' || LTRIM(refs.ref, '\"'), ' ') || ')' as refs

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -290,9 +290,9 @@ nodes."
                                                 (org-roam-node-id node)))))
     (pcase-let* ((`(,file ,level ,pos ,todo ,priority ,scheduled ,deadline ,title ,properties ,olp) node-info)
                  (`(,atime ,mtime ,file-title) (car (org-roam-db-query [:select [atime mtime title]
-                                                            :from files
-                                                            :where (= file $s1)]
-                                                           file)))
+                                                                        :from files
+                                                                        :where (= file $s1)]
+                                                                       file)))
                  (tag-info (mapcar #'car (org-roam-db-query [:select [tag] :from tags
                                                              :where (= node-id $s1)]
                                                             (org-roam-node-id node))))


### PR DESCRIPTION
The column "filetitle" is populated with the document title or, if
there is none, the basic filename (sans extension) of the file. It is
copied into the org-roam-node when retrieving nodes.

###### Motivation for this change

See #1956 