### PR TITLE
(fix): caching symlinked files

### DIFF
--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -289,7 +289,7 @@ If FILE is not specified, use the current buffer's file-path."
     (save-match-data
       (and
        (org-roam-file-p path)
-       (file-in-directory-p path directory)))))
+       (org-roam-descendant-of-p path directory)))))
 
 ;;;###autoload
 (defun org-roam-dailies-find-directory ()

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -108,6 +108,13 @@ SPEC is a list, as per `dolist'."
       `(dolist-with-progress-reporter ,spec ,msg ,@body)
     `(dolist ,spec ,@body)))
 
+;;; File utilities
+(defun org-roam-descendant-of-p (a b)
+  "Return t if A is descendant of B."
+  (unless (equal (file-truename a) (file-truename b))
+    (string-prefix-p (expand-file-name b)
+                     (expand-file-name a))))
+
 (defmacro org-roam-with-file (file keep-buf-p &rest body)
   "Execute BODY within FILE.
 If FILE is nil, execute BODY in the current buffer.

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -112,8 +112,8 @@ SPEC is a list, as per `dolist'."
 (defun org-roam-descendant-of-p (a b)
   "Return t if A is descendant of B."
   (unless (equal (file-truename a) (file-truename b))
-    (string-prefix-p (replace-regexp-in-string "^\(\w\):" 'downcase (expand-file-name b) t t)
-                     (replace-regexp-in-string "^\(\w\):" 'downcase (expand-file-name a) t t))))
+    (string-prefix-p (replace-regexp-in-string "^\\([A-Za-z]\\):" 'downcase (expand-file-name b) t t)
+                     (replace-regexp-in-string "^\\([A-Za-z]\\):" 'downcase (expand-file-name a) t t))))
 
 (defmacro org-roam-with-file (file keep-buf-p &rest body)
   "Execute BODY within FILE.

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -112,8 +112,8 @@ SPEC is a list, as per `dolist'."
 (defun org-roam-descendant-of-p (a b)
   "Return t if A is descendant of B."
   (unless (equal (file-truename a) (file-truename b))
-    (string-prefix-p (expand-file-name b)
-                     (expand-file-name a))))
+    (string-prefix-p (replace-regexp-in-string "^\(\w\):" 'downcase (expand-file-name b) t t)
+                     (replace-regexp-in-string "^\(\w\):" 'downcase (expand-file-name a) t t))))
 
 (defmacro org-roam-with-file (file keep-buf-p &rest body)
   "Execute BODY within FILE.

--- a/org-roam.el
+++ b/org-roam.el
@@ -194,7 +194,7 @@ FILE is an Org-roam file if:
        (member ext org-roam-file-extensions)
        (not (and org-roam-file-exclude-regexp
                  (string-match-p org-roam-file-exclude-regexp path)))
-       (file-in-directory-p path (expand-file-name org-roam-directory))))))
+       (org-roam-descendant-of-p path (expand-file-name org-roam-directory))))))
 
 (defun org-roam-list-files ()
   "Return a list of all Org-roam files under `org-roam-directory'.


### PR DESCRIPTION
###### Motivation for this change

It seems that the `file-in-directory-p` function proposed in #2089 is provided only for
*physical directories*, does not work as we would like with *symlinked directories*.
It dereferences all the symlinks in its path, and previously seemed related paths
cease to be such.

For example:

Source paths:

```
~/org-roam/ -> ~/MEGAsync/org-roam/
~/org-roam/note.org -> ~/Desktop/note.org
```

How `file-in-directory-p` sees them after dereference:

```
~/MEGAsync/org-roam/
~/Desktop/note.org
```

Because of this, such notes are ignored and not indexed, although they were indexed earlier.

This PR restores symlink support. Fixes #2111.