### PR TITLE
doc: Add mention of org-cite to bibliography

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1361,6 +1361,8 @@ documents (PDF, EPUB etc.) within Org-mode.
 
 ** Bibliography
 
+Org 9.5 added native citation and bibliography functionality, called "org-cite", which org-roam supports.
+
 [[https://github.com/org-roam/org-roam-bibtex][org-roam-bibtex]] offers tight integration between [[https://github.com/jkitchin/org-ref][org-ref]], [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]] and
 ~org-roam~. This helps you manage your bibliographic notes under ~org-roam~.
 

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -1361,7 +1361,8 @@ documents (PDF, EPUB etc.) within Org-mode.
 
 ** Bibliography
 
-Org 9.5 added native citation and bibliography functionality, called "org-cite", which org-roam supports.
+Org 9.5 added native citation and bibliography functionality, called "org-cite",
+which org-roam supports.
 
 [[https://github.com/org-roam/org-roam-bibtex][org-roam-bibtex]] offers tight integration between [[https://github.com/jkitchin/org-ref][org-ref]], [[https://github.com/tmalsburg/helm-bibtex][helm-bibtex]] and
 ~org-roam~. This helps you manage your bibliographic notes under ~org-roam~.

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1906,6 +1906,9 @@ documents (PDF, EPUB etc.) within Org-mode.
 @node Bibliography
 @section Bibliography
 
+Org 9.5 added native citation and bibliography functionality, called ``org-cite'',
+which org-roam supports.
+
 @uref{https://github.com/org-roam/org-roam-bibtex, org-roam-bibtex} offers tight integration between @uref{https://github.com/jkitchin/org-ref, org-ref}, @uref{https://github.com/tmalsburg/helm-bibtex, helm-bibtex} and
 @code{org-roam}. This helps you manage your bibliographic notes under @code{org-roam}.
 


### PR DESCRIPTION
###### Motivation for this change

To add mention of the org-cite support.

Also, though I have not included it, should also help the reader understand when and why they would want to also or alternatively to use ORB.