### PR TITLE
(fix): remove use of deprecated org-font-lock-ensure

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -230,7 +230,7 @@ Like `org-fontify-like-in-org-mode', but supports `org-ref'."
     (let ((org-ref-buffer-hacked t)
           (org-fold-core-style 'overlays))
       (org-mode)
-      (org-font-lock-ensure)
+      (font-lock-ensure)
       (buffer-string))))
 
 ;;;; Shielding regions


### PR DESCRIPTION
###### Motivation for this change

Closes #2235