### PR TITLE
(test): add org-roam-id-find

### DIFF
--- a/tests/roam-files/family.org
+++ b/tests/roam-files/family.org
@@ -1,0 +1,19 @@
+:PROPERTIES:
+:ID: 998b2341-b7fe-434d-848c-5282c0727870
+:END:
+#+title: Family
+
+* Grand-Parent
+:PROPERTIES:
+:ID: 77a90980-1994-464e-901f-7e3d3df07fd3
+:END:
+
+** Parent
+:PROPERTIES:
+:ID: 0fa5bb3e-3d8c-4966-8bc9-78d32e505d69
+:END:
+
+*** Child
+:PROPERTIES:
+:ID: 5fb4fdc5-b6d2-4f75-8d54-e60053e467ec
+:END:

--- a/tests/test-org-roam-id.el
+++ b/tests/test-org-roam-id.el
@@ -1,0 +1,50 @@
+;;; test-org-roam-id.el --- Tests for Org-roam -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020 Jethro Kuan
+
+;; Author: Jethro Kuan <jethrokuan95@gmail.com>
+;; Package-Requires: ((buttercup))
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Code:
+
+(require 'buttercup)
+(require 'org-roam)
+
+(describe "org-roam-id-find"
+  (before-each
+    (setq org-roam-directory (expand-file-name "tests/roam-files")
+          org-roam-db-location (expand-file-name "org-roam.db" temporary-file-directory)
+          org-roam-file-extensions '("org")
+          org-roam-file-exclude-regexp nil)
+    (org-roam-db-sync))
+
+  (it "finds nothing for non-existing node"
+    (expect (org-roam-id-find "non-existing") :to-equal nil))
+
+  (it "finds the correct file node"
+    (let ((location (org-roam-id-find "884b2341-b7fe-434d-848c-5282c0727861")))
+      (expect (car location) :to-equal "/home/runner/work/org-roam/org-roam/tests/roam-files/foo.org")
+      (expect (cdr location) :to-equal 1)))
+
+  (it "finds the correct heading node"
+    (let ((location (org-roam-id-find "0fa5bb3e-3d8c-4966-8bc9-78d32e505d69")))
+      (expect (car location) :to-equal "/home/runner/work/org-roam/org-roam/tests/roam-files/family.org")
+      (expect (cdr location) :to-equal 156))))
+
+(provide 'test-org-roam-id)
+
+;;; test-org-roam-id.el ends here

--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -33,17 +33,17 @@
 
   (it "gets files correctly"
     (expect (length (org-roam-list-files))
-            :to-equal 4))
+            :to-equal 5))
 
   (it "respects org-roam-file-extensions"
     (setq org-roam-file-extensions '("md"))
     (expect (length (org-roam-list-files)) :to-equal 1)
     (setq org-roam-file-extensions '("org" "md"))
-    (expect (length (org-roam-list-files)) :to-equal 5))
+    (expect (length (org-roam-list-files)) :to-equal 6))
 
   (it "respects org-roam-file-exclude-regexp"
     (setq org-roam-file-exclude-regexp (regexp-quote "foo.org"))
-    (expect (length (org-roam-list-files)) :to-equal 3)))
+    (expect (length (org-roam-list-files)) :to-equal 4)))
 
 (describe "org-roam-db-sync"
   (before-all
@@ -60,12 +60,12 @@
   (it "has the correct number of files"
     (expect (caar (org-roam-db-query [:select (funcall count) :from files]))
             :to-equal
-            4))
+            5))
 
   (it "has the correct number of nodes"
     (expect (caar (org-roam-db-query [:select (funcall count) :from nodes]))
             :to-equal
-            3))
+            7))
 
   (it "has the correct number of links"
     (expect (caar (org-roam-db-query [:select (funcall count) :from links]))
@@ -76,7 +76,13 @@
     ;; The excluded node has ID "53fadc75-f48e-461e-be06-44a1e88b2abe"
     (expect (mapcar #'car (org-roam-db-query [:select id :from nodes]))
             :to-have-same-items-as
-            '("884b2341-b7fe-434d-848c-5282c0727861" "440795d0-70c1-4165-993d-aebd5eef7a24" "5b9a7400-f59c-4ef9-acbb-045b69af98f1")))
+            '("884b2341-b7fe-434d-848c-5282c0727861"
+              "440795d0-70c1-4165-993d-aebd5eef7a24"
+              "5b9a7400-f59c-4ef9-acbb-045b69af98f1"
+              "0fa5bb3e-3d8c-4966-8bc9-78d32e505d69"
+              "5fb4fdc5-b6d2-4f75-8d54-e60053e467ec"
+              "77a90980-1994-464e-901f-7e3d3df07fd3"
+              "998b2341-b7fe-434d-848c-5282c0727870")))
 
   (it "reads ref in quotes correctly"
     (expect (mapcar #'car (org-roam-db-query [:select [ref] :from refs]))


### PR DESCRIPTION
###### Motivation for this change

Improving test coverage to avoid regressions on future PRs merging.
