### PR TITLE
(chore): fix indent blocking ci lint execution

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -264,14 +264,14 @@ Throw an error if multiple choices exist.
 If NOCASE is non-nil, the query is case insensitive.  It is case sensitive otherwise."
   (let ((matches (seq-uniq
                   (append
-	           (org-roam-db-query (vconcat [:select [id] :from nodes
-						        :where (= title $s1)]
-				               (if nocase [ :collate NOCASE ]))
-			              s)
-	           (org-roam-db-query (vconcat [:select [node-id] :from aliases
-						        :where (= alias $s1)]
-				               (if nocase [ :collate NOCASE ]))
-			              s)))))
+                   (org-roam-db-query (vconcat [:select [id] :from nodes
+                                                :where (= title $s1)]
+                                               (if nocase [ :collate NOCASE ]))
+                                      s)
+                   (org-roam-db-query (vconcat [:select [node-id] :from aliases
+                                                :where (= alias $s1)]
+                                               (if nocase [ :collate NOCASE ]))
+                                      s)))))
     (cond
      ((seq-empty-p matches)
       nil)


### PR DESCRIPTION
This mix of tabs and spaces was introduced recently in: https://github.com/org-roam/org-roam/commit/2e94f55cc58f6dce2772a6f33521eb5afcf67265

Example of failed ci job:
https://github.com/org-roam/org-roam/actions/runs/9748813724/job/26904611920
