### PR TITLE
[FIX] Added DOUBLE ACUTE ACCENT for unicode normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 - [#2055](https://github.com/org-roam/org-roam/pull/2055) dailies: removed stray f require, which was causing require and compilation errors
 ### Changed
+- [#2060](https://github.com/org-roam/org-roam/pull/2060) node: added double acute accent normalization for Unicode characters in titles
 - [#2040](https://github.com/org-roam/org-roam/pull/2040) completions: fix completions display-width for Helm users
 - [#2025](https://github.com/org-roam/org-roam/pull/2025) chore: removed the dependencies on f.el and s.el
 

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -174,6 +174,7 @@ It takes a single argument REF, which is a propertized string."
                            776 ; U+0308 COMBINING DIAERESIS
                            777 ; U+0309 COMBINING HOOK ABOVE
                            778 ; U+030A COMBINING RING ABOVE
+                           779 ; U+030B COMBINING DOUBLE ACUTE ACCENT
                            780 ; U+030C COMBINING CARON
                            795 ; U+031B COMBINING HORN
                            803 ; U+0323 COMBINING DOT BELOW


### PR DESCRIPTION
###### Motivation for this change
Org-roam usually "normalizes" non-english characters in node titles, such as á becomes a, é becomes e, which is helpful with external programs which are finicky with this.
The double acute accent was left out, so ű, ő wouldn't normalize.