### PR TITLE
Add org-roam-link-face

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -107,6 +107,11 @@
   :group 'org-roam
   :group 'faces)
 
+(defface org-roam-link-face
+  `((t :inherit org-link)))
+  "Customizable face to make id: links stand out from other org links")
+(org-link-set-parameters "id" :face 'org-roam-link-face)
+
 (defcustom org-roam-verbose t
   "Echo messages that are not errors."
   :type 'boolean


### PR DESCRIPTION
This registers an additional font-face distinct from org-link. This pull request doesn't change how anything appears on screen, it only makes it easier to customize the element. The (My) use case is to color "internal" links different than external World Wide Web links. I like to tell them apart at a glance, colored in pink:
![image](https://user-images.githubusercontent.com/66701832/174901344-a90ba2bf-21fd-4bd0-be97-cb6d45886d97.png)

Roam too, has a cue to visually distinguish [[roam]] links from external links. (image i found on google) The user can easily customize org-roam-link-face to be visually distinct, if he or she wants.
![image](https://user-images.githubusercontent.com/66701832/174900241-4a9637ec-b645-43ce-b0da-c2c72827158a.png)

I've given thought whether my proposed change may be org-roam overreaching its territory; since id links are a native feature of org, should the only face to style them be named after org-roam? Yes. Org-roam v2 itself was redesigned in part, to be more synonymous with the native id: links. When the user activates org-roam her or she has chosen to treat id: links in the org-roam context. He or she has chosen to apply org-roam-link-face.