### PR TITLE
(db)fix: fix sqlite-builtin and sqlite-module

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -163,11 +163,11 @@ ROAM_REFS."
        #'emacsql-sqlite))
     (sqlite-builtin
      (progn
-       (require 'emacs-sqlite-builtin)
+       (require 'emacsql-sqlite-builtin)
        #'emacsql-sqlite-builtin))
     (sqlite-module
      (progn
-       (require 'emacs-sqlite-module)
+       (require 'emacsql-sqlite-module)
        #'emacsql-sqlite-module))
     (libsqlite3
      (progn
@@ -188,7 +188,8 @@ Performs a database upgrade when required."
       (make-directory (file-name-directory org-roam-db-location) t)
       (let ((conn (funcall (org-roam-db--conn-fn) org-roam-db-location)))
         (emacsql conn [:pragma (= foreign_keys ON)])
-        (when-let ((process (emacsql-process conn)))
+        (when-let* ((process (emacsql-process conn))
+                    (_ (processp process)))
           (set-process-query-on-exit-flag process nil))
         (puthash (expand-file-name (file-name-as-directory org-roam-directory))
                  conn


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/org-roam/org-roam/issues/2146#issuecomment-1100790466

Tested on:

- Emacs: GNU Emacs 29.0.50 (build 1, aarch64-apple-darwin21.1.0, NS appkit-2113.00 Version 12.0.1 (Build 21A559))
 of 2022-01-11
- Framework: Doom
- Org: Org mode version 9.6 (9.6-??-971eb6885 @ /Users/jethro/.emacs.d/.local/straight/build-29.0.50/org/)
- Org-roam: v2.2.1-10-ga8d9790