### PR TITLE
(feat)buffer: pass args to org-mode-section-functions

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -648,13 +648,14 @@ To configure what sections are displayed in the buffer, set ~org-roam-mode-secti
 
 Note that computing unlinked references may be slow, and has not been added in by default.
 
-Or, if you want to render unique sources for backlinks (and also keep rendering reference links), set ~org-roam-mode-section-functions~ as follows:
+For each section function, you can pass args along to modify its behaviour. For
+example, if you want to render unique sources for backlinks (and also keep
+rendering reference links), set ~org-roam-mode-section-functions~ as follows:
 
 #+begin_src emacs-lisp
   (setq org-roam-mode-section-functions
-        (list
-         (lambda (node) (org-roam-backlinks-section node :unique t))
-         #'org-roam-reflinks-section))
+        '((org-roam-backlinks-section :unique t)
+          org-roam-reflinks-section))
 #+end_src
 
 ** Configuring the Org-roam buffer display

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -988,15 +988,15 @@ To configure what sections are displayed in the buffer, set @code{org-roam-mode-
 
 Note that computing unlinked references may be slow, and has not been added in by default.
 
-Or, if you want to render unique sources for backlinks (and also keep rendering reference links), set @code{org-roam-mode-section-functions} as follows:
+For each section function, you can pass args along to modify its behaviour. For
+example, if you want to render unique sources for backlinks (and also keep
+rendering reference links), set @code{org-roam-mode-section-functions} as follows:
 
 @lisp
-  (setq org-roam-mode-section-functions
-        (list
-         (lambda (node) (org-roam-backlinks-section node :unique t))
-         #'org-roam-reflinks-section))
+(setq org-roam-mode-section-functions
+      '((org-roam-backlinks-section :unique t)
+        org-roam-reflinks-section))
 @end lisp
-
 
 @node Configuring the Org-roam buffer display
 @section Configuring the Org-roam buffer display

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -228,7 +228,14 @@ buffer."
      (org-roam-node-title org-roam-buffer-current-node))
     (magit-insert-section (org-roam)
       (magit-insert-heading)
-      (run-hook-with-args 'org-roam-mode-section-functions org-roam-buffer-current-node))
+      (dolist (section-fn org-roam-mode-section-functions)
+        (pcase section-fn
+          ((pred functionp)
+           (funcall section-fn org-roam-buffer-current-node))
+          (`(,fn . ,args)
+           (apply fn (cons org-roam-buffer-current-node args)))
+          (_
+           (user-error "Invalid `org-roam-mode-section-functions specification.'")))))
     (run-hooks 'org-roam-buffer-postrender-functions)
     (goto-char 0)))
 


### PR DESCRIPTION
###### Motivation for this change

Update `org-mode-section-functions` to accept a list, that passes the arguments into the section rendering function. cc @jeremyf 