### PR TITLE
(db)fix: FOREIGN KEY error in narrowed buffer

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -381,12 +381,13 @@ If UPDATE-P is non-nil, first remove the file in the database."
 
 (defun org-roam-db-map-nodes (fns)
   "Run FNS over all nodes in the current buffer."
-  (org-map-region
-   (lambda ()
-     (when (org-roam-db-node-p)
-       (dolist (fn fns)
-         (funcall fn))))
-   (point-min) (point-max)))
+  (org-with-wide-buffer
+   (org-map-region
+    (lambda ()
+      (when (org-roam-db-node-p)
+        (dolist (fn fns)
+          (funcall fn))))
+    (point-min) (point-max))))
 
 (defun org-roam-db-map-links (fns)
   "Run FNS over all links in the current buffer."


### PR DESCRIPTION
When trying to save from a narrowed buffer, only the Roam nodes visible
in the narrowed buffer are written to the database.

This commit ensures that org-roam behaves the same whether the current
buffer is narrowed or not.