### PR TITLE
(fix): update `org-roam-unlinked-references-section` check

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -653,6 +653,7 @@ This is the ROW within FILE."
   "The unlinked references section for NODE.
 References from FILE are excluded."
   (when (and (executable-find "rg")
+             (org-roam-node-title node)
              (not (string-match "PCRE2 is not available"
                                 (shell-command-to-string "rg --pcre2-version"))))
     (let* ((titles (cons (org-roam-node-title node)


### PR DESCRIPTION
`org-roam-unlinked-references-section` would get nil org-roam-node-title
when create a headline node, which caused the issue #1625. This commit
add a check to make `org-roam-unlinked-references-section` work
correctly.
