### PR TITLE
Backlink heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 ### Removed
 ### Fixed
+- [#2165](https://github.com/org-roam/org-roam/pull/2165) (fix)org-roam-file-p: don't exclude org-roam-directory
 - [#2168](https://github.com/org-roam/org-roam/pull/2168) (perf)node-read: filter nodes before mapping --to-candidate
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## TBD
 ### Breaking
 ### Added
+- [#2333](https://github.com/org-roam/org-roam/pull/2333) buffer: allow a custom heading for a backlink section
 ### Removed
 ### Fixed
 - [#2264](https://github.com/org-roam/org-roam/pull/2264) Support multi-line org titles

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -514,7 +514,8 @@ Sorts by title."
   (string< (org-roam-node-title (org-roam-backlink-source-node a))
            (org-roam-node-title (org-roam-backlink-source-node b))))
 
-(cl-defun org-roam-backlinks-section (node &key (unique nil) (show-backlink-p nil) (section-heading "Backlinks:"))
+(cl-defun org-roam-backlinks-section (node &key (unique nil) (show-backlink-p nil)
+                                           (section-heading "Backlinks:"))
   "The backlinks section for NODE.
 
 When UNIQUE is nil, show all positions where references are found.

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -514,17 +514,19 @@ Sorts by title."
   (string< (org-roam-node-title (org-roam-backlink-source-node a))
            (org-roam-node-title (org-roam-backlink-source-node b))))
 
-(cl-defun org-roam-backlinks-section (node &key (unique nil) (show-backlink-p nil))
+(cl-defun org-roam-backlinks-section (node &key (unique nil) (show-backlink-p nil) (section-heading "Backlinks:"))
   "The backlinks section for NODE.
 
 When UNIQUE is nil, show all positions where references are found.
 When UNIQUE is t, limit to unique sources.
 
 When SHOW-BACKLINK-P is not null, only show backlinks for which
-this predicate is not nil."
+this predicate is not nil.
+
+SECTION-HEADING is the string used as a heading for the backlink section."
   (when-let ((backlinks (seq-sort #'org-roam-backlinks-sort (org-roam-backlinks-get node :unique unique))))
     (magit-insert-section (org-roam-backlinks)
-      (magit-insert-heading "Backlinks:")
+      (magit-insert-heading section-heading)
       (dolist (backlink backlinks)
         (when (or (null show-backlink-p)
                   (and (not (null show-backlink-p))

--- a/org-roam.el
+++ b/org-roam.el
@@ -193,6 +193,7 @@ FILE is an Org-roam file if:
 - It has a matching file extension (`org-roam-file-extensions')
 - It doesn't match excluded regexp (`org-roam-file-exclude-regexp')"
   (let* ((path (or file (buffer-file-name (buffer-base-buffer))))
+         (relative-path (file-relative-name path org-roam-directory))
          (ext (when path (org-roam--file-name-extension path)))
          (ext (if (string= ext "gpg")
                   (org-roam--file-name-extension (file-name-sans-extension path))
@@ -203,11 +204,11 @@ FILE is an Org-roam file if:
           (cond
            ((not org-roam-file-exclude-regexp) nil)
            ((stringp org-roam-file-exclude-regexp)
-            (string-match-p org-roam-file-exclude-regexp (file-relative-name path org-roam-directory)))
+            (string-match-p org-roam-file-exclude-regexp relative-path))
            ((listp org-roam-file-exclude-regexp)
             (let (is-match)
               (dolist (exclude-re org-roam-file-exclude-regexp)
-                (setq is-match (or is-match (string-match-p exclude-re (file-relative-name path org-roam-directory)))))
+                (setq is-match (or is-match (string-match-p exclude-re relative-path))))
               is-match)))))
     (save-match-data
       (and

--- a/org-roam.el
+++ b/org-roam.el
@@ -203,11 +203,11 @@ FILE is an Org-roam file if:
           (cond
            ((not org-roam-file-exclude-regexp) nil)
            ((stringp org-roam-file-exclude-regexp)
-            (string-match-p org-roam-file-exclude-regexp path))
+            (string-match-p org-roam-file-exclude-regexp (file-relative-name path org-roam-directory)))
            ((listp org-roam-file-exclude-regexp)
             (let (is-match)
               (dolist (exclude-re org-roam-file-exclude-regexp)
-                (setq is-match (or is-match (string-match-p exclude-re path))))
+                (setq is-match (or is-match (string-match-p exclude-re (file-relative-name path org-roam-directory)))))
               is-match)))))
     (save-match-data
       (and


### PR DESCRIPTION
###### Motivation for this change
After #2247 was merged, it is now possible to add multiple `org-roam-backlinks-section`s to `org-roam-section`, using different functions to filter the backlinks in the different sections.

However, all the sections have "Backlinks:" as the heading. This should enable the user to have different backlink sections with differing headings and filters.