### PR TITLE
(docs) minor correction to #2002

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1382,7 +1382,7 @@ variable using directory-local variables. This is what ~.dir-locals.el~ may
 contain:
 
 #+BEGIN_SRC emacs-lisp
-  ((nil . ((org-roam-directory . "/path/to/alt/org-roam/dir/org-roam-dir")
+  ((nil . ((org-roam-directory . "/path/to/alt/org-roam-dir")
            (org-roam-db-location . "/path/to/alt/org-roam-dir/org-roam.db"))))
 #+END_SRC
 

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1391,8 +1391,12 @@ Note ~org-roam-directory~ and ~org-roam-db-location~ should be an absolute path,
 Alternatively, use ~eval~ if you wish to call functions:
 
 #+BEGIN_SRC emacs-lisp
-  ((nil . ((eval . (setq-local org-roam-directory (expand-file-name ".")))
-           (eval . (setq-local org-roam-db-location (expand-file-name "org-roam.db"))))))
+  ((nil . ((eval . (setq-local
+                    org-roam-directory (expand-file-name (locate-dominating-file
+                                                          default-directory ".dir-locals.el"))))
+           (eval . (setq-local
+                    org-roam-db-location (expand-file-name "org-roam.db"
+                                                           org-roam-directory))))))
 #+END_SRC
 
 All files within that directory will be treated as their own separate set of

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1382,8 +1382,17 @@ variable using directory-local variables. This is what ~.dir-locals.el~ may
 contain:
 
 #+BEGIN_SRC emacs-lisp
-  ((nil . ((org-roam-directory . (expand-file-name "."))
-           (org-roam-db-location . (expand-file-name "./org-roam.db")))))
+  ((nil . ((org-roam-directory . "/path/to/alt/org-roam/dir/org-roam-dir")
+           (org-roam-db-location . "/path/to/alt/org-roam-dir/org-roam.db"))))
+#+END_SRC
+
+Note ~org-roam-directory~ and ~org-roam-db-location~ should be an absolute path, not relative.
+
+Alternatively, use ~eval~ if you wish to call functions:
+
+#+BEGIN_SRC emacs-lisp
+  ((nil . ((eval . (setq-local org-roam-directory (expand-file-name ".")))
+           (eval . (setq-local org-roam-db-location (expand-file-name "org-roam.db"))))))
 #+END_SRC
 
 All files within that directory will be treated as their own separate set of

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1935,8 +1935,21 @@ variable using directory-local variables. This is what @code{.dir-locals.el} may
 contain:
 
 @lisp
-((nil . ((org-roam-directory . (expand-file-name "."))
-         (org-roam-db-location . (expand-file-name "./org-roam.db")))))
+((nil . ((org-roam-directory . "/path/to/alt/org-roam/dir/org-roam-dir")
+         (org-roam-db-location . "/path/to/alt/org-roam-dir/org-roam.db"))))
+@end lisp
+
+Note @code{org-roam-directory} and @code{org-roam-db-location} should be an absolute path, not relative.
+
+Alternatively, use @code{eval} if you wish to call functions:
+
+@lisp
+((nil . ((eval . (setq-local
+                  org-roam-directory (expand-file-name (locate-dominating-file
+                                                        default-directory ".dir-locals.el"))))
+         (eval . (setq-local
+                  org-roam-db-location (expand-file-name "org-roam.db"
+                                                         org-roam-directory))))))
 @end lisp
 
 All files within that directory will be treated as their own separate set of

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1935,7 +1935,7 @@ variable using directory-local variables. This is what @code{.dir-locals.el} may
 contain:
 
 @lisp
-((nil . ((org-roam-directory . "/path/to/alt/org-roam/dir/org-roam-dir")
+((nil . ((org-roam-directory . "/path/to/alt/org-roam-dir")
          (org-roam-db-location . "/path/to/alt/org-roam-dir/org-roam.db"))))
 @end lisp
 


### PR DESCRIPTION
###### Motivation for this change

Correcting the example of .dir-locals using an absolute path to avoid confusion.
Lightly tested with a real absolute path in my system; works on my end with a
subdir.

Apologies for not having been more careful in the first time. I hope this PR does not cause any trouble in merging -- it seems to contain all the commits related to this change including the ones that you have already merged...
