### PR TITLE
Fix org-fold-core-style in org-roam-buffer

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -227,9 +227,9 @@ Like `org-fontify-like-in-org-mode', but supports `org-ref'."
   ;; `org-fontify-like-in-org-mode' here
   (with-temp-buffer
     (insert s)
-    (let ((org-ref-buffer-hacked t)
-          (org-fold-core-style 'overlays))
+    (let ((org-ref-buffer-hacked t))
       (org-mode)
+      (setq-local org-fold-core-style 'overlays)
       (font-lock-ensure)
       (buffer-string))))
 


### PR DESCRIPTION
Closes #2198

Related issues: #2228, #2236, [doomemacs#6542](https://github.com/doomemacs/doomemacs/issues/6542), [org-brain#387](https://github.com/Kungsgeten/org-brain/pull/387)

###### Motivation for this change

Strangely, Emacs 28.x and doom sync does optimize `org-fold-core-style` in a `let` clause. So `org-fold-core-style` in org-roam-buffer is still `text-properties`. People who doesn't use or skip bytecompiling didn't meet this issue. But some users who use bytecompiling see this issue.

On Emacs 30.0.50, `org-fold-core-style` doesn't be removed in `org-roam-utils.elc`. For 28.x, I think the best workaround is to change `let` binding to `setq-local`.

You can check this workaround.

1. cd `~/.emacs.d/.local/straight/build-*/org-roam`
2. `strings org-roam-utils.elc | grep org-fold-core-style`
    - If the `org-fold-core-style` exists, it will work.
3. Evaluate the below code and check that org-link works properly.

```elisp
(let ((buf (get-buffer-create "*test-org-roam-link*")))
  (with-current-buffer buf
    (delete-region (point-min) (point-max))
    (insert (org-roam-fontify-like-in-org-mode "[[id:a586b43b-c89c-4e60-99e8-17b89e1529fe][Test test node]]")))
  (pop-to-buffer buf))
```
