### PR TITLE
org-roam-node-rename

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -496,11 +496,15 @@ title/filename/link titles."
     (save-buffer)
 
     ;; Rename current buffer
-    (let* ((fname (buffer-file-name))
-	   (newreg (format "\\1-%s.org" newtitle))
-	   (newfname (s-replace-regexp "\\([0-9]+\\)\\-.+\.org" newreg fname)))
+    (let* ((orif (buffer-file-name))
+	   (dir (file-name-directory orif))
+	   (file (file-name-nondirectory orif))
+	   (titlenoslash (s-replace-regexp "/" "_" (downcase newtitle)))
+	   (newreg (format "\\1-%s.org" titlenoslash))
+	   (nfile (s-replace-regexp "\\([0-9]+\\)\\-.+\.org" newreg file))
+	   (newfname (concat dir nfile)))
       (progn
-	(rename-file fname newfname)
+	(rename-file orif newfname)
 	(rename-buffer newfname)
 	(set-visited-file-name newfname)
 	(set-buffer-modified-p nil)))
@@ -517,7 +521,6 @@ title/filename/link titles."
 	  (replace-match newlink))
 	(save-buffer)
 	(kill-buffer (current-buffer))))))
-
 
 ;;;###autoload
 (defun org-roam-node-random (&optional other-window)


### PR DESCRIPTION
Functionality to rename current node name minding the title, all links, and filename.

Previously, the links, filename, and title have to be renamed manually. It wound be nice to have clean function to rename a node with links and filename taken care of.

It is improved version of function mentioned in #1843. It uses org-roam-backlink to locate all occurrences of links and replaces. 

https://user-images.githubusercontent.com/24271442/147531641-6498dc78-2d25-4dda-ad3b-b08e60541db1.mov

 