### PR TITLE
(fix)org-roam-file-p: don't exclude org-roam-directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 ### Removed
 ### Fixed
+- [#2165](https://github.com/org-roam/org-roam/pull/2165) (fix)org-roam-file-p: don't exclude org-roam-directory
 - [#2168](https://github.com/org-roam/org-roam/pull/2168) (perf)node-read: filter nodes before mapping --to-candidate
 ### Changed
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -193,6 +193,7 @@ FILE is an Org-roam file if:
 - It has a matching file extension (`org-roam-file-extensions')
 - It doesn't match excluded regexp (`org-roam-file-exclude-regexp')"
   (let* ((path (or file (buffer-file-name (buffer-base-buffer))))
+         (relative-path (file-relative-name path org-roam-directory))
          (ext (when path (org-roam--file-name-extension path)))
          (ext (if (string= ext "gpg")
                   (org-roam--file-name-extension (file-name-sans-extension path))
@@ -203,11 +204,11 @@ FILE is an Org-roam file if:
           (cond
            ((not org-roam-file-exclude-regexp) nil)
            ((stringp org-roam-file-exclude-regexp)
-            (string-match-p org-roam-file-exclude-regexp (file-relative-name path org-roam-directory)))
+            (string-match-p org-roam-file-exclude-regexp relative-path))
            ((listp org-roam-file-exclude-regexp)
             (let (is-match)
               (dolist (exclude-re org-roam-file-exclude-regexp)
-                (setq is-match (or is-match (string-match-p exclude-re (file-relative-name path org-roam-directory)))))
+                (setq is-match (or is-match (string-match-p exclude-re relative-path))))
               is-match)))))
     (save-match-data
       (and

--- a/org-roam.el
+++ b/org-roam.el
@@ -203,11 +203,11 @@ FILE is an Org-roam file if:
           (cond
            ((not org-roam-file-exclude-regexp) nil)
            ((stringp org-roam-file-exclude-regexp)
-            (string-match-p org-roam-file-exclude-regexp path))
+            (string-match-p org-roam-file-exclude-regexp (file-relative-name path org-roam-directory)))
            ((listp org-roam-file-exclude-regexp)
             (let (is-match)
               (dolist (exclude-re org-roam-file-exclude-regexp)
-                (setq is-match (or is-match (string-match-p exclude-re path))))
+                (setq is-match (or is-match (string-match-p exclude-re (file-relative-name path org-roam-directory)))))
               is-match)))))
     (save-match-data
       (and


### PR DESCRIPTION
Don't exlude the org-roam-directory even if it matches
org-roam-file-exclude-regexp.

Should fix #2165.

This makes `org-roam-file-p` compare `org-roam-file-exclude-regexp` only with files and subdirectories within  `org-roam-directory`, not the entire path.

###### Motivation for this change
When someone has an `org-roam-directory` that contains a (sub)string that is a part of `org-roam-file-exclude-regexp`, the entire org-roam directory is excluded, and all files removed from the database.

For example, when `org-roam-directory` is "~/data/org-roam/" and `org-roam-file-exclude-regexp` is "data/", the entire roam directory is exluded, and no files are found.
