### PR TITLE
(fix): Use double quotes for proper single quote escape

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -664,9 +664,12 @@ This is the ROW within FILE."
           (mapconcat (lambda (glob) (concat "--glob " glob))
                      (org-roam--list-files-search-globs org-roam-file-extensions)
                      " ")
-          (format " \"\\[([^[]]++|(?R))*\\]%s\" "
+          (format " '\\[([^[]]++|(?R))*\\]%s' "
                   (mapconcat (lambda (title)
-                               (format "|(\\b%s\\b)" (shell-quote-argument title)))
+                               (format "|(\\b%s\\b)"
+                                       (mapconcat #'shell-quote-argument
+                                                  (split-string title "'")
+                                                  "'\"'\"'")))
                              titles ""))
           (shell-quote-argument org-roam-directory)))
 

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -668,7 +668,7 @@ References from FILE are excluded."
                                (mapconcat (lambda (glob) (concat "-g " glob))
                                           (org-roam--list-files-search-globs org-roam-file-extensions)
                                           " ")
-                               (format " '\\[([^[]]++|(?R))*\\]%s' "
+                               (format " \"\\[([^[]]++|(?R))*\\]%s\" "
                                        (mapconcat (lambda (title)
                                                     (format "|(\\b%s\\b)" (shell-quote-argument title)))
                                                   titles ""))

--- a/tests/test-org-roam-mode.el
+++ b/tests/test-org-roam-mode.el
@@ -32,17 +32,22 @@
   (it "returns the correct rg command for unlinked references"
     (expect (org-roam-unlinked-references--rg-command '("foo" "bar"))
             :to-equal
-            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" \"\\[([^[]]++|(?R))*\\]|(\\bfoo\\b)|(\\bbar\\b)\" /tmp/org\\ roam"))
+            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" '\\[([^[]]++|(?R))*\\]|(\\bfoo\\b)|(\\bbar\\b)' /tmp/org\\ roam"))
 
   (it "returns the correct rg command for unlinked references when input includes a single quote"
     (expect (org-roam-unlinked-references--rg-command '("Don't Repeat Yourself" "DRY"))
             :to-equal
-            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" \"\\[([^[]]++|(?R))*\\]|(\\bDon\\'t\\ Repeat\\ Yourself\\b)|(\\bDRY\\b)\" /tmp/org\\ roam"))
+            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" '\\[([^[]]++|(?R))*\\]|(\\bDon'\"'\"'t\\ Repeat\\ Yourself\\b)|(\\bDRY\\b)' /tmp/org\\ roam"))
 
   (it "returns the correct rg command for unlinked references when input includes a double quote"
     (expect (org-roam-unlinked-references--rg-command '("The \"p\" in pterodactyl"))
             :to-equal
-            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" \"\\[([^[]]++|(?R))*\\]|(\\bThe\\ \\\"p\\\"\\ in\\ pterodactyl\\b)\" /tmp/org\\ roam"))
+            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" '\\[([^[]]++|(?R))*\\]|(\\bThe\\ \\\"p\\\"\\ in\\ pterodactyl\\b)' /tmp/org\\ roam"))
+
+  (it "returns the correct rg command for unlinked references when input includes a dollar sign"
+    (expect (org-roam-unlinked-references--rg-command '("Is $USER a problem"))
+            :to-equal
+            "rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob \"*.org\" --glob \"*.org.gpg\" --glob \"*.org.age\" '\\[([^[]]++|(?R))*\\]|(\\bIs\\ \\$USER\\ a\\ problem\\b)' /tmp/org\\ roam"))
   )
 
 (provide 'test-org-roam-mode)


### PR DESCRIPTION
###### Motivation for this change

This PR provides a fix for https://github.com/org-roam/org-roam/issues/2407.