### PR TITLE
fix #2425 Prevent data loss when user has called org-roam-extract-subtree on folded org headline

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -878,6 +878,7 @@ node."
   (org-with-point-at 1
     (let ((title (nth 4 (org-heading-components)))
           (tags (org-get-tags)))
+      (org-fold-show-all)
       (kill-whole-line)
       (org-roam-end-of-meta-data t)
       (insert "#+title: " title "\n")


### PR DESCRIPTION
(kill-whole-line) kills folded text if called from column 1 Make sure to unfold text before calling it --
Prevents data loss if user has decided to extract subtree on a folded org headline.

###### Motivation for this change

As described in issue #2425 - org-roam-extract-subtree (by calling org-roam-promote-entire-buffer) deletes folded text because (kill-whole-line) when called from column 1 kills folded text -

Proposed change

```
-- org-roam-node-old.el	2024-06-26 00:04:34.713642244 +0530
+++ org-roam-node.el	2024-06-26 00:03:41.285582526 +0530
@@ -878,6 +878,7 @@
   (org-with-point-at 1
     (let ((title (nth 4 (org-heading-components)))
           (tags (org-get-tags)))
+      (org-fold-show-all)
       (kill-whole-line)
       (org-roam-end-of-meta-data t)
       (insert "#+title: " title "\n")
```

Best,