### PR TITLE
fix(db): fix support for sqlite3 connector

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -243,8 +243,8 @@ The query is expected to be able to fail, in this situation, run HANDLER."
 
 (defun org-roam-db--init (db)
   "Initialize database DB with the correct schema and user version."
+  (emacsql db [:pragma (= foreign_keys ON)])
   (emacsql-with-transaction db
-    (emacsql db "PRAGMA foreign_keys = ON")
     (pcase-dolist (`(,table ,schema) org-roam-db--table-schemata)
       (emacsql db [:create-table $i1 $S2] table schema))
     (pcase-dolist (`(,index-name ,table ,columns) org-roam-db--table-indices)


### PR DESCRIPTION
Moving the PRAGMA foreign_keys invocation out of the transaction seems
to work now.