### PR TITLE
(fix)db: fix org-roam-db-sync exiting early on unhandled errors

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -5,6 +5,7 @@
   (elisp-lint-indent-specs . ((describe . 1)
                               (it . 1)
                               (org-element-map . defun)
+                              (org-roam-dolist-with-progress . 2)
                               (org-roam-with-temp-buffer . 1)
                               (org-with-point-at . 1)
                               (magit-insert-section . defun)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -627,28 +627,17 @@ If FORCE, force a rebuild of the cache from scratch."
           (push file modified-files)))
       (remhash file current-files))
     (emacsql-with-transaction (org-roam-db)
-      (if (fboundp 'dolist-with-progress-reporter)
-          (dolist-with-progress-reporter (file (hash-table-keys current-files))
-              "Clearing removed files..."
-            (org-roam-db-clear-file file))
-        (dolist (file (hash-table-keys current-files))
-          (org-roam-db-clear-file file)))
-      (if (fboundp 'dolist-with-progress-reporter)
-          (dolist-with-progress-reporter (file modified-files)
-              "Processing modified files..."
-            (condition-case err
-              (org-roam-db-update-file file 'no-require)
-              (error
-               (org-roam-db-clear-file file)
-               (lwarn 'org-roam :error "Failed to process %s with error %s, skipping..."
-                      file (error-message-string err)))))
-        (dolist (file modified-files)
-          (condition-case err
-              (org-roam-db-update-file file 'no-require)
-            (error
-             (org-roam-db-clear-file file)
-             (lwarn 'org-roam :error "Failed to process %s with error %s, skipping..."
-                    file (error-message-string err)))))))))
+      (org-roam-dolist-with-progress (file (hash-table-keys current-files))
+          "Clearing removed files..."
+        (org-roam-db-clear-file file))
+      (org-roam-dolist-with-progress (file modified-files)
+          "Processing modified files..."
+        (condition-case err
+            (org-roam-db-update-file file 'no-require)
+          (error
+           (org-roam-db-clear-file file)
+           (lwarn 'org-roam :error "Failed to process %s with error %s, skipping..."
+                  file (error-message-string err))))))))
 
 ;;;###autoload
 (define-minor-mode org-roam-db-autosync-mode

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -636,9 +636,19 @@ If FORCE, force a rebuild of the cache from scratch."
       (if (fboundp 'dolist-with-progress-reporter)
           (dolist-with-progress-reporter (file modified-files)
               "Processing modified files..."
-            (org-roam-db-update-file file 'no-require))
+            (condition-case err
+              (org-roam-db-update-file file 'no-require)
+              (error
+               (org-roam-db-clear-file file)
+               (lwarn 'org-roam :error "Failed to process %s with error %s, skipping..."
+                      file (error-message-string err)))))
         (dolist (file modified-files)
-          (org-roam-db-update-file file))))))
+          (condition-case err
+              (org-roam-db-update-file file 'no-require)
+            (error
+             (org-roam-db-clear-file file)
+             (lwarn 'org-roam :error "Failed to process %s with error %s, skipping..."
+                    file (error-message-string err)))))))))
 
 ;;;###autoload
 (define-minor-mode org-roam-db-autosync-mode

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -73,7 +73,15 @@ FN must take two arguments: the key and the value."
 (defmacro org-roam-dolist-with-progress (spec msg &rest body)
   "Loop over a list and report progress in the echo area.
 Like `dolist-with-progress-reporter', but falls back to `dolist'
-if the function does not yet exist."
+if the function does not yet exist.
+
+Evaluate BODY with VAR bound to each car from LIST, in turn.
+Then evaluate RESULT to get return value, default nil.
+
+MSG is a progress reporter object or a string.  In the latter
+case, use this string to create a progress reporter.
+
+SPEC is a list, as per `dolist'."
   (declare (indent 2))
   (if (fboundp 'dolist-with-progress-reporter)
       `(dolist-with-progress-reporter ,spec ,msg ,@body)

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -70,6 +70,15 @@ FN must take two arguments: the key and the value."
               plist-index (cdr plist-index)))))
   plist)
 
+(defmacro org-roam-dolist-with-progress (spec msg &rest body)
+  "Loop over a list and report progress in the echo area.
+Like `dolist-with-progress-reporter', but falls back to `dolist'
+if the function does not yet exist."
+  (declare (indent 2))
+  (if (fboundp 'dolist-with-progress-reporter)
+      `(dolist-with-progress-reporter ,spec ,msg ,@body)
+    `(dolist ,spec ,@body)))
+
 ;;; File utilities
 (defmacro org-roam-with-file (file keep-buf-p &rest body)
   "Execute BODY within FILE.


### PR DESCRIPTION
When update-file fails, clear the file from the database and show an
error.

Closes #1978.