### PR TITLE
(fix)utils: fix org-roam-with-file changing the major-mode

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -87,7 +87,7 @@ Kills the buffer if KEEP-BUF-P is nil, and FILE is not yet visited."
                      (find-file-noselect ,file)))) ; Else, visit FILE and return buffer
           res)
      (with-current-buffer buf
-       (unless (equal major-mode 'org-mode)
+       (unless (derived-mode-p 'org-mode)
          (delay-mode-hooks
            (let ((org-inhibit-startup t)
                  (org-agenda-files nil))


### PR DESCRIPTION
`org-roam-with-file` should not alter the major-mode if the
mode is already derived from org-mode.