### PR TITLE
Allow specifying template keys in remaining org-roam-dailies capture/goto commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#2042](https://github.com/org-roam/org-roam/pull/2042) db: add `org-roam-db-extra-links-elements` and `org-roam-db-extra-links-exclude-keys` for fine-grained control over additional link parsing
 - [#2049](https://github.com/org-roam/org-roam/pull/2049) capture: allow ID to be used as part of `org-roam-capture-templates`
 - [#2050](https://github.com/org-roam/org-roam/pull/2050) core: add `FILTER-FN` to `org-roam-node-random`
+- [#2065](https://github.com/org-roam/org-roam/pull/2065) dailies: add `keys` argument to the remaining dailies functions `org-roam-dailies-goto-yesterday`/`-today`/`-tomorrow`/`-date` and `org-roam-dailies-capture-yesterday`/`-tomorrow`/`-date` to give the abilty to get into a capture buffer bypassing the selection screen in all dailies commands. Extension of #2055
 ### Removed
 ### Fixed
 - [#2055](https://github.com/org-roam/org-roam/pull/2055) dailies: removed stray f require, which was causing require and compilation errors

--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -139,14 +139,14 @@ In this case, interactive selection will be bypassed."
   (org-roam-dailies--capture (current-time) goto keys))
 
 ;;;###autoload
-(defun org-roam-dailies-goto-today ()
+(defun org-roam-dailies-goto-today (keys)
   "Find the daily-note for today, creating it if necessary."
   (interactive)
-  (org-roam-dailies-capture-today t))
+  (org-roam-dailies-capture-today t keys))
 
 ;;;; Tomorrow
 ;;;###autoload
-(defun org-roam-dailies-capture-tomorrow (n &optional goto)
+(defun org-roam-dailies-capture-tomorrow (n &optional goto keys)
   "Create an entry in the daily-note for tomorrow.
 
 With numeric argument N, use the daily-note N days in the future.
@@ -154,40 +154,40 @@ With numeric argument N, use the daily-note N days in the future.
 With a `C-u' prefix or when GOTO is non-nil, go the note without
 creating an entry."
   (interactive "p")
-  (org-roam-dailies--capture (time-add (* n 86400) (current-time)) goto))
+  (org-roam-dailies--capture (time-add (* n 86400) (current-time)) goto keys))
 
 ;;;###autoload
-(defun org-roam-dailies-goto-tomorrow (n)
+(defun org-roam-dailies-goto-tomorrow (n keys)
   "Find the daily-note for tomorrow, creating it if necessary.
 
 With numeric argument N, use the daily-note N days in the
 future."
   (interactive "p")
-  (org-roam-dailies-capture-tomorrow n t))
+  (org-roam-dailies-capture-tomorrow n t keys))
 
 ;;;; Yesterday
 ;;;###autoload
-(defun org-roam-dailies-capture-yesterday (n &optional goto)
+(defun org-roam-dailies-capture-yesterday (n &optional goto keys)
   "Create an entry in the daily-note for yesteday.
 
 With numeric argument N, use the daily-note N days in the past.
 
 When GOTO is non-nil, go the note without creating an entry."
   (interactive "p")
-  (org-roam-dailies-capture-tomorrow (- n) goto))
+  (org-roam-dailies-capture-tomorrow (- n) goto keys))
 
 ;;;###autoload
-(defun org-roam-dailies-goto-yesterday (n)
+(defun org-roam-dailies-goto-yesterday (n keys)
   "Find the daily-note for yesterday, creating it if necessary.
 
 With numeric argument N, use the daily-note N days in the
 future."
   (interactive "p")
-  (org-roam-dailies-capture-tomorrow (- n) t))
+  (org-roam-dailies-capture-tomorrow (- n) t keys))
 
 ;;;; Date
 ;;;###autoload
-(defun org-roam-dailies-capture-date (&optional goto prefer-future)
+(defun org-roam-dailies-capture-date (&optional goto prefer-future keys)
   "Create an entry in the daily-note for a date using the calendar.
 Prefer past dates, unless PREFER-FUTURE is non-nil.
 With a `C-u' prefix or when GOTO is non-nil, go the note without
@@ -197,14 +197,14 @@ creating an entry."
                 (org-read-date nil t nil (if goto
                                              "Find daily-note: "
                                            "Capture to daily-note: ")))))
-    (org-roam-dailies--capture time goto)))
+    (org-roam-dailies--capture time goto keys)))
 
 ;;;###autoload
-(defun org-roam-dailies-goto-date (&optional prefer-future)
+(defun org-roam-dailies-goto-date (&optional prefer-future keys)
   "Find the daily-note for a date using the calendar, creating it if necessary.
 Prefer past dates, unless PREFER-FUTURE is non-nil."
   (interactive)
-  (org-roam-dailies-capture-date t prefer-future))
+  (org-roam-dailies-capture-date t prefer-future keys))
 
 ;;;; Navigation
 (defun org-roam-dailies-goto-next-note (&optional n)

--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -139,7 +139,7 @@ In this case, interactive selection will be bypassed."
   (org-roam-dailies--capture (current-time) goto keys))
 
 ;;;###autoload
-(defun org-roam-dailies-goto-today (keys)
+(defun org-roam-dailies-goto-today (&optional keys)
   "Find the daily-note for today, creating it if necessary."
   (interactive)
   (org-roam-dailies-capture-today t keys))
@@ -157,7 +157,7 @@ creating an entry."
   (org-roam-dailies--capture (time-add (* n 86400) (current-time)) goto keys))
 
 ;;;###autoload
-(defun org-roam-dailies-goto-tomorrow (n keys)
+(defun org-roam-dailies-goto-tomorrow (n &optional keys)
   "Find the daily-note for tomorrow, creating it if necessary.
 
 With numeric argument N, use the daily-note N days in the
@@ -177,7 +177,7 @@ When GOTO is non-nil, go the note without creating an entry."
   (org-roam-dailies-capture-tomorrow (- n) goto keys))
 
 ;;;###autoload
-(defun org-roam-dailies-goto-yesterday (n keys)
+(defun org-roam-dailies-goto-yesterday (n &optional keys)
   "Find the daily-note for yesterday, creating it if necessary.
 
 With numeric argument N, use the daily-note N days in the

--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -140,7 +140,10 @@ In this case, interactive selection will be bypassed."
 
 ;;;###autoload
 (defun org-roam-dailies-goto-today (&optional keys)
-  "Find the daily-note for today, creating it if necessary."
+  "Find the daily-note for today, creating it if necessary.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (interactive)
   (org-roam-dailies-capture-today t keys))
 
@@ -152,7 +155,10 @@ In this case, interactive selection will be bypassed."
 With numeric argument N, use the daily-note N days in the future.
 
 With a `C-u' prefix or when GOTO is non-nil, go the note without
-creating an entry."
+creating an entry.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (interactive "p")
   (org-roam-dailies--capture (time-add (* n 86400) (current-time)) goto keys))
 
@@ -161,7 +167,10 @@ creating an entry."
   "Find the daily-note for tomorrow, creating it if necessary.
 
 With numeric argument N, use the daily-note N days in the
-future."
+future.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (interactive "p")
   (org-roam-dailies-capture-tomorrow n t keys))
 
@@ -172,7 +181,10 @@ future."
 
 With numeric argument N, use the daily-note N days in the past.
 
-When GOTO is non-nil, go the note without creating an entry."
+When GOTO is non-nil, go the note without creating an entry.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (interactive "p")
   (org-roam-dailies-capture-tomorrow (- n) goto keys))
 
@@ -181,7 +193,10 @@ When GOTO is non-nil, go the note without creating an entry."
   "Find the daily-note for yesterday, creating it if necessary.
 
 With numeric argument N, use the daily-note N days in the
-future."
+future.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (interactive "p")
   (org-roam-dailies-capture-tomorrow (- n) t keys))
 
@@ -191,7 +206,10 @@ future."
   "Create an entry in the daily-note for a date using the calendar.
 Prefer past dates, unless PREFER-FUTURE is non-nil.
 With a `C-u' prefix or when GOTO is non-nil, go the note without
-creating an entry."
+creating an entry.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (interactive "P")
   (let ((time (let ((org-read-date-prefer-future prefer-future))
                 (org-read-date nil t nil (if goto
@@ -202,7 +220,10 @@ creating an entry."
 ;;;###autoload
 (defun org-roam-dailies-goto-date (&optional prefer-future keys)
   "Find the daily-note for a date using the calendar, creating it if necessary.
-Prefer past dates, unless PREFER-FUTURE is non-nil."
+Prefer past dates, unless PREFER-FUTURE is non-nil.
+
+ELisp programs can set KEYS to a string associated with a template.
+In this case, interactive selection will be bypassed."
   (interactive)
   (org-roam-dailies-capture-date t prefer-future keys))
 


### PR DESCRIPTION
This is an extension of PR #2028 by @astery, where the `keys` argument was added to `org-roam-dailies--capture` `org-roam-dailies-capture-today`.

I extended this argument to also be available in other built-in dailies functions, as I didn't see any reason why not and it results in my opinion in more consistent behaviour. So far it seems to work for me. But I' wondering why @astery didn't implement that everywhere in the first place, so maybe there is a reason I don't know.

One thing that might be confusing for users is when they start adding the keys to all their dailies functions without reading their respective docstrings, since some have have already other optional arguments, so users might need to add some `nil`'s, e.g.

``` emacs-lisp
      (org-roam-dailies-goto-date nil "<key>")
```

Then, in this case, the key-string will be interpreted as the value for `prefer-future` and since it's non-nil, there won't be an error.

###### Motivation for this change
The rationale is the same as in #2028: Allow users to add keybindings (or in my case hydras) to calls of org-roam-dailies functions with specific template keys, thus circumventing the selection screen.