### PR TITLE
Fix some typos

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -873,7 +873,7 @@ Similarly, the completion candidates are the titles and aliases for all Org-roam
 nodes, and upon choosing a candidate a ~roam:Title~ link will be inserted
 linking to the node of choice.
 
-This is disable by default. To enable it, set ~org-roam-completion-everywhere~
+This is disabled by default. To enable it, set ~org-roam-completion-everywhere~
 to ~t~:
 
 #+begin_src emacs-lisp
@@ -1710,7 +1710,7 @@ queries on their Org files.
 ** Building Extensions and Advanced Customization of Org-roam
 
 Because Org-roam's core functionality is small, it is possible and sometimes
-desirable to build extensions on top of it. These extensions may one or more of
+desirable to build extensions on top of it. These extensions may use one or more of
 the following functionalities:
 
 - Access to Org-roam's database

--- a/doc/org-roam.texi
+++ b/doc/org-roam.texi
@@ -1261,7 +1261,7 @@ Similarly, the completion candidates are the titles and aliases for all Org-roam
 nodes, and upon choosing a candidate a @code{roam:Title} link will be inserted
 linking to the node of choice.
 
-This is disable by default. To enable it, set @code{org-roam-completion-everywhere}
+This is disabled by default. To enable it, set @code{org-roam-completion-everywhere}
 to @code{t}:
 
 @lisp
@@ -2354,7 +2354,7 @@ queries on their Org files.
 @section Building Extensions and Advanced Customization of Org-roam
 
 Because Org-roam's core functionality is small, it is possible and sometimes
-desirable to build extensions on top of it. These extensions may one or more of
+desirable to build extensions on top of it. These extensions may use one or more of
 the following functionalities:
 
 @itemize

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -42,8 +42,8 @@
 (defcustom org-roam-mode-sections (list #'org-roam-backlinks-section
                                         #'org-roam-reflinks-section)
   "A list of sections for the `org-roam-mode' based buffers.
-Each section is a function that is passed the an `org-roam-node'
-for which the section will be constructed for as the first
+Each section is a function that is passed the `org-roam-node'
+for which the section will be constructed as the first
 argument. Normally this node is `org-roam-buffer-current-node'.
 The function may also accept other optional arguments. Each item
 in the list is either:


### PR DESCRIPTION
For the sentence that was originally "These extensions may one or more of the following functionalities", I guessed that the intended meaning was "use". Let me know if I guessed wrong.