### PR TITLE
(db): fix db sync for narrowed buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - [#2130](https://github.com/org-roam/org-roam/pull/2130) buffer: unlinked-references section now also searches within symlinked directories
 - [#2152](https://github.com/org-roam/org-roam/pull/2152) org-roam-preview-default-function: doesn't copy copy content of next heading node when current node's content is empty
+- [#2159](https://github.com/org-roam/org-roam/pull/2159) db: fix db syncs on narrowed buffers
 - [#2156](https://github.com/org-roam/org-roam/pull/2157) capture: templates with functions are handled correctly to avoid signaling `char-or-string-p`
 
 ### Changed

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -617,7 +617,7 @@ in `org-roam-db-sync'."
         (org-roam-require '(org-ref oc)))
       (org-roam-with-file file-path nil
         (emacsql-with-transaction (org-roam-db)
-          (save-excursion
+          (org-with-wide-buffer
             (org-set-regexps-and-options 'tags-only)
             (org-refresh-category-properties)
             (org-roam-db-clear-file)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -618,26 +618,26 @@ in `org-roam-db-sync'."
       (org-roam-with-file file-path nil
         (emacsql-with-transaction (org-roam-db)
           (org-with-wide-buffer
-            (org-set-regexps-and-options 'tags-only)
-            (org-refresh-category-properties)
-            (org-roam-db-clear-file)
-            (org-roam-db-insert-file)
-            (org-roam-db-insert-file-node)
-            (setq org-outline-path-cache nil)
-            (org-roam-db-map-nodes
-             (list #'org-roam-db-insert-node-data
-                   #'org-roam-db-insert-aliases
-                   #'org-roam-db-insert-tags
-                   #'org-roam-db-insert-refs))
-            (setq org-outline-path-cache nil)
-            (setq info (org-element-parse-buffer))
-            (org-roam-db-map-links
-             (list #'org-roam-db-insert-link))
-            (when (fboundp 'org-cite-insert)
-              (require 'oc)             ;ensure feature is loaded
-              (org-roam-db-map-citations
-               info
-               (list #'org-roam-db-insert-citation)))))))))
+           (org-set-regexps-and-options 'tags-only)
+           (org-refresh-category-properties)
+           (org-roam-db-clear-file)
+           (org-roam-db-insert-file)
+           (org-roam-db-insert-file-node)
+           (setq org-outline-path-cache nil)
+           (org-roam-db-map-nodes
+            (list #'org-roam-db-insert-node-data
+                  #'org-roam-db-insert-aliases
+                  #'org-roam-db-insert-tags
+                  #'org-roam-db-insert-refs))
+           (setq org-outline-path-cache nil)
+           (setq info (org-element-parse-buffer))
+           (org-roam-db-map-links
+            (list #'org-roam-db-insert-link))
+           (when (fboundp 'org-cite-insert)
+             (require 'oc)             ;ensure feature is loaded
+             (org-roam-db-map-citations
+              info
+              (list #'org-roam-db-insert-citation)))))))))
 
 ;;;###autoload
 (defun org-roam-db-sync (&optional force)


### PR DESCRIPTION
###### Motivation for this change
Fixed cases where buffer is narrowed and `org-roam-db-update-file` is called. We need to widen and process everything before renarrowing.

Closes #2139.