### PR TITLE
Exposing defcustom for uniqueness of backlinks

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -657,6 +657,16 @@ Or, if you want to render unique sources for backlinks (and also keep rendering 
          #'org-roam-reflinks-section))
 #+end_src
 
+Alternatively, you can set ~org-roam-backlinks-section-unique-sources~ and use the default ~org-roam-mode-section-functions~.
+
+#+begin_src emacs-lisp
+  (setq org-roam-backlinks-section-unique-sources t)
+  (setq org-roam-mode-section-functions
+	(list
+	 #'org-roam-backlinks-section
+	 #'org-roam-reflinks-section))
+#+end_src
+
 ** Configuring the Org-roam buffer display
 
 Org-roam does not control how the pop-up buffer is displayed: this is left to

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -997,6 +997,15 @@ Or, if you want to render unique sources for backlinks (and also keep rendering 
          #'org-roam-reflinks-section))
 @end lisp
 
+Alternatively, you can set @code{org-roam-backlinks-section-unique-sources} and use the default @code{org-roam-mode-section-functions}.
+
+@lisp
+  (setq org-roam-backlinks-section-unique-sources t)
+  (setq org-roam-mode-section-functions
+	(list
+	 #'org-roam-backlinks-section
+	 #'org-roam-reflinks-section))
+@end lisp
 
 @node Configuring the Org-roam buffer display
 @section Configuring the Org-roam buffer display

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -72,6 +72,18 @@ applied in order of appearance in the list."
   :group 'org-roam
   :type 'hook)
 
+(defcustom org-roam-backlinks-section-unique-sources nil
+  "If non-nil, render one backlink per source.
+
+When non-nil `org-roam-backlinks-section' renders unique
+sources, using the first pos of the backlink reference.
+
+When nil, renders each reference source.  If a node references
+another node 5 times, it will render each of those five
+references (along with position and properties)."
+  :group 'org-roam
+  :type 'boolean)
+
 ;;; Faces
 (defface org-roam-header-line
   `((((class color) (background light))
@@ -491,12 +503,15 @@ Sorts by title."
   (string< (org-roam-node-title (org-roam-backlink-source-node a))
            (org-roam-node-title (org-roam-backlink-source-node b))))
 
-(cl-defun org-roam-backlinks-section (node &key (unique nil))
+(cl-defun org-roam-backlinks-section (node &key (unique org-roam-backlinks-section-unique-sources))
   "The backlinks section for NODE.
 
 When UNIQUE is nil, show all positions where references are found.
 When UNIQUE is t, limit to unique sources."
-  (when-let ((backlinks (seq-sort #'org-roam-backlinks-sort (org-roam-backlinks-get node :unique unique))))
+  (when-let ((backlinks (seq-sort #'org-roam-backlinks-sort
+                                  (org-roam-backlinks-get
+                                   node
+                                   :unique unique))))
     (magit-insert-section (org-roam-backlinks)
       (magit-insert-heading "Backlinks:")
       (dolist (backlink backlinks)


### PR DESCRIPTION
This builds on #2121 by providing a `defcustom` variable.  I include it
separately as I'm uncertain if this is a direction @jethrokuan wishes to
go with this feature.  (If it is not a direction to go, then please
close the PR).

This provides, perhaps, a cleaner customization experience.  For myself,
I prefer the uniformity of the list of functions (as below) comapred to
a list that is a mix of functions and lambdas.

```elisp
(setq org-roam-mode-section-functions
	(list
	 #'org-roam-backlinks-section
	 #'org-roam-reflinks-section))
```

In addition, I haven't delved into writing `defcustom` declarations so
this narrow scope commit helps me further my understanding of Emacs.

###### Motivation for this change
