### PR TITLE
(Docs): orgmode.org/elpa has been shut down

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -178,18 +178,7 @@ archives to =package-archives=:
 #+END_SRC
 
 Org-roam also depends on a recent version of Org, which can be obtained in Org's
-package repository (see info:org#Installation). To use Org's ELPA archive:
-
-#+BEGIN_SRC emacs-lisp
-(add-to-list 'package-archives '("org" . "https://orgmode.org/elpa/") t)
-#+END_SRC
-
-Once you have added your preferred archive, you need to update the
-local package list using:
-
-#+BEGIN_EXAMPLE
-  M-x package-refresh-contents RET
-#+END_EXAMPLE
+package repository (see info:org#Installation).
 
 Once you have done that, you can install Org-roam and its dependencies
 using:


### PR DESCRIPTION
See https://list.orgmode.org/87blb3epey.fsf@gnu.org/ for details. Removed it from the documentation in the manual to (try and) assist newcomers.

###### Motivation for this change
Trying to install `org-mode` according to the manual fails, and on my setup (Emacs 28.1) is unnecessary.

If it is still required for the manual to help users install a recent version of `org-mode`, its [installation docs](https://www.gnu.org/software/emacs/manual/html_mono/org.html#Installation) recommend:
1. Using Emacs packaging system (no mention of adding the elpa repo)
2. Using Org’s git repository
