### PR TITLE
[Fix #1732] Fix contents in org roam buffer being displayed in the wrong order

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -225,13 +225,19 @@ Like `org-fontify-like-in-org-mode', but supports `org-ref'."
   ;;
   ;; `org-ref-buffer-hacked' is a buffer-local variable, therefore we inline
   ;; `org-fontify-like-in-org-mode' here
-  (with-temp-buffer
-    (insert s)
-    (let ((org-ref-buffer-hacked t))
-      (org-mode)
-      (setq-local org-fold-core-style 'overlays)
-      (font-lock-ensure)
-      (buffer-string))))
+  ;;
+  ;; NOTE: we have to use `save-excursion', because after calling `org-mode' in temp buffer, the point in the "main" buffer
+  ;; might change to 1 for unknown reason, which we want to avoid. It's somehow related to using `page-break-lines-mode',
+  ;; `display-line-numbers-mode' and the corresponding global versions of those modes.
+  ;; See <https://github.com/org-roam/org-roam/issues/1732>.
+  (save-excursion
+    (with-temp-buffer
+      (insert s)
+      (let ((org-ref-buffer-hacked t))
+        (org-mode)
+        (setq-local org-fold-core-style 'overlays)
+        (font-lock-ensure)
+        (buffer-string)))))
 
 ;;;; Shielding regions
 (defface org-roam-shielded


### PR DESCRIPTION
###### Motivation for this change
This pull request is aimed to fix the issue when the preview sections of the backlinks inside an org roam buffer are not displayed where they should.

Steps to reproduce:
1. tested only on Spacemacs distro
2. page-break-lines-mode, global-page-break-lines-mode, display-line-numbers-mode and global-display-line-numbers-mode are enabled in org mode buffer
3. invoke org-roam-buffer-toggle to show up an org roam buffer

Result:
<img src="https://user-images.githubusercontent.com/11041382/227804879-656013e7-4b7a-4589-8100-c12281d0e67c.png" height="400">
Also hitting RET on any section inside such buffer would result in the following error message:
```
There is no thing at point that could be visited
```

Result if the fix is applied:
<img src="https://user-images.githubusercontent.com/11041382/227804893-e58bcb32-0dad-4ee9-9a7b-ab79b30cacf9.png" height="400">

What is also interesting is that even without this fix, if we navigated to org roam buffer and called org-roam-buffer-refresh, the buffer would redraw just fine. But if we then navigated back to the original org mode buffer and triggered org roam buffer refresh (by, say, pointing to another node that has it's own backlinks), the problem would occur once again.

I have no clear idea of why this happens, but here is a line that actually caused this issue:
```
  (defun org-roam-fontify-like-in-org-mode (s)
    "..."
    (with-temp-buffer
      (insert s)
      (let ((org-ref-buffer-hacked t))
        (org-mode) ;; after this call, the point inside the org roam buffer is set to 1 for some reason. this is why all the previews are displayed at the top of the buffer
        (setq-local org-fold-core-style 'overlays)
        (font-lock-ensure)
        (buffer-string))))
```

This fix is expected to close these issues:
https://github.com/org-roam/org-roam/issues/1732
https://github.com/syl20bnr/spacemacs/issues/14969
