### PR TITLE
(fix):db: pragma foreign keys to work with sqlite3

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -103,9 +103,10 @@ slow."
 
 ;; TODO Rename this
 (defconst org-roam--sqlite-available-p
-  (with-demoted-errors "Org-roam initialization: %S"
-    (emacsql-sqlite-ensure-binary)
-    t))
+  (when (equal org-roam-database-connector 'sqlite)
+    (with-demoted-errors "Org-roam initialization: %S"
+      (emacsql-sqlite-ensure-binary)
+      t)))
 
 (defvar org-roam-db--connection (make-hash-table :test #'equal)
   "Database connection to Org-roam database.")

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -145,6 +145,7 @@ Performs a database upgrade when required."
     (let ((init-db (not (file-exists-p org-roam-db-location))))
       (make-directory (file-name-directory org-roam-db-location) t)
       (let ((conn (funcall (org-roam-db--conn-fn) org-roam-db-location)))
+        (emacsql conn [:pragma (= foreign_keys ON)])
         (when-let ((process (emacsql-process conn)))
           (set-process-query-on-exit-flag process nil))
         (puthash (expand-file-name (file-name-as-directory org-roam-directory))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -244,7 +244,6 @@ The query is expected to be able to fail, in this situation, run HANDLER."
 
 (defun org-roam-db--init (db)
   "Initialize database DB with the correct schema and user version."
-  (emacsql db [:pragma (= foreign_keys ON)])
   (emacsql-with-transaction db
     (pcase-dolist (`(,table ,schema) org-roam-db--table-schemata)
       (emacsql db [:create-table $i1 $S2] table schema))

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -101,13 +101,6 @@ slow."
 ;;; Variables
 (defconst org-roam-db-version 18)
 
-;; TODO Rename this
-(defconst org-roam--sqlite-available-p
-  (when (equal org-roam-database-connector 'sqlite)
-    (with-demoted-errors "Org-roam initialization: %S"
-      (emacsql-sqlite-ensure-binary)
-      t)))
-
 (defvar org-roam-db--connection (make-hash-table :test #'equal)
   "Database connection to Org-roam database.")
 


### PR DESCRIPTION
This commit is follow-up for PR #2009 should fix issues #1927 & #1910.

Currently, `[:pragma (= foreign_keys ON)]` is present only in function
`org-roam-db--init`. This means the `foreign_keys` is turned on only when the db
file is created for the first time. Subsequent Emacs sessions won't turn it on
as the db file is already present and does not evaluate `org-roam-db--init`.

This PRAGMA needs to be turned on each database connection at runtime according
to sqlite's documentation (https://sqlite.org/foreignkeys.html#fk_enable)

```
Foreign key constraints are disabled by default (for backwards compatibility),
so must be enabled separately for each database connection
```

I have observed that on Windows only the Emacs session that initially creates
the Org-roam db file works correctly with the `sqlite3` option. Subsequent Emacs
sessions have the same "Unique constraint failed" error messages.

I have tested this patch on Windows and Ubuntu; both seem to work in the first
and subsequent Emacs sessions.

I am not 100% sure if the location of the PRAGMA is the best; use it as a
proof-of-cocenpt for the fix. Thank you.

###### Motivation for this change
