### PR TITLE
(fix): place cursor after inserted link for new nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#2060](https://github.com/org-roam/org-roam/pull/2060) node: added double acute accent normalization for Unicode characters in titles
 - [#2040](https://github.com/org-roam/org-roam/pull/2040) completions: fix completions display-width for Helm users
 - [#2025](https://github.com/org-roam/org-roam/pull/2025) chore: removed the dependencies on f.el and s.el
+- [#2109](https://github.com/org-roam/org-roam/pull/2109) capture: `org-roam-node-insert` places cursor after inserted link where appropriate
 
 ## 2.2.0
 ### Added

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -744,9 +744,12 @@ This function is to be called in the Org-capture finalization process."
         (delete-region (car region) (cdr region))
         (set-marker (car region) nil)
         (set-marker (cdr region) nil))
-      (org-with-point-at mkr
-        (insert (org-link-make-string (concat "id:" (org-roam-capture--get :id))
-                                      (org-roam-capture--get :link-description)))))))
+      (let ((link (org-link-make-string (concat "id:" (org-roam-capture--get :id))
+                                        (org-roam-capture--get :link-description))))
+        (if (eq (point) (marker-position mkr))
+            (insert link)
+          (org-with-point-at mkr
+            (insert link)))))))
 
 ;;;; Processing of the capture templates
 (defun org-roam-capture--fill-template (template &optional org-capture-p newline)

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -698,8 +698,7 @@ The INFO, if provided, is passed to the underlying `org-roam-capture-'."
              :props (append
                      (when (and beg end)
                        (list :region (cons beg end)))
-                     (list :insert-at (point-marker)
-                           :link-description description
+                     (list :link-description description
                            :finalize 'insert-link))))))
     (deactivate-mark)))
 


### PR DESCRIPTION
Special care is taken not to move the point if the original point is no
longer the same (i.e. the user moves the cursor after calling the
capture, but before finalizing it). Fixes #2108.