### PR TITLE
(fix)dailies: prevent multiple "dailies/" subdirectory expansions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#2065](https://github.com/org-roam/org-roam/pull/2065) dailies: add `keys` argument to the remaining dailies functions `org-roam-dailies-goto-yesterday`/`-today`/`-tomorrow`/`-date` and `org-roam-dailies-capture-yesterday`/`-tomorrow`/`-date` to give the abilty to get into a capture buffer bypassing the selection screen in all dailies commands. Extension of #2055
 ### Removed
 ### Fixed
+- [#2080](https://github.com/org-roam/org-roam/pull/2080) dailies: prevent multiple "dailies/" subdir expansions
 - [#2055](https://github.com/org-roam/org-roam/pull/2055) dailies: removed stray f require, which was causing require and compilation errors
 ### Changed
 - [#2060](https://github.com/org-roam/org-roam/pull/2060) node: added double acute accent normalization for Unicode characters in titles

--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -329,7 +329,8 @@ When GOTO is non-nil, go the note without creating an entry.
 
 ELisp programs can set KEYS to a string associated with a template.
 In this case, interactive selection will be bypassed."
-  (let ((org-roam-directory (expand-file-name org-roam-dailies-directory org-roam-directory)))
+  (let ((org-roam-directory (expand-file-name org-roam-dailies-directory org-roam-directory))
+        (org-roam-dailies-directory "./"))
     (org-roam-capture- :goto (when goto '(4))
                        :keys keys
                        :node (org-roam-node-create)


### PR DESCRIPTION
When dynamic binding `org-roam-directory` to the "dailies/"
subdirectory also bind `org-roam-dailies-directory` to "./" to prevent
invalid expansions in user-defined hook functions.

Fixes #2070
