### PR TITLE
support custom minibuffer matching function

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -477,7 +477,7 @@ interactive calls FORCE always set to t."
                       force))
 
 ;;;###autoload
-(cl-defun org-roam-node-find (&optional other-window initial-input filter-fn &key templates)
+(cl-defun org-roam-node-find (&optional other-window initial-input filter-fn pred &key templates)
   "Find and open an Org-roam node by its title or alias.
 INITIAL-INPUT is the initial input for the prompt.
 FILTER-FN is a function to filter out nodes: it takes an `org-roam-node',
@@ -486,7 +486,7 @@ If OTHER-WINDOW, visit the NODE in another window.
 The TEMPLATES, if provided, override the list of capture templates (see
 `org-roam-capture-'.)"
   (interactive current-prefix-arg)
-  (let ((node (org-roam-node-read initial-input filter-fn)))
+  (let ((node (org-roam-node-read initial-input filter-fn pred)))
     (if (org-roam-node-file node)
         (org-roam-node-visit node other-window)
       (org-roam-capture-


### PR DESCRIPTION
###### Motivation for this change

Added support for custom `completion-read` predicate to the
`org-rom-node-find` function.

The `org-roam-node-find` function relies on `org-roam-node-read`,
which already provides the `require-match` argument to support this
behavior.

This PR adds an optional argument to `org-roam-node-find` which is
passed to the embedded `org-roam-node-read` call in order to support
custom `completion-read` predicates when searching for nodes in the
minibuffer.

# Example Usage

Case-insensitive search in the minibuffer:

```elisp
(defun case-insensitive-matchp (nodes string)
  "Check if the interactive prompt contains a case insensitive
substring of an Org Roam node title."
  (interactive)
  (lambda (needle haystack) (cl-search (downcase needle) (downcase haystack))) nodes)

(defun my-org-roam-node-find ()
  "Wrapper to run case-insensitive search for Org Roam node
titles."
  (interactive)
  (org-roam-node-find nil nil nil #'case-insensitive-matchp))
```
