### PR TITLE
Ensuring that :ref info capture in all cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Breaking
 - [#2054](https://github.com/org-roam/org-roam/pull/2054) node: simplify default `org-roam-node-display-template`.
   This was done so completions work fine by default on all completion systems. To restore the tabular vertical completion interface, set this in your configuration:
-  
+
   ```emacs-lisp
   (setq org-roam-node-display-template
         (concat "${title:*} "
@@ -15,6 +15,8 @@
 - [#2049](https://github.com/org-roam/org-roam/pull/2049) capture: allow ID to be used as part of `org-roam-capture-templates`
 - [#2050](https://github.com/org-roam/org-roam/pull/2050) core: add `FILTER-FN` to `org-roam-node-random`
 - [#2065](https://github.com/org-roam/org-roam/pull/2065) dailies: add `keys` argument to the remaining dailies functions `org-roam-dailies-goto-yesterday`/`-today`/`-tomorrow`/`-date` and `org-roam-dailies-capture-yesterday`/`-tomorrow`/`-date` to give the abilty to get into a capture buffer bypassing the selection screen in all dailies commands. Extension of #2055
+- [#2079](https://github.com/org-roam/org-roam/pull/2079) capture: ensure that `:ref` info captured in all cases.
+
 ### Removed
 ### Fixed
 - [#2055](https://github.com/org-roam/org-roam/pull/2055) dailies: removed stray f require, which was causing require and compilation errors

--- a/extensions/org-roam-protocol.el
+++ b/extensions/org-roam-protocol.el
@@ -169,25 +169,6 @@ org-protocol://roam-node?node=uuid"
 (push '("org-roam-node"  :protocol "roam-node"   :function org-roam-protocol-open-node)
       org-protocol-protocol-alist)
 
-;;; Capture implementation
-(add-hook 'org-roam-capture-preface-hook #'org-roam-protocol--try-capture-to-ref-h)
-(defun org-roam-protocol--try-capture-to-ref-h ()
-  "Try to capture to an existing node that match the ref."
-  (when-let ((node (and (plist-get org-roam-capture--info :ref)
-                        (org-roam-node-from-ref
-                         (plist-get org-roam-capture--info :ref)))))
-    (set-buffer (org-capture-target-buffer (org-roam-node-file node)))
-    (goto-char (org-roam-node-point node))
-    (widen)
-    (org-roam-node-id node)))
-
-(add-hook 'org-roam-capture-new-node-hook #'org-roam-protocol--insert-captured-ref-h)
-(defun org-roam-protocol--insert-captured-ref-h ()
-  "Insert the ref if any."
-  (when-let ((ref (plist-get org-roam-capture--info :ref)))
-    (org-roam-ref-add ref)))
-
-
 (provide 'org-roam-protocol)
 
 ;;; org-roam-protocol.el ends here

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -679,6 +679,24 @@ the current value of `point'."
             (goto-char (org-entry-end-position))))))))
   (point))
 
+;;; Capture implementation
+(add-hook 'org-roam-capture-preface-hook #'org-roam-capture--try-capture-to-ref-h)
+(defun org-roam-capture--try-capture-to-ref-h ()
+  "Try to capture to an existing node that match the ref."
+  (when-let ((node (and (plist-get org-roam-capture--info :ref)
+                        (org-roam-node-from-ref
+                         (plist-get org-roam-capture--info :ref)))))
+    (set-buffer (org-capture-target-buffer (org-roam-node-file node)))
+    (goto-char (org-roam-node-point node))
+    (widen)
+    (org-roam-node-id node)))
+
+(add-hook 'org-roam-capture-new-node-hook #'org-roam-capture--insert-captured-ref-h)
+(defun org-roam-capture--insert-captured-ref-h ()
+  "Insert the ref if any."
+  (when-let ((ref (plist-get org-roam-capture--info :ref)))
+    (org-roam-ref-add ref)))
+
 ;;;; Finalizers
 (add-hook 'org-capture-prepare-finalize-hook #'org-roam-capture--install-finalize-h)
 (defun org-roam-capture--install-finalize-h ()


### PR DESCRIPTION
Let's assume we're evaluating the following region:

```elisp
(org-roam-capture-
     :node (org-roam-node-create :title "Org Roam Homepage")
     :info '(:ref "https://orgroam.com")
     :props '(:immediate-finish nil))
```

Prior to this commit, if you did not require "org-roam-protocol" then
`org-roam-capture-` would ignore the `:info '(:ref
"https://orgroam.com")` parameter.  Once you required
"org-roam-protocol" then the callback hooks that process `:info`'s
`:ref` will fire regardless of whether it comes from org-roam-protocol.

After this commit, you no longer need to require "org-roam-protocol" to
ensure that you capture an `:info`'s `:ref`.

Why is this useful?  When I'm reading through my elfeed RSS feed, I want
to capture an article.  I could use the org-roam-protocol to do this,
but that seems a bit unnecessary given that I'm already in Emacs.

Closes org-roam/org-roam#2078

###### Motivation for this change
