### PR TITLE
(fix)org-roam-db-map-links: pos for atypical links

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -417,7 +417,9 @@ If HASH is non-nil, use that as the file's hash without recalculating it."
           (with-temp-buffer
             (delay-mode-hooks (org-mode))
             (insert link)
-            (setq link (org-element-context)))))
+            (setq link (org-element-context))
+            (org-element-put-property link :begin (car bounds))
+            (org-element-put-property link :end (cdr bounds)))))
         (when link
           (dolist (fn fns)
             (funcall fn link)))))))


### PR DESCRIPTION
###### Motivation for this change

Fixes #2252 
Enable links in property drawers of nested nodes to be picked up.