### PR TITLE
Fix the file listing methods broken by change #2025

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -260,7 +260,7 @@ If no files are found, an empty list is returned."
        (ansi-color-filter-apply it)
        (split-string it "\n")
        (seq-filter (lambda (s)
-                     (or (null s) (string= "" s))) it)))
+                     (not (or (null s) (string= "" s)))) it)))
 
 (defun org-roam--list-files-search-globs (exts)
   "Given EXTS, return a list of search globs.


### PR DESCRIPTION
The below was originally prepared for submitting an Issue, but once I realized a problem I am having with the "elisp" method was separate, I decided to update to the head of master and submit a PR for this.

### Description
Change #2025 broke all of the `org-roam-list-files-command` methods except `elisp`. This causes `org-roam--list-files` to iterate through all the variants executing their commands via `org-roam--shell-command-files` but to not see any output, until it finally lands upon `elisp` and gets some results.

I say that Change #2025 broke it because it replaced
```elisp
       (seq-filter #'s-present? it)))
```

with

```elisp
        (seq-filter (lambda (s)
                      (or (null s) (string= "" s))) it)))
```

effectively turning it into `#'s-blank?` and reversing the test. Wrapping the `or` in `(not ...)` addresses the issue.

#### Steps to Reproduce

1. Load Emacs
2. Trace the `org-roam--list-files-*` functions.
```elisp
(trace-function #'org-roam--list-files-find)
(trace-function #'org-roam--list-files-fd)
(trace-function #'org-roam--list-files-rg)
(trace-function #'org-roam--list-files-elisp)
```
3. Execute `(org-roam-list-files)`
4. Observe the results in the `*trace-output*` buffer

#### Expected Results

```
======================================================================
1 -> (org-roam--list-files-find "/usr/bin/find" "\"/Users/me/org-roam\"")
1 <- org-roam--list-files-find: ("/Users/me/xyz.org" ...)
```

#### Actual Results

```
======================================================================
1 -> (org-roam--list-files-find "/usr/bin/find" "\"/Users/me/org-roam\"")
1 <- org-roam--list-files-find: ("")
======================================================================
1 -> (org-roam--list-files-elisp "/Users/me/org-roam/work")
1 <- org-roam--list-files-find: ("/Users/me/xyz.org" ...)
```

### Environment

- Emacs: GNU Emacs 29.0.50 (build 1, x86_64-apple-darwin21.2.0, NS appkit-2113.20 Version 10.16 (Build 21C52))
- Framework: None
- Org: Org mode version 9.5.2 (9.5.2-gfbff08 @ /Users/me/.emacs.d/straight/build-29.0.50/org/)
- Org-roam: v2.2.0-25-gcebe771
- Org-roam commit: https://github.com/org-roam/org-roam/tree/cebe77135a327cacf7fa60265b553c984664e32a  