### PR TITLE
(fix): improve org-roam buffer fontification speed #1853

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -206,6 +206,18 @@ value (possibly nil). Adapted from `s-format'."
 ;;; Fontification
 (defvar org-ref-buffer-hacked)
 
+(defvar org-roam-fontification-buffer "*org-roam-fontification-buffer*"
+  "The buffer helps to increase the speed of org-roam-buffer
+fontification.")
+
+(defun org-roam-get-fontification-buffer-create ()
+  "Get or create the `org-roam-fontification-buffer'. Ensures the
+org-mode is activated."
+  (with-current-buffer (get-buffer-create org-roam-fontification-buffer)
+    (unless (derived-mode-p 'org-mode)
+      (org-mode))
+    (current-buffer)))
+
 (defun org-roam-fontify-like-in-org-mode (s)
   "Fontify string S like in Org mode.
 Like `org-fontify-like-in-org-mode', but supports `org-ref'."
@@ -225,10 +237,10 @@ Like `org-fontify-like-in-org-mode', but supports `org-ref'."
   ;;
   ;; `org-ref-buffer-hacked' is a buffer-local variable, therefore we inline
   ;; `org-fontify-like-in-org-mode' here
-  (with-temp-buffer
+  (with-current-buffer (org-roam-get-fontification-buffer-create)
+    (erase-buffer)
     (insert s)
     (let ((org-ref-buffer-hacked t))
-      (org-mode)
       (setq-local org-fold-core-style 'overlays)
       (font-lock-ensure)
       (buffer-string))))


### PR DESCRIPTION
Related issue: #1853

When there are a lot of nodes to write on the org-roam-buffer, Emacs starts to hang. This improvement decreases the fontification run time from `1.6 sec` to `0.07 sec` for a 10 node example (in my org-mode setup).

The basic idea is that (org-mode) has lots of initial needs, and users can have special org-mode hooks. Instead of calling org-mode for every node fontification, we could initialize it once and use it later.

You can test the speed improvements without needing to pull changes with:


```elisp
(with-eval-after-load 'org-roam-mode

  (setq org-roam-fontify-buffer (get-buffer-create "*org-roam-fontify-buffer*"))
  (with-current-buffer org-roam-fontify-buffer (org-mode))

  (defun org-roam-fontify-like-in-org-mode (s)
    (with-current-buffer org-roam-fontify-buffer
      (erase-buffer)
      (insert s)
      (let ((org-ref-buffer-hacked t))
        (setq-local org-fold-core-style 'overlays)
        (font-lock-ensure)
        (buffer-string))))

  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
  ;; Advice for runtime test
  
  (defun calculate-runtime (orig-fun &rest args)
    (let ((start-time (float-time)))
      (apply orig-fun args)
      (message "Runtime of `org-roam-backlinks-section` is %.6f seconds."
               (- (float-time) start-time))))

  (advice-add 'org-roam-backlinks-section :around #'calculate-runtime))

```


Test file
```org
:PROPERTIES:
:ID:       c5e11a88-78c0-433a-abfb-43a95f28376e
:END:
#+title: org roam test


* A
:PROPERTIES:
:ID:       9b073a73-0d3b-4309-97bc-bbb672deb07b
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* B
:PROPERTIES:
:ID:       6a76ce97-7ddb-490a-a27a-33f550818055
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* C
:PROPERTIES:
:ID:       17159c89-1938-4311-84ed-37f8aac15aee
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* D
:PROPERTIES:
:ID:       0f6b16dc-e275-4c39-aac9-ffc36a5bc977
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* E
:PROPERTIES:
:ID:       be1b11e6-8b6d-4a50-bc6f-5ec841c14989
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* F
:PROPERTIES:
:ID:       8efcfa66-0f43-45b3-9737-9aabe0d304aa
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* G
:PROPERTIES:
:ID:       61d131ff-cc13-40ff-970d-ddbf483b7980
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* H
:PROPERTIES:
:ID:       93ccde48-bf2a-4f0b-abb6-23259f6ef589
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* I
:PROPERTIES:
:ID:       f86f62c9-3261-4788-a040-4ca814416d0b
:END:
[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]

* J
:PROPERTIES:
:ID:       0979836a-7023-4919-ab8f-c2de6bf2b592
:END:

[[id:9b073a73-0d3b-4309-97bc-bbb672deb07b][A]]
[[id:6a76ce97-7ddb-490a-a27a-33f550818055][B]]
[[id:17159c89-1938-4311-84ed-37f8aac15aee][C]]
[[id:0f6b16dc-e275-4c39-aac9-ffc36a5bc977][D]]
[[id:be1b11e6-8b6d-4a50-bc6f-5ec841c14989][E]]
[[id:8efcfa66-0f43-45b3-9737-9aabe0d304aa][F]]
[[id:61d131ff-cc13-40ff-970d-ddbf483b7980][G]]
[[id:93ccde48-bf2a-4f0b-abb6-23259f6ef589][H]]
[[id:f86f62c9-3261-4788-a040-4ca814416d0b][I]]
[[id:0979836a-7023-4919-ab8f-c2de6bf2b592][J]]
```