### PR TITLE
(fix)db: update atime on file access

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -73,7 +73,7 @@ It takes a single argument NODE, which is an `org-roam-node' construct."
   :group 'org-roam
   :type 'function)
 
-(defcustom org-roam-node-default-sort 'file-mtime
+(defcustom org-roam-node-default-sort 'file-atime
   "Default sort order for Org-roam node completions."
   :type '(choice
           (const :tag "none" nil)


### PR DESCRIPTION
###### Motivation for this change

Previously we only updated the database on file save, but we need to
update the file's atime on file access, so we hook into `find-file-hook`
to do so. We only update the file atime if the file exists in the file table.

Fixes #2075