### PR TITLE
Add `keys` argument to `org-roam-dailies-capture-today` and `org-roam-dailies--capture` functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
 ### Added
 - [#1806](https://github.com/org-roam/org-roam/pull/1806) db: support caching and usage of Org 9.5's in-built citations
+- [#1806](https://github.com/org-roam/org-roam/pull/2028) dailies: add `keys` argument to `org-roam-dailies-capture-today` and `org-roam-dailies--capture` functions to give the abilty to get into a capture buffer bypassing the selection screen
 
 ### Removed
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## TBD
 ### Added
 - [#1806](https://github.com/org-roam/org-roam/pull/1806) db: support caching and usage of Org 9.5's in-built citations
-- [#1806](https://github.com/org-roam/org-roam/pull/2028) dailies: add `keys` argument to `org-roam-dailies-capture-today` and `org-roam-dailies--capture` functions to give the abilty to get into a capture buffer bypassing the selection screen
+- [#2028](https://github.com/org-roam/org-roam/pull/2028) dailies: add `keys` argument to `org-roam-dailies-capture-today` and `org-roam-dailies--capture` functions to give the abilty to get into a capture buffer bypassing the selection screen
 
 ### Removed
 ### Changed

--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -130,11 +130,14 @@ See `org-roam-capture-templates' for the template documentation."
 ;;; Commands
 ;;;; Today
 ;;;###autoload
-(defun org-roam-dailies-capture-today (&optional goto)
+(defun org-roam-dailies-capture-today (&optional goto keys)
   "Create an entry in the daily-note for today.
-When GOTO is non-nil, go the note without creating an entry."
+When GOTO is non-nil, go the note without creating an entry.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (interactive "P")
-  (org-roam-dailies--capture (current-time) goto))
+  (org-roam-dailies--capture (current-time) goto keys))
 
 ;;;###autoload
 (defun org-roam-dailies-goto-today ()
@@ -300,11 +303,15 @@ Return (MONTH DAY YEAR) or nil if not an Org time-string."
 ;;; Capture implementation
 (add-to-list 'org-roam-capture--template-keywords :override-default-time)
 
-(defun org-roam-dailies--capture (time &optional goto)
+(defun org-roam-dailies--capture (time &optional goto keys)
   "Capture an entry in a daily-note for TIME, creating it if necessary.
-When GOTO is non-nil, go the note without creating an entry."
+When GOTO is non-nil, go the note without creating an entry.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (let ((org-roam-directory (expand-file-name org-roam-dailies-directory org-roam-directory)))
     (org-roam-capture- :goto (when goto '(4))
+                       :keys keys
                        :node (org-roam-node-create)
                        :templates org-roam-dailies-capture-templates
                        :props (list :override-default-time time)))


### PR DESCRIPTION
That gives convenience to create shorter keybindings that lead right into desired capture template buffer avoiding the need to select it each time in the capture selection screen. 

```elisp
    (leader-def
      "rt" '((lambda () (interactive) (org-roam-dailies-capture-today nil "d")) :wk "capture today daily")
      "ri" '((lambda () (interactive) (org-roam-dailies-capture-today nil "i")) :wk "capture interruption"))
      "ro" '(some-other-roam-bindings)
```

It makes `org-roam-dailies-capture-today` arguments to behave exactly as `org-capture` arguments do - (&optional goto keys).