### PR TITLE
(fix)capture: don't update org-id-locations if file is unknown

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -716,7 +716,7 @@ the current value of `point'."
           (kill-buffer (find-buffer-visiting new-file)))
         (delete-file new-file))
     (when-let* ((buffer (plist-get org-capture-plist :buffer))
-		(file (buffer-file-name buffer)))
+                (file (buffer-file-name buffer)))
       (org-id-add-location (org-roam-capture--get :id) file))
     (when-let* ((finalize (org-roam-capture--get :finalize))
                 (org-roam-finalize-fn (intern (concat "org-roam-capture--finalize-"

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -715,7 +715,9 @@ the current value of `point'."
         (when (find-buffer-visiting new-file)
           (kill-buffer (find-buffer-visiting new-file)))
         (delete-file new-file))
-    (org-id-add-location (org-roam-capture--get :id) (org-roam-capture--get :new-file))
+    (when-let* ((buffer (plist-get org-capture-plist :buffer))
+		(file (buffer-file-name buffer)))
+      (org-id-add-location (org-roam-capture--get :id) file))
     (when-let* ((finalize (org-roam-capture--get :finalize))
                 (org-roam-finalize-fn (intern (concat "org-roam-capture--finalize-"
                                                       (symbol-name finalize)))))


### PR DESCRIPTION
My attempt to address https://github.com/org-roam/org-roam/issues/2102 .
Feedback is welcome.


###### Motivation for this change