### PR TITLE
(perf)node-read: filter before map to candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - [#2152](https://github.com/org-roam/org-roam/pull/2152) org-roam-preview-default-function: doesn't copy copy content of next heading node when current node's content is empty
 - [#2159](https://github.com/org-roam/org-roam/pull/2159) db: fix db syncs on narrowed buffers
 - [#2156](https://github.com/org-roam/org-roam/pull/2157) capture: templates with functions are handled correctly to avoid signaling `char-or-string-p`
+- [#2168](https://github.com/org-roam/org-roam/pull/2168) (perf)node-read: filter nodes before mapping --to-candidate
+
 
 ### Changed
 - [#2160](https://github.com/org-roam/org-roam/pull/2160) core: ignore files in `org-attach-id-dir` by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## TBD
+### Breaking
+### Added
+### Removed
+### Fixed
+- [#2168](https://github.com/org-roam/org-roam/pull/2168) (perf)node-read: filter nodes before mapping --to-candidate
+### Changed
+
 ## 2.2.2
 ### Breaking
 ### Added

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -548,13 +548,13 @@ for an example sort function.
 The displayed title is formatted according to `org-roam-node-display-template'."
   (let* ((template (org-roam-node--process-display-format org-roam-node-display-template))
          (nodes (org-roam-node-list))
-         (nodes (mapcar (lambda (node)
-                          (org-roam-node-read--to-candidate node template)) nodes))
          (nodes (if filter-fn
                     (cl-remove-if-not
-                     (lambda (n) (funcall filter-fn (cdr n)))
+                     (lambda (n) (funcall filter-fn n))
                      nodes)
                   nodes))
+         (nodes (mapcar (lambda (node)
+                          (org-roam-node-read--to-candidate node template)) nodes))
          (sort-fn (or sort-fn
                       (when org-roam-node-default-sort
                         (intern (concat "org-roam-node-read-sort-by-"


### PR DESCRIPTION
Moves the optional node filter in org-roam-node-read--completions before
the mapcar `org-roam-node-read--to-candidate`.

This saves time for completion on org-roam-node-find and
org-roam-node-insert (but only when a filter-fn is passed).

-------

###### Motivation for this change

I have experienced slowness (several seconds) on every node-find and node-insert
command for a while, but finally made the time to dig into _why_ today.

I have about 1k files and 5k nodes in my roam db.

I realized while digging that my 'archived' org nodes are being included, which
could perhaps be filtered to speed things up. Alternatively, i mostly
only care to link to files anyway. Fortunately, `filter-fn` exists as a way to
filter some nodes.

I tried:

``` emacs-lisp
;;;###autoload
(defun russ/org-roam-insert-node-level-0 ()
  "`org-roam-node-insert' but filtering for level 0 (files)"
  (interactive)
  (org-roam-node-insert (lambda (node)
                          (= 0 (org-roam-node-level node)))))
```

This 'works', but for whatever reason takes just as long (still several seconds
with a mouse-spinner before ivy pops up).

Digging into why, i traced `org-roam-node-insert` to `org-roam-node-list`. The
SQL returns more or less immediately in a sqlite shell, and via elisp:

``` emacs-lisp
(comment
 (cl-first
  (org-roam-node-list))

 (cl-first
  (reverse
   (org-roam-node-list))))
```

Then I noticed we're mapping everything via `org-roam-node-read--to-candidate`
_before_ filtering. Sure enough, moving the filtering ahead of this immediately
speeds up commands that include filters to more or less match the sql-speed:

``` emacs-lisp
(comment
 (cl-first
  (org-roam-node-read--completions
   (lambda (node)
     (= 0 (org-roam-node-level node))))))
```

I don't think this will break any existing usage - I believe the same node is
being passed to the filter function, but a quick read of
`org-roam-node-read--to-candidate` to be sure it's actually passing the node
through unaltered is probably worth it:

``` emacs-lisp
(defun org-roam-node-read--to-candidate (node template)
  "Return a minibuffer completion candidate given NODE.
TEMPLATE is the processed template used to format the entry."
  (let ((candidate-main (org-roam-node--format-entry
                         template
                         node
                         (1- (if (bufferp (current-buffer))
                                 (window-width) (frame-width))))))
    (cons (propertize candidate-main 'node node) node)))
```

Seems fine to me, and with this change i can overwrite the insert/find bindings
with filters, leading to much better performance. Huzzah!

###### Other thoughts

Because sqlite is likely to scale well performance-wise, we might consider
including the work of --to-candidate in there, if it's possible. Although, this
seems unlikely, given that it seems to depend on the current buffer, width, and
frame.

Otherwise, `org-roam-node-read--to-candidate` could probably be refactored to
re-use the `(if (bufferp (current-buffer)) (window-width) (frame-width))` bit.
In fact, is that being called for every candidate?? I'm not sure what `1-` does.
I'll explore and report back.