### PR TITLE
Add exclude patterns to org-roam-graph

### DIFF
--- a/extensions/org-roam-graph.el
+++ b/extensions/org-roam-graph.el
@@ -175,44 +175,64 @@ CALLBACK is passed the graph file as its sole argument."
                      (progn (funcall callback temp-graph)
                             (run-hook-with-args 'org-roam-graph-generation-hook temp-dot temp-graph))))))))
 
+(defcustom org-roam-graph-exclude-patterns '()
+  "List of patterns to exclude from the Org-roam graph.
+Nodes with file names or titles matching any pattern in this list will be excluded."
+  :type '(repeat string)
+  :group 'org-roam)
+
+
 (defun org-roam-graph--dot (&optional edges all-nodes)
   "Build the graphviz given the EDGES of the graph.
 If ALL-NODES, include also nodes without edges."
   (let ((org-roam-directory-temp org-roam-directory)
         (nodes-table (make-hash-table :test #'equal))
         (seen-nodes (list))
+        (excluded-nodes (list)) ;; List to store IDs of excluded nodes
         (edges (or edges (org-roam-db-query [:select :distinct [source dest type] :from links]))))
-    (pcase-dolist (`(,id ,file ,title)
-                   (org-roam-db-query [:select [id file title] :from nodes]))
-      (puthash id (org-roam-node-create :file file :id id :title title) nodes-table))
-    (with-temp-buffer
-      (setq-local org-roam-directory org-roam-directory-temp)
-      (insert "digraph \"org-roam\" {\n")
-      (dolist (option org-roam-graph-extra-config)
-        (insert (org-roam-graph--dot-option option) ";\n"))
-      (insert (format " edge [%s];\n"
-                      (mapconcat (lambda (var)
-                                   (org-roam-graph--dot-option var nil "\""))
-                                 org-roam-graph-edge-extra-config
-                                 ",")))
-      (pcase-dolist (`(,source ,dest ,type) edges)
-        (unless (member type org-roam-graph-link-hidden-types)
-          (pcase-dolist (`(,node ,node-type) `((,source "id")
-                                               (,dest ,type)))
-            (unless (member node seen-nodes)
-              (insert (org-roam-graph--format-node
-                       (or (gethash node nodes-table) node) node-type))
-              (push node seen-nodes)))
-          (insert (format "  \"%s\" -> \"%s\";\n"
-                          (xml-escape-string source)
-                          (xml-escape-string dest)))))
-      (when all-nodes
+
+    ;; Function to check if a string matches any of the exclude patterns
+    (cl-flet ((matches-exclude-pattern (s)
+                                       (seq-some (lambda (pattern)
+                                                   (string-match pattern s))
+                                                 org-roam-graph-exclude-patterns)))
+      ;; First, identify nodes to exclude
+      (pcase-dolist (`(,id ,file ,title)
+                     (org-roam-db-query [:select [id file title] :from nodes]))
+        (if (or (matches-exclude-pattern file)
+                (matches-exclude-pattern title))
+            (push id excluded-nodes) ;; Add to excluded list
+          (puthash id (org-roam-node-create :file file :id id :title title) nodes-table))) ;; Add to nodes table
+
+      (with-temp-buffer
+        (setq-local org-roam-directory org-roam-directory-temp)
+        (insert "digraph \"org-roam\" {\n")
+        (dolist (option org-roam-graph-extra-config)
+          (insert (org-roam-graph--dot-option option) ";\n"))
+        (insert (format " edge [%s];\n"
+                        (mapconcat (lambda (var)
+                                     (org-roam-graph--dot-option var nil "\""))
+                                   org-roam-graph-edge-extra-config
+                                   ",")))
+
+        ;; Process edges, excluding those connected to excluded nodes
+        (pcase-dolist (`(,source ,dest ,type) edges)
+          (unless (or (member source excluded-nodes)
+                      (member dest excluded-nodes)
+                      (member type org-roam-graph-link-hidden-types))
+            (insert (format "  \"%s\" -> \"%s\";\n"
+                            (xml-escape-string source)
+                            (xml-escape-string dest)))))
+
+        ;; Process nodes, excluding those in the excluded list
         (maphash (lambda (id node)
-                   (unless (member id seen-nodes)
+                   (unless (member id excluded-nodes)
                      (insert (org-roam-graph--format-node node "id"))))
-                 nodes-table))
-      (insert "}")
-      (buffer-string))))
+                 nodes-table)
+
+        (insert "}")
+        (buffer-string)))))
+
 
 (defun org-roam-graph--connected-component (id distance)
   "Return the edges for all nodes reachable from/connected to ID.


### PR DESCRIPTION
Define `org-roam-graph-exclude-patterns` which allows filtering the graph nodes by title/filenames.

###### Motivation for this change

The org-roam directory may include files that should not be visualized in the org-roam-graph. This change allows defining string patterns which are used to filter nodes in the node collection process of `org-roam-graph--dot`.