### PR TITLE
Make 'fd and 'fdfind backend actually work for listing files

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -279,8 +279,8 @@ E.g. (\".org\") => (\"*.org\" \"*.org.gpg\")"
 (defun org-roam--list-files-fd (executable dir)
   "Return all Org-roam files under DIR, using \"fd\", provided as EXECUTABLE."
   (let* ((globs (org-roam--list-files-search-globs org-roam-file-extensions))
-         (extensions (string-join (mapcar (lambda (glob) (substring glob 2 -1)) globs) " -e "))
-         (command (string-join `(,executable "-L" ,dir "--type file" ,extensions) " ")))
+         (extensions (string-join (mapcar (lambda (glob) (concat "-e " (substring glob 2 -1))) globs) " "))
+         (command (string-join `(,executable "-L" "--type file" ,extensions "." ,dir) " ")))
     (org-roam--shell-command-files command)))
 
 (defalias 'org-roam--list-files-fdfind #'org-roam--list-files-fd)


### PR DESCRIPTION
###### Motivation for this change

The `fd` backend for listing files, introduced in #1583, did not work for me, mainly because the command is actually:

    fd -L --type file -e .org -e .org.gpg . "/home/user/org-roam"

In other words, the directory comes last, and a pattern (a match-all pattern `.`) needs to be specified (otherwise `fd` assumes the last argument is the pattern, in this case `/home/user/org-roam`). There was a slight bug in the creation of the `extensions`variable, where only the second pattern (`.org.gpg`) would be prefixed by `-e`.

P.S. It might be good if @Wetlize would chime in, as they wrote the original PR.