### PR TITLE
(feat): add org-roam-post-node-insert-hook

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -744,12 +744,17 @@ This function is to be called in the Org-capture finalization process."
         (delete-region (car region) (cdr region))
         (set-marker (car region) nil)
         (set-marker (cdr region) nil))
-      (let ((link (org-link-make-string (concat "id:" (org-roam-capture--get :id))
-                                        (org-roam-capture--get :link-description))))
+      (let* ((id (org-roam-capture--get :id))
+             (description (org-roam-capture--get :link-description))
+             (link (org-link-make-string (concat "id:" id)
+                                         description)))
         (if (eq (point) (marker-position mkr))
             (insert link)
           (org-with-point-at mkr
-            (insert link)))))))
+            (insert link)))
+        (run-hook-with-args 'org-roam-post-node-insert-hook
+                            id
+                            description)))))
 
 ;;;; Processing of the capture templates
 (defun org-roam-capture--fill-template (template &optional ensure-newline)

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -688,9 +688,13 @@ The INFO, if provided, is passed to the underlying `org-roam-capture-'."
                   (delete-region beg end)
                   (set-marker beg nil)
                   (set-marker end nil))
-                (insert (org-link-make-string
-                         (concat "id:" (org-roam-node-id node))
-                         description)))
+                (let ((id (org-roam-node-id node)))
+                  (insert (org-link-make-string
+                           (concat "id:" id)
+                           description))
+                  (run-hook-with-args 'org-roam-post-node-insert-hook
+                                      id
+                                      description)))
             (org-roam-capture-
              :node node
              :info info

--- a/org-roam.el
+++ b/org-roam.el
@@ -123,9 +123,8 @@ All Org files, at any level of nesting, are considered part of the Org-roam."
   :type 'hook)
 
 (defcustom org-roam-post-node-insert-hook nil
-  "Hook run when an Org-roam node is insert.
-The first parameter is the id of the node's link,
-The second parameter is the link's description"
+  "Hook run when an Org-roam node is inserted as an Org link.
+Each function takes two arguments: the id of the node, and the link description."
   :group 'org-roam
   :type 'hook)
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -122,7 +122,7 @@ All Org files, at any level of nesting, are considered part of the Org-roam."
   :group 'org-roam
   :type 'hook)
 
-(defcustom org-roam-post-node-insert-hook '()
+(defcustom org-roam-post-node-insert-hook nil
   "Hook run when an Org-roam node is insert.
 The first parameter is the id of the node's link,
 The second parameter is the link's description"

--- a/org-roam.el
+++ b/org-roam.el
@@ -122,6 +122,13 @@ All Org files, at any level of nesting, are considered part of the Org-roam."
   :group 'org-roam
   :type 'hook)
 
+(defcustom org-roam-post-node-insert-hook '()
+  "Hook run when an Org-roam node is insert.
+The first parameter is the id of the node's link,
+The second parameter is the link's description"
+  :group 'org-roam
+  :type 'hook)
+
 (defcustom org-roam-file-extensions '("org")
   "List of file extensions to be included by Org-Roam.
 While a file extension different from \".org\" may be used, the


### PR DESCRIPTION
some times the node title and the tag are the same, so I added this callback to automatically add the label every time when I insert a node

###### Motivation for this change
