### PR TITLE
Add hook that runs when org-roam-db-sync is done

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -634,7 +634,10 @@ If FORCE, force a rebuild of the cache from scratch."
       (org-roam-dolist-with-progress (file modified-files)
           "Processing modified files..."
         (condition-case err
-            (org-roam-db-update-file file 'no-require)
+            (progn
+                (run-hooks 'org-roam-after-db-sync-hook)
+                (org-roam-db-update-file file 'no-require)
+            )
           (error
            (org-roam-db-clear-file file)
            (lwarn 'org-roam :error "Failed to process %s with error %s, skipping..."

--- a/org-roam.el
+++ b/org-roam.el
@@ -123,6 +123,12 @@ All Org files, at any level of nesting, are considered part of the Org-roam."
   :group 'org-roam
   :type 'hook)
 
+(defcustom org-roam-after-db-sync-hook nil
+  "Hook run just after a successfull db sync."
+  :group 'org-roam
+  :type 'hook)
+
+
 (defcustom org-roam-file-extensions '("org")
   "List of file extensions to be included by Org-Roam.
 While a file extension different from \".org\" may be used, the


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

###### Motivation for this change
Add support for a thing to react a index update

In this case a hook to update `org-agenda-files` on db update.

