### PR TITLE
org-roam-tag-add: use tags separator as crm-separator

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -1064,7 +1064,8 @@ and when nil is returned the node will be filtered out."
 (defun org-roam-tag-add (tags)
   "Add TAGS to the node at point."
   (interactive
-   (list (completing-read-multiple "Tag: " (org-roam-tag-completions))))
+   (list (let ((crm-separator "[ 	]*:[ 	]*"))
+           (completing-read-multiple "Tag: " (org-roam-tag-completions)))))
   (let ((node (org-roam-node-at-point 'assert)))
     (save-excursion
       (goto-char (org-roam-node-point node))


### PR DESCRIPTION
Allows use of : in minibuffer to separate multiple selected tags.

-------

###### Motivation for this change
Tags in org are separated with a colon, so it makes sense to have them separated this way when selecting them in completing-read-multiple too. This is the approach taken by `org-set-tags`.