### PR TITLE
(feat)buffer: add customization variables for buffer

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -10,5 +10,4 @@
                               (org-with-point-at . 1)
                               (magit-insert-section . defun)
                               (magit-section-case . 0)
-                              (->> . 1)
                               (org-roam-with-file . 2)))))

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -49,8 +49,8 @@
 (defun org-roam-quote-string (s)
   "Quotes string S."
   (->> s
-    (org-roam-replace-string "\\" "\\\\")
-    (org-roam-replace-string "\"" "\\\"")))
+       (org-roam-replace-string "\\" "\\\\")
+       (org-roam-replace-string "\"" "\\\"")))
 
 (defun org-roam-string-equal (s1 s2)
   "Return t if S1 and S2 are equal.
@@ -58,6 +58,17 @@ Like `string-equal', but case-insensitive."
   (and (= (length s1) (length s2))
        (or (string-equal s1 s2)
            (string-equal (downcase s1) (downcase s2)))))
+
+(defun org-roam-strip-comments (s)
+  "Strip Org comments from string S."
+  (with-temp-buffer
+    (insert s)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (if (org-at-comment-p)
+          (delete-region (point-at-bol) (progn (forward-line) (point)))
+        (forward-line)))
+    (buffer-string)))
 
 ;;; List utilities
 (defun org-roam-plist-map! (fn plist)


### PR DESCRIPTION
This commit adds 3 custom variables:

1. org-roam-buffer-postrender-functions

This list of functions are run within the Org-roam buffer after the
Org-roam buffer is rendered. For example, one can produce latex previews
for all content within the Org-roam buffer:

``` emacs-lisp
(add-hook 'org-roam-buffer-postrender-functions
  (lambda () (org--latex-preview-region (point-min) (point-max))))
```

2. org-roam-preview-function

This is the function used to extract the content to populate the buffer.
It defaults to `org-roam-preview-default-function`, which extracts all
contents within the headline up to the next headline.

3. org-roam-preview-postprocess-functions

This is a list of functions run to post-process the content retrieved
from org-roam-preview-function. It can be used to strip additional
content from the buffer, or perform sentence-unwrapping.