### PR TITLE
Fix `org-roam-descendant-of-p` bug on Windows

### DIFF
--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -289,7 +289,7 @@ If FILE is not specified, use the current buffer's file-path."
     (save-match-data
       (and
        (org-roam-file-p path)
-       (org-roam-descendant-of-p path directory)))))
+       (file-in-directory-p path directory)))))
 
 ;;;###autoload
 (defun org-roam-dailies-find-directory ()

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -108,14 +108,6 @@ SPEC is a list, as per `dolist'."
       `(dolist-with-progress-reporter ,spec ,msg ,@body)
     `(dolist ,spec ,@body)))
 
-;;; File utilities
-(defun org-roam-descendant-of-p (a b)
-  "Return t if A is descendant of B."
-  (let ((a (file-truename a))
-        (b (file-truename b)))
-    (unless (equal a b)
-      (string-prefix-p b a))))
-
 (defmacro org-roam-with-file (file keep-buf-p &rest body)
   "Execute BODY within FILE.
 If FILE is nil, execute BODY in the current buffer.

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -111,9 +111,10 @@ SPEC is a list, as per `dolist'."
 ;;; File utilities
 (defun org-roam-descendant-of-p (a b)
   "Return t if A is descendant of B."
-  (unless (equal (file-truename a) (file-truename b))
-    (string-prefix-p (expand-file-name b)
-                     (expand-file-name a))))
+  (let ((a (file-truename a))
+        (b (file-truename b)))
+    (unless (equal a b)
+      (string-prefix-p b a))))
 
 (defmacro org-roam-with-file (file keep-buf-p &rest body)
   "Execute BODY within FILE.

--- a/org-roam.el
+++ b/org-roam.el
@@ -194,7 +194,7 @@ FILE is an Org-roam file if:
        (member ext org-roam-file-extensions)
        (not (and org-roam-file-exclude-regexp
                  (string-match-p org-roam-file-exclude-regexp path)))
-       (org-roam-descendant-of-p path (expand-file-name org-roam-directory))))))
+       (file-in-directory-p path (expand-file-name org-roam-directory))))))
 
 (defun org-roam-list-files ()
   "Return a list of all Org-roam files under `org-roam-directory'.


### PR DESCRIPTION
On Windows, `file-truename` and `directory-file-name` downcase drive label: "C:/" => "c:/", while `expand-file-name` keep the case unchanged.

If `org-roam-directory` use upper case drive label, `org-roam-descendant-of-p` will alway return `nil`.

This make `org-roam` totally unusable!!

From [here](https://github.com/org-roam/org-roam/blob/b163c900b8ec2e3637bc251d9b90421efc771c02/org-roam-compat.el#L64), all the candidates file names have a lowercase drive label.
