### PR TITLE
Fix space chars in roam refs

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -543,10 +543,10 @@ INFO is the org-element parsed buffer."
                 (;; https://google.com, cite:citeKey
                  ;; Note: we use string-match here because it matches any link: e.g. [[cite:abc][abc]]
                  ;; But this form of matching is loose, and can accept invalid links e.g. [[cite:abc]
-                 (setq ref (org-link-encode ref '(#x20))
-                 (string-match org-link-any-re ref) ;; clear url-type for backward compatible.
+                 (string-match org-link-any-re (org-link-encode ref '(#x20)))
+                 (setq ref (org-link-encode ref '(#x20)))
                  (let ((ref-url (url-generic-parse-url (or (match-string 2 ref) (match-string 0 ref))))
-                        (link-type ())
+                       (link-type ()) ;; clear url-type for backward compatible.
                        (path ()))
                    (setq link-type (url-type ref-url))
                    (setf (url-type ref-url) nil)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -31,6 +31,8 @@
 ;;
 ;;; Code:
 (require 'org-roam)
+(require 'url-parse)
+(require 'ol)
 (defvar org-outline-path-cache)
 
 ;;; Options

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -541,9 +541,14 @@ INFO is the org-element parsed buffer."
                 (;; https://google.com, cite:citeKey
                  ;; Note: we use string-match here because it matches any link: e.g. [[cite:abc][abc]]
                  ;; But this form of matching is loose, and can accept invalid links e.g. [[cite:abc]
-                 (string-match org-link-plain-re ref)
-                 (let ((link-type (match-string 1 ref))
-                       (path (match-string 2 ref)))
+                 (setq ref (org-link-encode ref '(#x20))
+                 (string-match org-link-any-re ref) ;; clear url-type for backward compatible.
+                 (let ((ref-url (url-generic-parse-url (or (match-string 2 ref) (match-string 0 ref))))
+                        (link-type ())
+                       (path ()))
+                   (setq link-type (url-type ref-url))
+                   (setf (url-type ref-url) nil)
+                   (setq path (org-link-decode (url-recreate-url ref-url)))
                    (if (and (boundp 'org-ref-cite-types)
                             (or (assoc link-type org-ref-cite-types)
                                 (member link-type org-ref-cite-types)))

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -1036,7 +1036,9 @@ and when nil is returned the node will be filtered out."
   (let ((node (org-roam-node-at-point 'assert)))
     (save-excursion
       (goto-char (org-roam-node-point node))
-      (org-roam-property-add "ROAM_REFS" ref))))
+      (org-roam-property-add "ROAM_REFS" (if (memq " " (string-to-list ref))
+                                             (concat "\"" ref "\"")
+                                           ref)))))
 
 (defun org-roam-ref-remove (&optional ref)
   "Remove a REF from the node at point."

--- a/tests/roam-files/ref_with_space.org
+++ b/tests/roam-files/ref_with_space.org
@@ -1,0 +1,7 @@
+:PROPERTIES:
+:ROAM_REFS: "http://site.net/docs/01. introduction - hello world.html"
+:ID: 5b9a7400-f59c-4ef9-acbb-045b69af98f1
+:END:
+#+title: ref with space
+* Note
+hello

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -33,17 +33,17 @@
 
   (it "gets files correctly"
     (expect (length (org-roam-list-files))
-            :to-equal 3))
+            :to-equal 4))
 
   (it "respects org-roam-file-extensions"
     (setq org-roam-file-extensions '("md"))
     (expect (length (org-roam-list-files)) :to-equal 1)
     (setq org-roam-file-extensions '("org" "md"))
-    (expect (length (org-roam-list-files)) :to-equal 4))
+    (expect (length (org-roam-list-files)) :to-equal 5))
 
   (it "respects org-roam-file-exclude-regexp"
     (setq org-roam-file-exclude-regexp (regexp-quote "foo.org"))
-    (expect (length (org-roam-list-files)) :to-equal 2)))
+    (expect (length (org-roam-list-files)) :to-equal 3)))
 
 (describe "org-roam-db-sync"
   (before-all
@@ -60,12 +60,12 @@
   (it "has the correct number of files"
     (expect (caar (org-roam-db-query [:select (funcall count) :from files]))
             :to-equal
-            3))
+            4))
 
   (it "has the correct number of nodes"
     (expect (caar (org-roam-db-query [:select (funcall count) :from nodes]))
             :to-equal
-            2))
+            3))
 
   (it "has the correct number of links"
     (expect (caar (org-roam-db-query [:select (funcall count) :from links]))
@@ -76,7 +76,12 @@
     ;; The excluded node has ID "53fadc75-f48e-461e-be06-44a1e88b2abe"
     (expect (mapcar #'car (org-roam-db-query [:select id :from nodes]))
             :to-have-same-items-as
-            '("884b2341-b7fe-434d-848c-5282c0727861" "440795d0-70c1-4165-993d-aebd5eef7a24"))))
+            '("884b2341-b7fe-434d-848c-5282c0727861" "440795d0-70c1-4165-993d-aebd5eef7a24" "5b9a7400-f59c-4ef9-acbb-045b69af98f1")))
+
+  (it "reads ref in quotes correctly"
+    (expect (mapcar #'car (org-roam-db-query [:select [ref] :from refs]))
+            :to-have-same-items-as
+            '("//site.net/docs/01. introduction - hello world.html"))))
 
 (provide 'test-org-roam)
 


### PR DESCRIPTION
###### Motivation for this change
Fix #2214

Some URLs and local links have space characters. `org-roam` can't handle these types of link.

- Add double quotes if the URL has a space when user is capturing.
- Update ref cache logic to handle the org-link which has spaces.