### PR TITLE
(fix) unlinked-references: search symlinked directories

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -655,7 +655,7 @@ References from FILE are excluded."
                                 (shell-command-to-string "rg --pcre2-version"))))
     (let* ((titles (cons (org-roam-node-title node)
                          (org-roam-node-aliases node)))
-           (rg-command (concat "rg -o --vimgrep -P -i "
+           (rg-command (concat "rg -L -o --vimgrep -P -i "
                                (mapconcat (lambda (glob) (concat "-g " glob))
                                           (org-roam--list-files-search-globs org-roam-file-extensions)
                                           " ")


### PR DESCRIPTION
Org-roam finds nodes across symlinked directories.  The `org-roam-unlinked-references-section` function does not.

This addresses that by adding the `-L` option to tell ripgrep to follow directory symlinks while looking for unlinked references. which matches what `org-roam--list-files-rg` does.