### PR TITLE
(node): org-roam-node-at-point: don't error in non-org buffers

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -236,11 +236,10 @@ populated."
         (t (org-with-wide-buffer
             (while (not (or (org-roam-db-node-p)
                             (bobp)
-                            ;; Handle case where top-level is a heading
-                            (= (funcall outline-level)
-                               (save-excursion
-                                 (org-roam-up-heading-or-point-min)
-                                 (funcall outline-level)))))
+                            (eq (funcall outline-level)
+                                (save-excursion
+                                  (org-roam-up-heading-or-point-min)
+                                  (funcall outline-level)))))
               (org-roam-up-heading-or-point-min))
             (when-let ((id (org-id-get)))
               (org-roam-populate


### PR DESCRIPTION
`=' assumes that both objects being compared are numbers. In some
buffers `outline-level' can return nil, so `=' returns an error. `eq'
does not assume this, but does return t when comparing two numbers.

-------

###### Motivation for this change
I use `org-roam-node-at-point` in my [related-files](https://github.com/DamienCassou/related-files) config to get the node at point when there is one, assuming that it returns nil if there *isn't* one.

In the case where `outline-level` can return nil, (e.g. for me in some elisp buffers where I use `outshine-mode`), nil is the compared with a number using `=`, which throws an error (when I should just get nil).

This change solves this issue.