### PR TITLE
(feat)capture: create ID before capture process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 ## TBD
 ### Added
-- [#2042](https://github.com/org-roam/org-roam/pull/2042) Add `org-roam-db-extra-links-elements` and `org-roam-db-extra-links-exclude-keys` for fine-grained control over additional link parsing.
+- [#2042](https://github.com/org-roam/org-roam/pull/2042) db: add `org-roam-db-extra-links-elements` and `org-roam-db-extra-links-exclude-keys` for fine-grained control over additional link parsing
+- [#2049](https://github.com/org-roam/org-roam/pull/2049) capture: allow ID to be used as part of `org-roam-capture-templates` 
 ### Removed
 ### Fixed
 ### Changed

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -407,6 +407,8 @@ TEMPLATES is a list of org-roam templates."
           (mapcar (lambda (template)
                     (org-roam-capture--convert-template template props))
                   (or templates org-roam-capture-templates)))
+         (_ (setf (org-roam-node-id node) (or (org-roam-node-id node)
+                                              (org-id-new))))
          (org-roam-capture--node node)
          (org-roam-capture--info info))
     (when (and (not keys)
@@ -572,12 +574,10 @@ Return the ID of the location."
     ;; caller.
     (save-excursion
       (goto-char p)
-      (when-let* ((node org-roam-capture--node)
-                  (id (org-roam-node-id node)))
-        (org-entry-put p "ID" id))
-      (prog1
-          (org-id-get-create)
-        (run-hooks 'org-roam-capture-new-node-hook)))))
+      (if-let ((id (org-entry-get p "ID")))
+          (setf (org-roam-node-id org-roam-capture--node) id)
+        (org-entry-put p "ID" (org-roam-node-id org-roam-capture--node)))
+      (run-hooks 'org-roam-capture-new-node-hook))))
 
 (defun org-roam-capture--get-target ()
   "Get the current capture :target for the capture template in use."


### PR DESCRIPTION
This allows the ID to be used as part of the capture template. Addresses #2048.