### PR TITLE
(fix): links not displayed properly in org-roam-buffer

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -227,7 +227,8 @@ Like `org-fontify-like-in-org-mode', but supports `org-ref'."
   ;; `org-fontify-like-in-org-mode' here
   (with-temp-buffer
     (insert s)
-    (let ((org-ref-buffer-hacked t))
+    (let ((org-ref-buffer-hacked t)
+          (org-fold-core-style 'overlays))
       (org-mode)
       (org-font-lock-ensure)
       (buffer-string))))


### PR DESCRIPTION
Closes #2228.

###### Motivation for this change

`org-fold` was recently implemented in Org Mode. The default `org-fold-core-style` is `text-properties`, which causes links to be displayed incorrectly as reported in #2228. Switching to the `overlays` style fixes this.

(My current `org` is pinned to https://github.com/emacs-straight/org-mode/commit/e9da29b6fafe63abbc2774e9d485ac13d2811b65).