### PR TITLE
utils: descendant-of-p: Defend against nils

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -120,7 +120,7 @@ SPEC is a list, as per `dolist'."
 ;;; File utilities
 (defun org-roam-descendant-of-p (a b)
   "Return t if A is descendant of B."
-  (unless (equal (file-truename a) (file-truename b))
+  (unless (and a b (equal (file-truename a) (file-truename b)))
     (string-prefix-p (replace-regexp-in-string "^\\([A-Za-z]\\):" 'downcase (expand-file-name b) t t)
                      (replace-regexp-in-string "^\\([A-Za-z]\\):" 'downcase (expand-file-name a) t t))))
 


### PR DESCRIPTION
This has an effect on find-file-hook for totally unrelated files, through the callchain of `org-roam-db-autosync--setup-file-h -> org-roam-file-p -> org-roam-descendant-of-p'.

From an org file, inside a project-el project, (find-file "some/other/file") will intermittently reproduce this error:

   org-roam-descendant-of-p: Wrong type argument: arrayp, nil

If this fix seems inappropriate -- it could amount to surppressing a valid error in routine calls -- then I would advise throwing an explicit signal here, or finding a safer way to get the `path` inside `org-roam-file-p'; the current means:

    (or file (buffer-file-name (buffer-base-buffer)))

.. can result in nil, which then bleeds errors into use elsewhere.

for posterity, here is the full calling context I'm referring to, from `org-roam-file-p'.

  (let* ((path (or file (buffer-file-name (buffer-base-buffer))))
         (ext (when path (org-roam--file-name-extension path)))
         (ext (if (string= ext "gpg")
                  (org-roam--file-name-extension (file-name-sans-extension path))
                ext))
         (org-roam-dir-p (org-roam-descendant-of-p path
         org-roam-directory))
         ...

###### Motivation for this change
I should be able to find-file to any file, outside of org-roam, without error bleed from this package's hook functions.
