### PR TITLE
Add customisable function for prompting when adding refs

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -1044,7 +1044,9 @@ and when nil is returned the node will be filtered out."
 ;;;; Editing
 (defun org-roam-ref-add (ref)
   "Add REF to the node at point."
-  (interactive "sRef: ")
+  (interactive `(,(if org-roam-ref-prompt-function
+                      (funcall org-roam-ref-prompt-function)
+                    (read-string "Ref: "))))
   (let ((node (org-roam-node-at-point 'assert)))
     (save-excursion
       (goto-char (org-roam-node-point node))

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -112,6 +112,12 @@ It takes a single argument REF, which is a propertized string."
   :group 'org-roam
   :type  '(function))
 
+(defcustom org-roam-ref-prompt-function nil
+  "Function to prompt for ref strings in `org-roam-ref-add'.
+Should take no arguments, prompt the user, and return a string."
+  :group 'org-roam
+  :type 'function)
+
 ;;;; Completion-at-point
 (defcustom org-roam-completion-everywhere nil
   "When non-nil, provide link completion matching outside of Org links."


### PR DESCRIPTION
###### Motivation for this change
I only use bibliography keys as refs, but I use a *lot* (e.g. for a book I'm half way through, I have nine nodes with the book's ref). When I want to add the ref to a node, at the moment I have to get the book's ref key somehow (e.g. with an embark action from citar, or by copying straight from Ebib), then run ``org-roam-ref-add`, *then* type '@', and finally insert the ref key and hit <kbd>RET</kbd>. This is a heavy workflow for something I do so often.


I imagine other users feel similarly. This PR lets the user set a prompt function for getting refs, which can streamline processes like this.

Personally, I could set this to a simple wrapper over `citar-select-ref`, though others might do otherwise. This makes the whole process of adding refs much simpler. Leaving the variable at nil retains the current behaviour or just prompting for a string.