### PR TITLE
(fix)db: fix node caching

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -338,12 +338,12 @@ If UPDATE-P is non-nil, first remove the file in the database."
 
 (defun org-roam-db-map-nodes (fns)
   "Run FNS over all nodes in the current buffer."
-  (org-with-point-at 1
-    (org-map-entries
-     (lambda ()
-       (when (org-roam-db-node-p)
-         (dolist (fn fns)
-           (funcall fn)))))))
+  (org-map-region
+   (lambda ()
+     (when (org-roam-db-node-p)
+       (dolist (fn fns)
+         (funcall fn))))
+   (point-min) (point-max)))
 
 (defun org-roam-db-map-links (fns)
   "Run FNS over all links in the current buffer."


### PR DESCRIPTION
###### Motivation for this change

Previously node caching used org-map-entries: this only mapped over agenda
entries, hence skipping various nodes. Instead, we should be using
org-map-region, which maps over the entire file.

Fixes #1989.