### PR TITLE
fix: plain link is not inserted into db

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -491,7 +491,8 @@ INFO is the org-element parsed buffer."
                             (or (assoc link-type org-ref-cite-types)
                                 (member link-type org-ref-cite-types)))
                        (dolist (key (org-roam-org-ref-path-to-keys path))
-                         (push (vector node-id key link-type) rows)))))
+                         (push (vector node-id key link-type) rows))
+                     (push (vector node-id path link-type) rows))))
                 (t
                  (lwarn '(org-roam) :warning
                         "%s:%s\tInvalid ref %s, skipping..." (buffer-file-name) (point) ref)))))


### PR DESCRIPTION
###### Motivation for this change

Plain link in ROAM_REFS is not inserted into the database, which seems an oversight in https://github.com/org-roam/org-roam/pull/1977