### PR TITLE
Allow word boundary regex to be customized for unlinked reference

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -677,7 +677,7 @@ References from FILE are excluded."
                                (mapconcat (lambda (glob) (concat "-g " glob))
                                           (org-roam--list-files-search-globs org-roam-file-extensions)
                                           " ")
-                               (format " '\\[([^[]]++|(?R))*\\]%s' "
+                               (format " \"\\[([^[]]++|(?R))*\\]%s\" "
                                        (mapconcat (lambda (title)
                                                     (format org-roam-unlinked-references-word-boundary-re
                                                             (shell-quote-argument title)))

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -86,6 +86,15 @@ applied in order of appearance in the list."
   :group 'org-roam
   :type 'hook)
 
+(defcustom org-roam-unlinked-references-word-boundary-re "|(\\b%1$s\\b)"
+  "The word bounday regex used by ripgrep for unlinked references.
+
+In some languages such as CJK, the regex's word boundary does not
+correctly determine how words and phrases should be tokenized.
+This custom variable allows users to extend regex in those cases."
+  :group 'org-roam
+  :type 'string)
+
 ;;; Faces
 (defface org-roam-header-line
   `((((class color) (background light))
@@ -670,7 +679,8 @@ References from FILE are excluded."
                                           " ")
                                (format " '\\[([^[]]++|(?R))*\\]%s' "
                                        (mapconcat (lambda (title)
-                                                    (format "|(\\b%s\\b)" (shell-quote-argument title)))
+                                                    (format org-roam-unlinked-references-word-boundary-re
+                                                            (shell-quote-argument title)))
                                                   titles ""))
                                org-roam-directory))
            (results (split-string (shell-command-to-string rg-command) "\n"))


### PR DESCRIPTION
###### Motivation for this change

The unlinked references are searched for by ripgrep using a simple regex pattern `(\b%s\b`). This works fine with English, but in a language for which the concept of regex word boundary doesn't apply (e.g., CJK), the pattern doesn't work. The issue https://github.com/org-roam/org-roam/issues/1290 for Chinese is an example.

This PR introduces `org-roam-unlinked-references-word-boundary-re` custom variable so that users can modify the regex pattern used by ripgrep.

For example, adding a pattern like this

``` emacs-lisp
(set-q org-roam-unlinked-references-word-boundary-re
       "|(\\b%1$s\\b|(?<=[^\x20-\x7e\xff61-\xff9f])%1$s(?=[^\x20-\x7e\xff61-\xff9f]))")
``` 

the regex would work sufficiently well in both English and Japanese.

This PR should fix #1290, though improving regex pattern is delegated to users. 