### PR TITLE
(docs): fix name of my-org-roam-show-backlink-p

### DIFF
--- a/doc/org-roam.org
+++ b/doc/org-roam.org
@@ -659,7 +659,7 @@ as follows:
     (not (member "daily" (org-roam-node-tags (org-roam-backlink-source-node backlink)))))
 
   (setq org-roam-mode-sections
-        '((org-roam-backlinks-section :unique t :show-backlink-p my/org-roam-show-backlink-p)
+        '((org-roam-backlinks-section :unique t :show-backlink-p my-org-roam-show-backlink-p)
           org-roam-reflinks-section))
 #+end_src
 


### PR DESCRIPTION
Fix: #2392

###### Motivation for this change

As noted in the related issue, the example was not working due to the `my/` vs `my-` mismatch.

I decided to change to `my-` to be coherent with other variables and function in this document.