### PR TITLE
(docs): explain org-roam-file-exclude-regexp

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -138,7 +138,7 @@ responsibility to ensure that."
   :group 'org-roam)
 
 (defcustom org-roam-file-exclude-regexp (list org-attach-id-dir)
-  "Files matching this regular expression are excluded from the Org-roam."
+  "Files matching this regular expression or list of regular expressions are excluded from the Org-roam."
   :type '(choice
           (repeat
            (string :tag "Regular expression matching files to ignore"))


### PR DESCRIPTION
###### Motivation for this change
As explained in #2442 , the documentation `org-roam-file-exclude-regexp` may be more detailed to let the user know he/she can use a single regexp or a list of regexp to exlude files.