### PR TITLE
(feat)db: add customizability of extra element link parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## TBD
 ### Added
+- [#2042](https://github.com/org-roam/org-roam/pull/2042) Add `org-roam-db-extra-links-elements` and `org-roam-db-extra-links-exclude-keys` for fine-grained control over additional link parsing.
 ### Removed
 ### Fixed
 ### Changed

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -490,6 +490,35 @@ all headlines with the ~ATTACH~ tag from the Org-roam database, one can set:
         (not (member "ATTACH" (org-get-tags)))))
 #+end_src
 
+Org-roam relied on the obtained Org AST for the buffer to parse links. However,
+links appearing in some places (e.g. within property drawers) are not considered
+by the Org AST to be links. Therefore, Org-roam takes special care of
+additionally trying to process these links. Use
+~org-roam-db-extra-links-elements~ to specify which additional Org AST element
+types to consider.
+
+- Variable: org-roam-db-extra-links-elements
+
+  The list of Org element types to include for parsing by Org-roam.
+
+  By default, when parsing Org's AST, links within keywords and
+  property drawers are not parsed as links. Sometimes however, it
+  is desirable to parse and cache these links (e.g. hiding links in
+  a property drawer).
+
+Additionally, one may want to ignore certain keys from being excluded within
+property drawers. For example, we would not want ~ROAM_REFS~ links to be
+self-referential. Hence, to exclude specific keys, we use
+~org-roam-db-extra-links-exclude-keys~.
+
+- Variable: org-roam-db-extra-links-exclude-keys
+
+  Keys to ignore when mapping over links.
+
+  The car of the association list is the Org element type (e.g. keyword). The
+  cdr is a list of case-insensitive strings to exclude from being treated as
+  links.
+
 ** When to cache
 
 By default, Org-roam is eager in caching: each time an Org-roam file is modified

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -791,6 +791,37 @@ all headlines with the @code{ATTACH} tag from the Org-roam database, one can set
         (not (member "ATTACH" (org-get-tags)))))
 @end example
 
+Org-roam relied on the obtained Org AST for the buffer to parse links. However,
+links appearing in some places (e.g. within property drawers) are not considered
+by the Org AST to be links. Therefore, Org-roam takes special care of
+additionally trying to process these links. Use
+@code{org-roam-db-extra-links-elements} to specify which additional Org AST element
+types to consider.
+
+@defvar org-roam-db-extra-links-elements
+
+The list of Org element types to include for parsing by Org-roam.
+
+By default, when parsing Org's AST, links within keywords and
+property drawers are not parsed as links. Sometimes however, it
+is desirable to parse and cache these links (e.g. hiding links in
+a property drawer).
+@end defvar
+
+Additionally, one may want to ignore certain keys from being excluded within
+property drawers. For example, we would not want @code{ROAM_REFS} links to be
+self-referential. Hence, to exclude specific keys, we use
+@code{org-roam-db-extra-links-exclude-keys}.
+
+@defvar org-roam-db-extra-links-exclude-keys
+
+Keys to ignore when mapping over links.
+
+The car of the association list is the Org element type (e.g. keyword). The
+cdr is a list of case-insensitive strings to exclude from being treated as
+links.
+@end defvar
+
 @node When to cache
 @section When to cache
 


### PR DESCRIPTION
Adds two customizable variables: org-roam-db-extra-links-elements and
org-roam-db-extra-links-exclude-keys, which govern which elements are to
be considered for link parsing by Org-roam.

Also added sane defaults to org-roam-db-extra-links-exclude-keys.

Closes #2029