### PR TITLE
fix(org-roam-db-map-links): goto-char added to point-min

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -375,7 +375,7 @@ If UPDATE-P is non-nil, first remove the file in the database."
           (with-temp-buffer
             (delay-mode-hooks (org-mode))
             (insert link)
-            (point-min)
+            (goto-char (point-min))
             (setq link (org-element-context)))))
         (when link
           (dolist (fn fns)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -375,7 +375,6 @@ If UPDATE-P is non-nil, first remove the file in the database."
           (with-temp-buffer
             (delay-mode-hooks (org-mode))
             (insert link)
-            (goto-char (point-min))
             (setq link (org-element-context)))))
         (when link
           (dolist (fn fns)


### PR DESCRIPTION
###### Motivation for this change

Apparently, 4a2b44252ef4e71f183f627a49e6ec70c3cf8903 introduced a change that was not intended. The reason why I state this is because in that commit, `org-roam-db-map-links` evaluates `(point-min)` and it does nothing with the returned value. I think that `(goto-char (point-min))` was intended to be evaluated.