### PR TITLE
Added error checking org-roam-capture--setup-target-location

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -569,7 +569,9 @@ Return the ID of the location."
                        (user-error "No node with title or id \"%s\"" title-or-id))))
          (set-buffer (org-capture-target-buffer (org-roam-node-file node)))
          (goto-char (org-roam-node-point node))
-         (setq p (org-roam-node-point node)))))
+         (setq p (org-roam-node-point node))))
+      (t (error "Invalid org-roam capture specification %S" (org-roam-capture--get-target)))
+      )
     ;; Setup `org-id' for the current capture target and return it back to the
     ;; caller.
     (save-excursion


### PR DESCRIPTION
If a template is invalid org-roam-capture--setup-target-location does not set any target. Then (goto) fails due to lack of buffer.

For example, this template:

     (setq org-roam-capture-templates
        '(
          ("m"
           "movie" plain
           "*** ${title}\n :PROPERTIES:\n :RATING:\n:END:\n%t\n"
           :target (file+olp+datetree "Weekly.org" "abc")
           ))))

generates the error:

    save-excursion: Wrong type argument: integer-or-marker-p, nil

which is not very helpful

This patch adds an error message in such a case. It will report instead:

   Invalid org-roam capture specification (file+olp+datetree "Weekly.org" "abc")

###### Motivation for this change
