### PR TITLE
(docs): fix examples for .dir-locals.el

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1391,8 +1391,12 @@ Note ~org-roam-directory~ and ~org-roam-db-location~ should be an absolute path,
 Alternatively, use ~eval~ if you wish to call functions:
 
 #+BEGIN_SRC emacs-lisp
-  ((nil . ((eval . (setq-local org-roam-directory (expand-file-name ".")))
-           (eval . (setq-local org-roam-db-location (expand-file-name "org-roam.db"))))))
+  ((nil . ((eval . (setq-local
+                    org-roam-directory (expand-file-name (locate-dominating-file
+                                                          default-directory ".dir-locals.el"))))
+           (eval . (setq-local
+                    org-roam-db-location (expand-file-name "org-roam.db"
+                                                           org-roam-directory))))))
 #+END_SRC
 
 All files within that directory will be treated as their own separate set of

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1382,8 +1382,17 @@ variable using directory-local variables. This is what ~.dir-locals.el~ may
 contain:
 
 #+BEGIN_SRC emacs-lisp
-  ((nil . ((org-roam-directory . (expand-file-name "."))
-           (org-roam-db-location . (expand-file-name "./org-roam.db")))))
+  ((nil . ((org-roam-directory . "/path/to/alt/org-roam/dir/org-roam-dir")
+           (org-roam-db-location . "/path/to/alt/org-roam-dir/org-roam.db"))))
+#+END_SRC
+
+Note ~org-roam-directory~ and ~org-roam-db-location~ should be an absolute path, not relative.
+
+Alternatively, use ~eval~ if you wish to call functions:
+
+#+BEGIN_SRC emacs-lisp
+  ((nil . ((eval . (setq-local org-roam-directory (expand-file-name ".")))
+           (eval . (setq-local org-roam-db-location (expand-file-name "org-roam.db"))))))
 #+END_SRC
 
 All files within that directory will be treated as their own separate set of

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1935,8 +1935,21 @@ variable using directory-local variables. This is what @code{.dir-locals.el} may
 contain:
 
 @lisp
-((nil . ((org-roam-directory . (expand-file-name "."))
-         (org-roam-db-location . (expand-file-name "./org-roam.db")))))
+((nil . ((org-roam-directory . "/path/to/alt/org-roam/dir/org-roam-dir")
+         (org-roam-db-location . "/path/to/alt/org-roam-dir/org-roam.db"))))
+@end lisp
+
+Note @code{org-roam-directory} and @code{org-roam-db-location} should be an absolute path, not relative.
+
+Alternatively, use @code{eval} if you wish to call functions:
+
+@lisp
+((nil . ((eval . (setq-local
+                  org-roam-directory (expand-file-name (locate-dominating-file
+                                                        default-directory ".dir-locals.el"))))
+         (eval . (setq-local
+                  org-roam-db-location (expand-file-name "org-roam.db"
+                                                         org-roam-directory))))))
 @end lisp
 
 All files within that directory will be treated as their own separate set of


### PR DESCRIPTION
Two items:

1. The current example does not work; in order to call a function wihtin
`.dir-locals.el`, you should use `eval`.

  - [StackExchange](https://emacs.stackexchange.com/questions/21955/calling-functions-in-dir-locals-in-emacs)

  - [Working example buried in an issue](https://github.com/org-roam/org-roam/issues/1527#issuecomment-933674233)

  - `(info "(emacs)Directory Variables")`

2. Add clear instruction to use an absolute path to define `org-roam-directory` in
this context (it's buried in this [issue](https://github.com/org-roam/org-roam/issues/1459#issuecomment-817259656)).

###### Motivation for this change
Questions relatd to mulitple Org-roam DB are occasionally posted on Discouse (a [recent example](https://org-roam.discourse.group/t/small-independent-org-roam-instances/2267))

There has been some issues around `.dir-locals.el` -- I hope this update will help close this one, for example:
- https://github.com/org-roam/org-roam/issues/1933