### PR TITLE
(fix) org-roam-preview-default-function doesn't copy next node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 ### Fixed
 - [#2130](https://github.com/org-roam/org-roam/pull/2130) buffer: unlinked-references section now also searches within symlinked directories
+- [#2152](https://github.com/org-roam/org-roam/pull/2152) org-roam-preview-default-function: doesn't copy copy content of next heading node when current node's content is empty
 
 ### Changed
 

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -449,10 +449,12 @@ In interactive calls OTHER-WINDOW is set with
 
 This function returns the all contents under the current
 headline, up to the next headline."
-  (let ((beg (progn (org-roam-end-of-meta-data t)
-                    (point)))
-        (end (progn (org-next-visible-heading 1)
-                    (point))))
+  (let ((beg (save-excursion
+               (org-roam-end-of-meta-data t)
+               (point)))
+        (end (save-excursion
+               (org-next-visible-heading 1)
+               (point))))
     (string-trim (buffer-substring-no-properties beg end))))
 
 (defun org-roam-preview-get-contents (file pt)


### PR DESCRIPTION
Fix #2151 
Using save-excursion in `org-roam-preview-default-function` to avoid copying next heading. 