### PR TITLE
(fix)node: make filter-fn for org-roam-node-random optional

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -477,7 +477,7 @@ The TEMPLATES, if provided, override the list of capture templates (see
        :props '(:finalize find-file)))))
 
 ;;;###autoload
-(defun org-roam-node-random (filter-fn &optional other-window)
+(defun org-roam-node-random (&optional other-window filter-fn)
   "Find and open a random Org-roam node.
 With prefix argument OTHER-WINDOW, visit the node in another
 window instead.


### PR DESCRIPTION
Also, make interactive argument actually apply for other-window