### PR TITLE
(docs): add docs for org-protocol

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -902,7 +902,16 @@ file:
 #+END_SRC
 
 We also need to set up ~org-protocol~: the instructions for setting up
-~org-protocol~ are reproduced below.
+~org-protocol~ are reproduced here.
+
+On a high-level, external calls are passed to Emacs via ~emacsclient~.
+~org-protocol~ intercepts these and runs custom actions based on the protocols
+registered. Hence, to use ~org-protocol~, once must:
+
+1. launch the ~emacsclient~ process
+2. Register ~org-protocol://~ as a valid scheme-handler
+
+The instructions for the latter for each operating system is detailed below.
 
 *** Linux
 For Linux users, create a desktop application in

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1309,7 +1309,21 @@ file:
 @end lisp
 
 We also need to set up @code{org-protocol}: the instructions for setting up
-@code{org-protocol} are reproduced below.
+@code{org-protocol} are reproduced here.
+
+On a high-level, external calls are passed to Emacs via @code{emacsclient}.
+@code{org-protocol} intercepts these and runs custom actions based on the protocols
+registered. Hence, to use @code{org-protocol}, once must:
+
+@itemize
+@item
+launch the @code{emacsclient} process
+
+@item
+Register @code{org-protocol://} as a valid scheme-handler
+@end itemize
+
+The instructions for the latter for each operating system is detailed below.
 
 @menu
 * Linux::


### PR DESCRIPTION
###### Motivation for this change
Add more notes about using `org-roam-protocol`.