### PR TITLE
(fix)Format completions to window-width, not frame-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## TBD
+### Added
+### Removed
+### Fixed
+### Changed
+- [#2040](https://github.com/org-roam/org-roam/pull/2040) completions: fix completions display-width for Helm users
 
 ## 2.2.0
 ### Added

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -545,7 +545,8 @@ TEMPLATE is the processed template used to format the entry."
   (let ((candidate-main (org-roam-node--format-entry
                          template
                          node
-                         (1- (window-width)))))
+                         (1- (if (bufferp (current-buffer))
+                                 (window-width) (frame-width))))))
     (cons (propertize candidate-main 'node node) node)))
 
 (defun org-roam-node--format-entry (template node &optional width)

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -545,7 +545,7 @@ TEMPLATE is the processed template used to format the entry."
   (let ((candidate-main (org-roam-node--format-entry
                          template
                          node
-                         (1- (frame-width)))))
+                         (1- (window-width)))))
     (cons (propertize candidate-main 'node node) node)))
 
 (defun org-roam-node--format-entry (template node &optional width)


### PR DESCRIPTION
Format minibuffer completion candidates using `window-width` instead of `frame-width`. This way completions render as a single line even if the frame is split.

Before: Empty line between completions
<img width="1175" alt="frame-width" src="https://user-images.githubusercontent.com/382515/149641416-ab26b9de-aa72-469b-90b4-a91c42f7ba7d.png">

After: No empty line between completions
<img width="1173" alt="window-width" src="https://user-images.githubusercontent.com/382515/149641419-1acaad76-f9a3-4b06-a9af-9141ad5530e5.png">