### PR TITLE
(fix)buffer: update defcustom for org-roam-mode-section-functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#2050](https://github.com/org-roam/org-roam/pull/2050) core: add `FILTER-FN` to `org-roam-node-random`
 - [#2065](https://github.com/org-roam/org-roam/pull/2065) dailies: add `keys` argument to the remaining dailies functions `org-roam-dailies-goto-yesterday`/`-today`/`-tomorrow`/`-date` and `org-roam-dailies-capture-yesterday`/`-tomorrow`/`-date` to give the abilty to get into a capture buffer bypassing the selection screen in all dailies commands. Extension of #2055
 - [#2079](https://github.com/org-roam/org-roam/pull/2079) capture: ensure that `:ref` info captured in all cases.
+- [#2121](https://github.com/org-roam/org-roam/pull/2121) buffer: add unique option to `org-roam-backlinks-section`
 
 ### Removed
 ### Fixed
@@ -30,6 +31,7 @@
 - [#2040](https://github.com/org-roam/org-roam/pull/2040) completions: fix completions display-width for Helm users
 - [#2025](https://github.com/org-roam/org-roam/pull/2025) chore: removed the dependencies on f.el and s.el
 - [#2109](https://github.com/org-roam/org-roam/pull/2109) capture: `org-roam-node-insert` places cursor after inserted link where appropriate
+- [#2123](https://github.com/org-roam/org-roam/pull/2123), [#2124](https://github.com/org-roam/org-roam/pull/2124) buffer: `org-roam-mode-section-functions` renamed to `org-roam-mode-sections`, supports passing args into the section-rendering function
 
 ## 2.2.0
 ### Added

--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -636,10 +636,10 @@ There are currently 3 provided widget types:
 - Unlinked references :: View nodes that contain text that match the nodes
   title/alias but are not linked
 
-To configure what sections are displayed in the buffer, set ~org-roam-mode-section-functions~.
+To configure what sections are displayed in the buffer, set ~org-roam-mode-sections.
 
 #+begin_src emacs-lisp
-  (setq org-roam-mode-section-functions
+  (setq org-roam-mode-sections
         (list #'org-roam-backlinks-section
               #'org-roam-reflinks-section
               ;; #'org-roam-unlinked-references-section
@@ -650,10 +650,10 @@ Note that computing unlinked references may be slow, and has not been added in b
 
 For each section function, you can pass args along to modify its behaviour. For
 example, if you want to render unique sources for backlinks (and also keep
-rendering reference links), set ~org-roam-mode-section-functions~ as follows:
+rendering reference links), set ~org-roam-mode-sections~ as follows:
 
 #+begin_src emacs-lisp
-  (setq org-roam-mode-section-functions
+  (setq org-roam-mode-sections
         '((org-roam-backlinks-section :unique t)
           org-roam-reflinks-section))
 #+end_src

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -976,10 +976,10 @@ There are currently 3 provided widget types:
 title/alias but are not linked
 @end itemize
 
-To configure what sections are displayed in the buffer, set @code{org-roam-mode-section-functions}.
+To configure what sections are displayed in the buffer, set ~org-roam-mode-sections.
 
 @lisp
-(setq org-roam-mode-section-functions
+(setq org-roam-mode-sections
       (list #'org-roam-backlinks-section
             #'org-roam-reflinks-section
             ;; #'org-roam-unlinked-references-section
@@ -990,10 +990,10 @@ Note that computing unlinked references may be slow, and has not been added in b
 
 For each section function, you can pass args along to modify its behaviour. For
 example, if you want to render unique sources for backlinks (and also keep
-rendering reference links), set @code{org-roam-mode-section-functions} as follows:
+rendering reference links), set @code{org-roam-mode-sections} as follows:
 
 @lisp
-(setq org-roam-mode-section-functions
+(setq org-roam-mode-sections
       '((org-roam-backlinks-section :unique t)
         org-roam-reflinks-section))
 @end lisp

--- a/org-roam-compat.el
+++ b/org-roam-compat.el
@@ -229,6 +229,10 @@ nodes." org-id-locations-file)
   'org-roam-remove-property
   'org-roam-property-remove "org-roam 2.1")
 
+(define-obsolete-variable-alias
+  'org-roam-mode-section-functions
+  'org-roam-mode-sections "org-roam 2.2.0")
+
 ;;; Obsolete functions
 (make-obsolete 'org-roam-get-keyword 'org-collect-keywords "org-roam 2.0")
 


### PR DESCRIPTION
###### Motivation for this change

With #2123, we introduced an additional way to specify `org-roam-mode-section-functions`. Rename this to `org-roam-mode-sections` to reflect the changes, and update the defcustom.