### PR TITLE
(feat)org-roam-node-random: support filter-fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ## TBD
 ### Added
 - [#2042](https://github.com/org-roam/org-roam/pull/2042) db: add `org-roam-db-extra-links-elements` and `org-roam-db-extra-links-exclude-keys` for fine-grained control over additional link parsing
-- [#2049](https://github.com/org-roam/org-roam/pull/2049) capture: allow ID to be used as part of `org-roam-capture-templates` 
+- [#2049](https://github.com/org-roam/org-roam/pull/2049) capture: allow ID to be used as part of `org-roam-capture-templates`
+- [#2050](https://github.com/org-roam/org-roam/pull/2050) core: add `FILTER-FN` to `org-roam-node-random`
 ### Removed
 ### Fixed
 ### Changed


### PR DESCRIPTION
Adds an argument `FILTER-FN` to `org-roam-node-random` to restrict selection for random Org-roam nodes.

E.g.

``` emacs-lisp
(defun my-org-roam-node-random (&optional other-window)
  (interactive current-prefix-arg)
  (org-roam-node-random
   (lambda (node)
     (member "draft" (org-roam-node-tags node)))
   other-window))
```

Will restrict random notes to only those tagged `draft`. Closes #2022.