### PR TITLE
(feat)db: support org-ref v3

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -355,6 +355,16 @@ If VAL is not specified, user is prompted to select a value."
       (org-delete-property prop))
     prop-to-remove))
 
+;;; Refs
+(defun org-roam-org-ref-path-to-keys (path)
+  "Return a list of keys given an org-ref cite: PATH.
+Accounts for both v2 and v3."
+  (cond ((fboundp 'org-ref-parse-cite-path)
+         (mapcar (lambda (cite) (plist-get cite :key))
+                 (plist-get (org-ref-parse-cite-path path) :references)))
+        ((fboundp 'org-ref-split-and-strip-string)
+         (org-ref-split-and-strip-string path))))
+
 ;;; Logs
 (defvar org-roam-verbose)
 (defun org-roam-message (format-string &rest args)


### PR DESCRIPTION
Org-ref v3 introduced a new citation syntax, and removed some functions
that org-roam had previously relied upon (e.g. for extracting keys from
multi-citations).

This commit introduces support on two fronts:

1. Add `org-roam-org-ref-path-to-keys` which converts a link path to a
list of keys. This supports both Org-ref v2 and v3.

2. Adds support for parsing multi-citations in refs.

Addresses #1973.