### PR TITLE
Support multi-line org titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 ### Removed
 ### Fixed
+- [#2264](https://github.com/org-roam/org-roam/pull/2264) Support multi-line org titles
 - [#2165](https://github.com/org-roam/org-roam/pull/2165) (fix)org-roam-file-p: don't exclude org-roam-directory
 - [#2168](https://github.com/org-roam/org-roam/pull/2168) (perf)node-read: filter nodes before mapping --to-candidate
 ### Changed

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -344,7 +344,7 @@ If FILE is nil, clear the current buffer."
 If there is no title, return the file name relative to
 `org-roam-directory'."
   (org-link-display-format
-   (or (cadr (assoc "TITLE" (org-collect-keywords '("title"))))
+   (or (string-join (cdr (assoc "TITLE" (org-collect-keywords '("title")))) " ")
        (file-name-sans-extension (file-relative-name
                                   (buffer-file-name (buffer-base-buffer))
                                   org-roam-directory)))))

--- a/tests/test-org-roam-utils.el
+++ b/tests/test-org-roam-utils.el
@@ -36,4 +36,27 @@
      (org-roam-whitespace-content "foo\n\t\n")
      :to-equal "\n\t\n")))
 
+(describe "org-roam-db--file-title"
+  (it "supports normal titles"
+    (expect
+     (with-temp-buffer
+       (insert "#+title:normal title")
+       (org-roam-db--file-title))
+     :to-equal "normal title"))
+  (it "supports multi-line titles"
+    (expect
+     (with-temp-buffer
+       (insert "#+title: title:\n#+title: separated by newline")
+       (org-roam-db--file-title))
+     :to-equal "title: separated by newline"))
+  (it "supports file-name based titles"
+    (progn
+      (setq org-roam-directory temporary-file-directory
+            org-roam-db-location (expand-file-name "org-roam.db" temporary-file-directory)
+            org-roam-file-extensions '("org"))
+      (with-temp-buffer
+        (write-file (expand-file-name "test file.org" org-roam-directory))
+        (org-roam-db--file-title)))
+    :to-equal "test file"))
+
 (provide 'test-org-roam-utils)


### PR DESCRIPTION
  org-mode allows multi-line titles, for example:
  
  ```org
  #+title: Spatiotemporal Variance-Guided Filtering:
  #+title: Real-Time Reconstruction for Path-Traced Global Illumination
  ```
  This helps with legibility. When exporting, org joins the multiple lines with a space as separator to produce the final title for the exported document.
  
  Until now this functionality does not seem to be supported by org-roam. Only the first line will be used as the title.
  
  I have to admit, I am not a elisp expert but I managed to narrow the problem down to the `org-roam-db--file-title` (thanks to its very hepful docstring!).
  
  ```lisp
  (defun org-roam-db--file-title ()
    "In current Org buffer, get the title.
  If there is no title, return the file name relative to
  `org-roam-directory'."
    (org-link-display-format
     (or (cadr (assoc "TITLE" (org-collect-keywords '("title"))))
         (file-name-sans-extension (file-relative-name
                                    (buffer-file-name (buffer-base-buffer))
                                    org-roam-directory)))))
  ```
I found out that `(assoc "TITLE" (org-collect-keywords '("title")))` returns a list of the title lines. When joined via `string-join` it was consistent with default org behaviour. I also found out `string-join` was part of `subr-x` (so it might not be available by default?) but I noticed it was already used in `org-roam.el`, so this shouldn't bring in new dependencies.
  
However, I can't gurantee that other parts of the code have to be touched to accomodate this change, maybe someone with more experience with the org-roam code base could take a look at this?