### PR TITLE
Adding unique option fro org-roam-backlinks-section

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -648,6 +648,15 @@ To configure what sections are displayed in the buffer, set ~org-roam-mode-secti
 
 Note that computing unlinked references may be slow, and has not been added in by default.
 
+Or, if you want to render unique sources for backlinks (and also keep rendering reference links), set ~org-roam-mode-section-functions~ as follows:
+
+#+begin_src emacs-lisp
+  (setq org-roam-mode-section-functions
+        (list
+         (lambda (node) (org-roam-backlinks-section node :unique t))
+         #'org-roam-reflinks-section))
+#+end_src
+
 ** Configuring the Org-roam buffer display
 
 Org-roam does not control how the pop-up buffer is displayed: this is left to

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -988,6 +988,16 @@ To configure what sections are displayed in the buffer, set @code{org-roam-mode-
 
 Note that computing unlinked references may be slow, and has not been added in by default.
 
+Or, if you want to render unique sources for backlinks (and also keep rendering reference links), set @code{org-roam-mode-section-functions} as follows:
+
+@lisp
+  (setq org-roam-mode-section-functions
+        (list
+         (lambda (node) (org-roam-backlinks-section node :unique t))
+         #'org-roam-reflinks-section))
+@end lisp
+
+
 @node Configuring the Org-roam buffer display
 @section Configuring the Org-roam buffer display
 


### PR DESCRIPTION
Prior to this commit, when we would render backlinks in the
`org-buffer`, we would render each reference.  This meant that if a
source file referenced the node 5 times, there would be 5 backlink
references in the `org-buffer` (one for each position of the reference).

With this change, we add a parameter that specifies that backlink
sources should be unique.  In the above example, that would mean instead
of 5 backlinks we'd see 1.  And, as a concession, we'd use the lowest
position (e.g. the first reference in the source).

Closes #2119