### PR TITLE
(feat)db: allow [cite:@foo] links in ROAM_REFS

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -711,6 +711,16 @@ citation key:
 :END:
 #+end_src
 
+or
+
+#+begin_src org
+,* Probabilistic Robotics
+:PROPERTIES:
+:ID:       51b7b82c-bbb4-4822-875a-ed548cffda10
+:ROAM_REFS: [cite:@thrun2005probabilistic]
+:END:
+#+end_src
+
 for ~org-cite~, or:
 
 #+begin_src org

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1091,6 +1091,16 @@ citation key:
 :END:
 @end example
 
+or
+
+@example
+* Probabilistic Robotics
+:PROPERTIES:
+:ID:       51b7b82c-bbb4-4822-875a-ed548cffda10
+:ROAM_REFS: [cite:@@thrun2005probabilistic]
+:END:
+@end example
+
 for @code{org-cite}, or:
 
 @example

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -495,7 +495,7 @@ INFO is the org-element parsed buffer."
                              (push (vector node-id key "cite") rows)))))
                    (error
                     (lwarn '(org-roam) :warning
-                        "%s:%s\tInvalid cite %s, skipping..." (buffer-file-name) (point) ref))))
+                           "%s:%s\tInvalid cite %s, skipping..." (buffer-file-name) (point) ref))))
                 (;; https://google.com, cite:citeKey
                  ;; Note: we use string-match here because it matches any link: e.g. [[cite:abc][abc]]
                  ;; But this form of matching is loose, and can accept invalid links e.g. [[cite:abc]


### PR DESCRIPTION
Parse the Org-cite syntax in ROAM_REFS