### PR TITLE
fix:(org-roam-db)Support Org-ref V3 syntax #1973

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -507,10 +507,11 @@ INFO is the org-element parsed buffer."
       ;; For Org-ref links, we need to split the path into the cite keys
       (when (and source path)
         (if (and (boundp 'org-ref-cite-types)
-                 (fboundp 'org-ref-split-and-strip-string)
-                 (member type org-ref-cite-types))
+                 (assoc type org-ref-cite-types))
             (progn
-              (setq path (org-ref-split-and-strip-string path))
+              ;; For Org-ref V3's syntax, remove the prefix ampersand "&". V3 also supports V2 syntax; hence
+              ;; the `when' conditional.
+              (when (string-prefix-p "&" path) (setq path (substring path 1)))
               (org-roam-db-query
                [:insert :into citations
                 :values $v1]


### PR DESCRIPTION
###### Motivation for this change
Refer to issue #1973. This is meant to be a discussion starter with a concrete implementation example.
As the change will render `org-roam-db` incompatible with V2, we might not like to use it as is.

1. Function org-ref-split-and-strip-string does not exist in V3 Org-ref

2. org-ref-cite-types is now a different type in V3; `member` does not match; use `assoc` instead

3. match ROAM_REF without "&"

Because of Point 2 above, this change is not backward compatible with V2; the
change will make org-roam-db support only V3 Org-ref.

##### Test results:

![Screenshot from 2021-11-18 17-36-06](https://user-images.githubusercontent.com/12507865/142459060-5544f010-f652-451e-a1a0-36abded24669.png)


