### PR TITLE
fix #2083 ID should be added to org-id-locations-file after capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Removed
 ### Fixed
+- [#2086](https://github.com/org-roam/org-roam/pull/2086) capture: correctly update org-id-locations on capture
 - [#2082](https://github.com/org-roam/org-roam/pull/2082) buffer: don't destroy window if `org-roam-node-toggle` reuses window
 - [#2080](https://github.com/org-roam/org-roam/pull/2080) dailies: prevent multiple "dailies/" subdir expansions
 - [#2055](https://github.com/org-roam/org-roam/pull/2055) dailies: removed stray f require, which was causing require and compilation errors

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -714,7 +714,7 @@ the current value of `point'."
         (when (find-buffer-visiting new-file)
           (kill-buffer (find-buffer-visiting new-file)))
         (delete-file new-file))
-    (org-id-add-location (org-roam-capture--get :id)(org-roam-capture--get :new-file))
+    (org-id-add-location (org-roam-capture--get :id) (org-roam-capture--get :new-file))
     (when-let* ((finalize (org-roam-capture--get :finalize))
                 (org-roam-finalize-fn (intern (concat "org-roam-capture--finalize-"
                                                       (symbol-name finalize)))))

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -714,6 +714,7 @@ the current value of `point'."
         (when (find-buffer-visiting new-file)
           (kill-buffer (find-buffer-visiting new-file)))
         (delete-file new-file))
+    (org-id-add-location (org-roam-capture--get :id)(org-roam-capture--get :new-file))
     (when-let* ((finalize (org-roam-capture--get :finalize))
                 (org-roam-finalize-fn (intern (concat "org-roam-capture--finalize-"
                                                       (symbol-name finalize)))))


### PR DESCRIPTION
Currently, Condition 1 below is met. A fix will need to meet Condition 2 in addition.

1. The new Org ID must be available to other functions during the capture
   process

2. Adding the new Org ID to Org ID file/hash must be done after "Abort" check
   -- i.e., when the user aborts the capture process, the new ID must not be
   added to the Org ID file and hash database

###### Motivation for this change
