### PR TITLE
[Fix #2156] Process fn capture templates before whitespace-content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - [#2130](https://github.com/org-roam/org-roam/pull/2130) buffer: unlinked-references section now also searches within symlinked directories
 - [#2152](https://github.com/org-roam/org-roam/pull/2152) org-roam-preview-default-function: doesn't copy copy content of next heading node when current node's content is empty
+- [#2156](https://github.com/org-roam/org-roam/pull/2157) capture: templates with functions are handled correctly to avoid signaling `char-or-string-p`
 
 ### Changed
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -762,7 +762,10 @@ This function is to be called in the Org-capture finalization process."
 It expands ${var} occurrences in TEMPLATE, and then runs
 org-capture's template expansion.
 When ENSURE-NEWLINE, always ensure there's a newline behind."
-  (let ((template-whitespace-content (org-roam-whitespace-content template)))
+  (let* ((template (if (functionp template)
+                       (funcall template)
+                     template))
+         (template-whitespace-content (org-roam-whitespace-content template)))
     (setq template
           (org-roam-format-template
            template

--- a/tests/test-org-roam-capture.el
+++ b/tests/test-org-roam-capture.el
@@ -46,6 +46,11 @@
      :to-equal "foo\n\n")
     (expect
      (org-roam-capture--fill-template "foo\n\t\n")
-     :to-equal "foo\n\t\n")))
+     :to-equal "foo\n\t\n"))
+
+  (it "expands templates when it's a function"
+    (expect
+     (org-roam-capture--fill-template (lambda () "foo"))
+     :to-equal "foo")))
 
 (provide 'test-org-roam-capture)


### PR DESCRIPTION
Fix #2156 

See above issue for description of the cause.

Issue is addressed by processing the function templates before `org-roam-capture--fill-template` is being called.