### PR TITLE
fix: expand file name for org-roam-directory

### DIFF
--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -668,7 +668,7 @@ This is the ROW within FILE."
                   (mapconcat (lambda (title)
                                (format "|(\\b%s\\b)" (shell-quote-argument title)))
                              titles ""))
-          (shell-quote-argument org-roam-directory)))
+          (shell-quote-argument (expand-file-name org-roam-directory))))
 
 (defun org-roam-unlinked-references-section (node)
   "The unlinked references section for NODE.


### PR DESCRIPTION
I am new to both Emacs & Emacs Lisp. I do not fully understand the implications of using `expand-file-name`.

###### Motivation for this change
Issue #2478.

I had set my `org-roam-directory` to be `~/org/roam` and that made `rg` silently fail. Running 

```
(org-roam-unlinked-references--rg-command '("Site Controller"))
```

then returned

```
rg --follow --only-matching --vimgrep --pcre2 --ignore-case --glob "*.org" --glob "*.org.gpg" --glob "*.org.age" '\[([^[]]++|(?R))*\]|(\bSite\ Controller\b)' \~/org/roam
```
which caused `rg` to fail with:

```
rg: ~/org/roam: IO error for operation on ~/org/roam: No such file or directory (os error 2)
```

It was solved by expanding the `~/org/roam` path.