### PR TITLE
(fix) `org-roam-file-p` handle opening a buffer with no path

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -192,29 +192,30 @@ FILE is an Org-roam file if:
 - It's located somewhere under `org-roam-directory'
 - It has a matching file extension (`org-roam-file-extensions')
 - It doesn't match excluded regexp (`org-roam-file-exclude-regexp')"
-  (let* ((path (or file (buffer-file-name (buffer-base-buffer))))
-         (ext (when path (org-roam--file-name-extension path)))
-         (ext (if (string= ext "gpg")
-                  (org-roam--file-name-extension (file-name-sans-extension path))
-                ext))
-         (org-roam-dir-p (when path (org-roam-descendant-of-p path org-roam-directory)))
-         (valid-file-ext-p (member ext org-roam-file-extensions))
-         (match-exclude-regexp-p
-          (cond
-           ((not org-roam-file-exclude-regexp) nil)
-           ((stringp org-roam-file-exclude-regexp)
-            (string-match-p org-roam-file-exclude-regexp path))
-           ((and path (listp org-roam-file-exclude-regexp))
-            (let (is-match)
-              (dolist (exclude-re org-roam-file-exclude-regexp)
-                (setq is-match (or is-match (string-match-p exclude-re path))))
-              is-match)))))
-    (save-match-data
-      (and
-       path
-       org-roam-dir-p
-       valid-file-ext-p
-       (not match-exclude-regexp-p)))))
+  (when (or file (buffer-file-name (buffer-base-buffer)))
+    (let* ((path (or file (buffer-file-name (buffer-base-buffer))))
+           (ext (org-roam--file-name-extension path))
+           (ext (if (string= ext "gpg")
+                    (org-roam--file-name-extension (file-name-sans-extension path))
+                  ext))
+           (org-roam-dir-p (org-roam-descendant-of-p path org-roam-directory))
+           (valid-file-ext-p (member ext org-roam-file-extensions))
+           (match-exclude-regexp-p
+            (cond
+             ((not org-roam-file-exclude-regexp) nil)
+             ((stringp org-roam-file-exclude-regexp)
+              (string-match-p org-roam-file-exclude-regexp path))
+             ((listp org-roam-file-exclude-regexp)
+              (let (is-match)
+                (dolist (exclude-re org-roam-file-exclude-regexp)
+                  (setq is-match (or is-match (string-match-p exclude-re path))))
+                is-match)))))
+      (save-match-data
+        (and
+         path
+         org-roam-dir-p
+         valid-file-ext-p
+         (not match-exclude-regexp-p))))))
 
 (defun org-roam-list-files ()
   "Return a list of all Org-roam files under `org-roam-directory'.

--- a/org-roam.el
+++ b/org-roam.el
@@ -197,14 +197,14 @@ FILE is an Org-roam file if:
          (ext (if (string= ext "gpg")
                   (org-roam--file-name-extension (file-name-sans-extension path))
                 ext))
-         (org-roam-dir-p (org-roam-descendant-of-p path org-roam-directory))
+         (org-roam-dir-p (when path (org-roam-descendant-of-p path org-roam-directory)))
          (valid-file-ext-p (member ext org-roam-file-extensions))
          (match-exclude-regexp-p
           (cond
            ((not org-roam-file-exclude-regexp) nil)
            ((stringp org-roam-file-exclude-regexp)
             (string-match-p org-roam-file-exclude-regexp path))
-           ((listp org-roam-file-exclude-regexp)
+           ((and path (listp org-roam-file-exclude-regexp))
             (let (is-match)
               (dolist (exclude-re org-roam-file-exclude-regexp)
                 (setq is-match (or is-match (string-match-p exclude-re path))))


### PR DESCRIPTION
###### Motivation for this change

Errors when opening a .epub file with nov.el (a package
that renders EPUB file) because nov.el doesn't store the filename
in `buffer-file-name`, opening it caused errors with `org-roam-file-p`.

The error is documented in #2163 