### PR TITLE
was missing the FULL parameter to `org-end-of-meta-data` - fixes #2242

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -864,7 +864,7 @@ node."
     (let ((title (nth 4 (org-heading-components)))
           (tags (org-get-tags)))
       (kill-whole-line)
-      (org-roam-end-of-meta-data)
+      (org-roam-end-of-meta-data t)
       (insert "#+title: " title "\n")
       (when tags (org-roam-tag-add tags))
       (org-map-region #'org-promote (point-min) (point-max))


### PR DESCRIPTION
Without specifying `t`, it is only pushing the PROPERTIES drawer up  to
the file level, missing any other "planning information, clocking lines and
any kind of drawer." We want to promote all of this to the file level.
