### PR TITLE
(fix): remove dead-code about org-roam-shield feature

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -707,8 +707,6 @@ the current value of `point'."
 
 (defun org-roam-capture--finalize ()
   "Finalize the `org-roam-capture' process."
-  (when-let ((region (org-roam-capture--get :region)))
-    (org-roam-unshield-region (car region) (cdr region)))
   (if org-note-abort
       (when-let ((new-file (org-roam-capture--get :new-file))
                  (_ (yes-or-no-p "Delete file for aborted capture?")))
@@ -740,7 +738,6 @@ This function is to be called in the Org-capture finalization process."
               (buf (marker-buffer mkr)))
     (with-current-buffer buf
       (when-let ((region (org-roam-capture--get :region)))
-        (org-roam-unshield-region (car region) (cdr region))
         (delete-region (car region) (cdr region))
         (set-marker (car region) nil)
         (set-marker (cdr region) nil))

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -233,33 +233,6 @@ Like `org-fontify-like-in-org-mode', but supports `org-ref'."
       (font-lock-ensure)
       (buffer-string))))
 
-;;;; Shielding regions
-(defface org-roam-shielded
-  '((t :inherit (warning)))
-  "Face for regions that are shielded (marked as read-only).
-This face is used on the region target by org-roam-insertion
-during an `org-roam-capture'."
-  :group 'org-roam-faces)
-
-(defun org-roam-shield-region (beg end)
-  "Shield region against modifications.
-BEG and END are markers for the beginning and end regions.
-REGION must be a cons-cell containing the marker to the region
-beginning and maximum values."
-  (add-text-properties beg end
-                       '(font-lock-face org-roam-shielded
-                                        read-only t)
-                       (marker-buffer beg)))
-
-(defun org-roam-unshield-region (beg end)
-  "Unshield the shielded REGION.
-BEG and END are markers for the beginning and end regions."
-  (let ((inhibit-read-only t))
-    (remove-text-properties beg end
-                            '(font-lock-face org-roam-shielded
-                                             read-only t)
-                            (marker-buffer beg))))
-
 ;;; Org-mode utilities
 ;;;; Motions
 (defun org-roam-up-heading-or-point-min ()


### PR DESCRIPTION
As described in https://github.com/org-roam/org-roam/issues/2348, the `org-roam-shield-region` function is not called anymore.

The reverse function and associated face can also be removed.

Fix: #2348

