### PR TITLE
docs: fix little typos

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -793,7 +793,7 @@ citation key:
 :END:
 #+end_src
 
-or
+or:
 
 #+begin_src org
 ,* Probabilistic Robotics
@@ -803,7 +803,7 @@ or
 :END:
 #+end_src
 
-for ~org-cite~, or:
+or, for ~org-cite~:
 
 #+begin_src org
 ,* Probabilistic Robotics
@@ -812,8 +812,6 @@ for ~org-cite~, or:
 :ROAM_REFS: cite:thrun2005probabilistic
 :END:
 #+end_src
-
-for ~org-ref~.
 
 When another node has a citation for that key, we can see it using the
 ~Reflinks~ section of the Org-roam buffer.

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1179,7 +1179,7 @@ citation key:
 :END:
 @end example
 
-or
+or:
 
 @example
 * Probabilistic Robotics
@@ -1189,7 +1189,7 @@ or
 :END:
 @end example
 
-for @code{org-cite}, or:
+or, for @code{org-cite}:
 
 @example
 * Probabilistic Robotics
@@ -1198,8 +1198,6 @@ for @code{org-cite}, or:
 :ROAM_REFS: cite:thrun2005probabilistic
 :END:
 @end example
-
-for @code{org-ref}.
 
 When another node has a citation for that key, we can see it using the
 @code{Reflinks} section of the Org-roam buffer.


### PR DESCRIPTION
Found these typos while I was reading the manual.