### PR TITLE
Solved issue #2192 (Respect blank lines in capture templates)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build:

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -788,7 +788,7 @@ When ENSURE-NEWLINE, always ensure there's a newline behind."
     ;; template does not start with any whitespace, and only ends with a single newline
     ;;
     ;; Instead, we restore the whitespace in the original template.
-    (setq template (replace-regexp-in-string "\n$" "" (org-capture-fill-template template)))
+    (setq template (replace-regexp-in-string "[\n]*\\'" "" (org-capture-fill-template template)))
     (when (and ensure-newline
                (string-equal template-whitespace-content ""))
       (setq template-whitespace-content "\n"))

--- a/tests/test-org-roam-capture.el
+++ b/tests/test-org-roam-capture.el
@@ -48,6 +48,11 @@
      (org-roam-capture--fill-template "foo\n\t\n")
      :to-equal "foo\n\t\n"))
 
+  (it "fills template without deleting newlines in its body"
+    (expect
+     (org-roam-capture--fill-template "foo\n\nbar\n\n")
+     :to-equal "foo\n\nbar\n\n"))
+
   (it "expands templates when it's a function"
     (expect
      (org-roam-capture--fill-template (lambda () "foo"))

--- a/tests/test-org-roam-capture.el
+++ b/tests/test-org-roam-capture.el
@@ -50,8 +50,8 @@
 
   (it "fills template without deleting newlines in its body"
     (expect
-     (org-roam-capture--fill-template "foo\n\nbar\n\n")
-     :to-equal "foo\n\nbar\n\n"))
+     (org-roam-capture--fill-template "foo\n\n\nbar\n\n")
+     :to-equal "foo\n\n\nbar\n\n"))
 
   (it "expands templates when it's a function"
     (expect


### PR DESCRIPTION
Issue: https://github.com/org-roam/org-roam/issues/2192

###### Motivation for this change

Unwanted removal of `\n` characters in Org Roam template strings.

-----

`org-capture-fill-template` fills the template string, but it removes whitespace and newlines at the beginning and end of the template.*

`org-roam-capture--fill-template` removes all blank lines and restores them after calling `org-capture-fill-template`.

The regex formula used for this however (`\n$`) eliminates all blank lines in the template, whether or not they are at the beginning and end of the template.

By replacing it with `[\n]*\\'` only the blank lines at the end of the template will be removed -only the ones which will be later restored.

###### Example

With a default template as follows:

```
(setq org-roam-capture-templates
      '(("d" "default" plain "%?"
	    :target (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
			       "#+STARTUP: overview\n\n\n\n#+title:${title}\n\n\n")
	    :unnarrowed t)))
```

`org-roam-capture--fill-template` would previously output

```
"#+STARTUP: overview#+title:${title}\n\n\n"
```

while with the new formula it outputs (the user's input as would be expected)

```
"#+STARTUP: overview\n\n\n#+title:${title}\n\n\n"
```

-----
*: paraphrased from the comment in `org-roam-capture--fill-template`
