### PR TITLE
Make the `org-roam-node-read` prompt configurable

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -496,7 +496,8 @@ FILTER-FN is a function to filter out nodes: it takes an `org-roam-node',
 and when nil is returned the node will be filtered out.
 SORT-FN is a function to sort nodes. See `org-roam-node-read-sort-by-file-mtime'
 for an example sort function.
-If REQUIRE-MATCH, the minibuffer prompt will require a match."
+If REQUIRE-MATCH, the minibuffer prompt will require a match.
+PROMPT is a string to show at the beginning of the mini-buffer, defaulting to \"Node: \""
   (let* ((nodes (org-roam-node-read--completions))
          (nodes (if filter-fn
                     (cl-remove-if-not

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -489,7 +489,7 @@ window instead."
                          other-window)))
 
 ;;;; Completing-read interface
-(defun org-roam-node-read (&optional initial-input filter-fn sort-fn require-match)
+(defun org-roam-node-read (&optional initial-input filter-fn sort-fn require-match prompt)
   "Read and return an `org-roam-node'.
 INITIAL-INPUT is the initial minibuffer prompt value.
 FILTER-FN is a function to filter out nodes: it takes an `org-roam-node',
@@ -508,8 +508,9 @@ If REQUIRE-MATCH, the minibuffer prompt will require a match."
                         (intern (concat "org-roam-node-read-sort-by-"
                                         (symbol-name org-roam-node-default-sort))))))
          (_ (when sort-fn (setq nodes (seq-sort sort-fn nodes))))
+         (prompt (or prompt "Node: "))
          (node (completing-read
-                "Node: "
+                prompt
                 (lambda (string pred action)
                   (if (eq action 'metadata)
                       `(metadata


### PR DESCRIPTION
###### Motivation for this change
I have various capture templates that prompt for a node using `org-roam-node-read` with a filtered down set of nodes (using the handy `filter-fn` argument). This works great. A few of my templates prompt for multiple nodes, and use the selections for different purposes; it would be nice if I didn't have to remember what the order of the prompts was.

The trivial feature makes the prompt configurable, with a default of "Node: " just like this function previously had.