### PR TITLE
(fix)buffer: buffer-toggle: don't destroy window if `org-roam-node-toggle` reuses window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Removed
 ### Fixed
+- [#2082](https://github.com/org-roam/org-roam/pull/2082) buffer: don't destroy window if `org-roam-node-toggle` reuses window
 - [#2080](https://github.com/org-roam/org-roam/pull/2080) dailies: prevent multiple "dailies/" subdir expansions
 - [#2055](https://github.com/org-roam/org-roam/pull/2055) dailies: removed stray f require, which was causing require and compilation errors
 ### Changed

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -289,7 +289,7 @@ To toggle its display use `org-roam-buffer-toggle' command.")
   (pcase (org-roam-buffer--visibility)
     ('visible
      (progn
-       (delete-window (get-buffer-window org-roam-buffer))
+       (quit-window nil (get-buffer-window org-roam-buffer))
        (remove-hook 'post-command-hook #'org-roam-buffer--redisplay-h)))
     ((or 'exists 'none)
      (progn


### PR DESCRIPTION
Closes #2077