### PR TITLE
Fix Issue #2410 - Unlinked References doesnt work if the org-roam-directory has a space in it. 

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -672,7 +672,7 @@ References from FILE are excluded."
                                        (mapconcat (lambda (title)
                                                     (format "|(\\b%s\\b)" (shell-quote-argument title)))
                                                   titles ""))
-                               org-roam-directory))
+                               (shell-quote-argument org-roam-directory)))
            (results (split-string (shell-command-to-string rg-command) "\n"))
            f row col match)
       (magit-insert-section (unlinked-references)


### PR DESCRIPTION
Fix Issue #2410 
In the function `org-roam-unlinked-references-section` the `org-roam-directory` variable is concated to form the `rg_command`. This doesn't cover any spaces in the `org-roam-directory` path.
So if the path is `/Users/user123/MyDrive/My Files/org-mode/org-roam`, due to the space in My Files rg returns an error:
```
rg: /Users/user123/MyDrive/My: No such file or directory (os error 2)
rg: Files/org-mode/org-roam: No such file or directory (os error 2)
```

This is due to the [lines here](https://github.com/org-roam/org-roam/blob/8667e441876cd2583fbf7282a65796ea149f0e5f/org-roam-mode.el#L667-L675):
```elisp
(rg-command (concat "rg -L -o --vimgrep -P -i "
                               (mapconcat (lambda (glob) (concat "-g " glob))
                                          (org-roam--list-files-search-globs org-roam-file-extensions)
                                          " ")
                               (format " '\\[([^[]]++|(?R))*\\]%s' "
                                       (mapconcat (lambda (title)
                                                    (format "|(\\b%s\\b)" (shell-quote-argument title)))
                                                  titles ""))
                               org-roam-directory))
```