### PR TITLE
Refile complete roam node

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -905,6 +905,7 @@ If region is active, then use it instead of the node at point."
             (org-kill-new (buffer-substring region-start region-end))
             (org-save-markers-in-region region-start region-end))
         (progn
+          (goto-char (org-roam-node-point node))
           (if (org-before-first-heading-p)
               (org-roam-demote-entire-buffer))
           (org-copy-subtree 1 nil t)))


### PR DESCRIPTION
Calling `org-roam-refile' inside a sub-heading within a node now refiles whole node and not just that sub-tree.

###### Motivation for this change
Currently when calling `org-roam-refile' if the point is within sub-tree of a roam node, only that sub-tree gets refiled.