### PR TITLE
Rely on emacsql-sqlite-open to pick the best available back-end

### DIFF
--- a/extensions/org-roam-export.el
+++ b/extensions/org-roam-export.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (org "9.4") (org-roam "2.1"))
+;; Package-Requires: ((emacs "26.1") (org "9.6") (org-roam "2.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/extensions/org-roam-graph.el
+++ b/extensions/org-roam-graph.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (org "9.4") (org-roam "2.1"))
+;; Package-Requires: ((emacs "26.1") (org "9.6") (org-roam "2.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/extensions/org-roam-overlay.el
+++ b/extensions/org-roam-overlay.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (org "9.4") (org-roam "2.1"))
+;; Package-Requires: ((emacs "26.1") (org "9.6") (org-roam "2.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/extensions/org-roam-protocol.el
+++ b/extensions/org-roam-protocol.el
@@ -5,7 +5,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (org "9.4") (org-roam "2.1"))
+;; Package-Requires: ((emacs "26.1") (org "9.6") (org-roam "2.1"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.0.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -337,7 +337,7 @@ If HASH is non-nil, use that as the file's hash without recalculating it."
       (let* ((begin (match-beginning 0))
              (element (org-element-context))
              (type (org-element-type element))
-             link bounds)
+             link)
         (cond
          ;; Links correctly recognized by Org Mode
          ((eq type 'link)
@@ -581,7 +581,8 @@ in `org-roam-db-sync'."
         (emacsql-with-transaction (org-roam-db)
           (org-with-wide-buffer
            (org-set-regexps-and-options 'tags-only)
-           (org-refresh-category-properties)
+           ;; Org doesn't use this anymore, so we probably should stop too.
+           ;; (org-refresh-category-properties)
            (org-roam-db-clear-file)
            (org-roam-db-insert-file content-hash)
            (org-roam-db-insert-file-node)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -36,40 +36,6 @@
 (defvar org-outline-path-cache)
 
 ;;; Options
-(defcustom org-roam-database-connector (if (and (progn
-                                                  (require 'emacsql-sqlite-builtin nil t)
-                                                  (functionp 'emacsql-sqlite-builtin))
-                                                (functionp 'sqlite-open))
-                                           'sqlite-builtin
-                                         'sqlite-module)
-  "The database connector used by Org-roam.
-This must be set before `org-roam' is loaded.  To use an alternative
-connector you must install the respective package explicitly.
-If you are using Emacs 29 or newer, then the default connector is
-`sqlite-builtin', which uses the new builtin support for SQLite.
-You need to install the `emacsql-sqlite-builtin' package to use
-this connector.
-If you are using an older Emacs release, then the default
-connector is `sqlite-module', which uses the module provided by
-the `sqlite3' package.  This is very similar to the previous
-connector and the built-in support in Emacs 29 derives from this
-module.  You need to install the `emacsql-sqlite-module' package
-to use this connector.
-For the time being `libsqlite3' is still supported.  Do not use
-this, it is an older version of the `sqlite-module' connector
-from before the connector and the package were renamed.
-For the time being `sqlite3' is also supported.  Do not use this.
-This uses the third-party `emacsql-sqlite3' package, which uses
-the official `sqlite3' cli tool, which is not intended
-to be used like this.  See https://nullprogram.com/blog/2014/02/06/."
-  :package-version '(forge . "0.3.0")
-  :group 'org-roam
-  :type '(choice
-          (const sqlite-builtin)
-          (const sqlite-module)
-          (const :tag "libsqlite3 (OBSOLETE)" libsqlite3)
-          (const :tag "sqlite3 (BROKEN)" sqlite3)))
-
 (defcustom org-roam-db-location (locate-user-emacs-file "org-roam.db")
   "The path to file where the Org-roam database is stored.
 
@@ -153,31 +119,6 @@ ROAM_REFS."
   (gethash (expand-file-name (file-name-as-directory org-roam-directory))
            org-roam-db--connection))
 
-(declare-function emacsql-sqlite3 "ext:emacsql-sqlite3")
-(declare-function emacsql-libsqlite3 "ext:emacsql-libsqlite3")
-(declare-function emacsql-sqlite-builtin "ext:emacsql-sqlite-builtin")
-(declare-function emacsql-sqlite-module "ext:emacsql-sqlite-module")
-
-(defun org-roam-db--conn-fn ()
-  "Return the function for creating the database connection."
-  (cl-case org-roam-database-connector
-    (sqlite-builtin
-     (progn
-       (require 'emacsql-sqlite-builtin)
-       #'emacsql-sqlite-builtin))
-    (sqlite-module
-     (progn
-       (require 'emacsql-sqlite-module)
-       #'emacsql-sqlite-module))
-    (libsqlite3
-     (progn
-       (require 'emacsql-libsqlite3)
-       #'emacsql-libsqlite3))
-    (sqlite3
-     (progn
-       (require 'emacsql-sqlite3)
-       #'emacsql-sqlite3))))
-
 (defun org-roam-db ()
   "Entrypoint to the Org-roam sqlite database.
 Initializes and stores the database, and the database connection.
@@ -186,11 +127,8 @@ Performs a database upgrade when required."
                (emacsql-live-p (org-roam-db--get-connection)))
     (let ((init-db (not (file-exists-p org-roam-db-location))))
       (make-directory (file-name-directory org-roam-db-location) t)
-      (let ((conn (funcall (org-roam-db--conn-fn) org-roam-db-location)))
+      (let ((conn (emacsql-sqlite-open org-roam-db-location)))
         (emacsql conn [:pragma (= foreign_keys ON)])
-        (when-let* ((process (emacsql-process conn))
-                    (_ (processp process)))
-          (set-process-query-on-exit-flag process nil))
         (puthash (expand-file-name (file-name-as-directory org-roam-directory))
                  conn
                  org-roam-db--connection)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -140,7 +140,7 @@ Performs a database upgrade when required."
            ((> version org-roam-db-version)
             (emacsql-close conn)
             (user-error
-             "The Org-roam database was created with a newer Org-roam version.  "
+             "The Org-roam database was created with a newer Org-roam version.  %s"
              "You need to update the Org-roam package"))
            ((< version org-roam-db-version)
             (emacsql-close conn)

--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.0.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -128,7 +128,6 @@ Performs a database upgrade when required."
     (let ((init-db (not (file-exists-p org-roam-db-location))))
       (make-directory (file-name-directory org-roam-db-location) t)
       (let ((conn (emacsql-sqlite-open org-roam-db-location)))
-        (emacsql conn [:pragma (= foreign_keys ON)])
         (puthash (expand-file-name (file-name-as-directory org-roam-directory))
                  conn
                  org-roam-db--connection)

--- a/org-roam-id.el
+++ b/org-roam-id.el
@@ -55,11 +55,10 @@ With optional argument MARKERP, return the position as a new marker."
   (let ((node (org-roam-populate (org-roam-node-create :id id))))
     (when-let ((file (org-roam-node-file node)))
       (if markerp
-          (unwind-protect
-              (let ((buffer (or (find-buffer-visiting file)
-                                (find-file-noselect file))))
-                (with-current-buffer buffer
-                  (move-marker (make-marker) (org-roam-node-point node) buffer))))
+          (let ((buffer (or (find-buffer-visiting file)
+                            (find-file-noselect file))))
+            (with-current-buffer buffer
+              (move-marker (make-marker) (org-roam-node-point node) buffer)))
         (cons (org-roam-node-file node)
               (org-roam-node-point node))))))
 

--- a/org-roam-id.el
+++ b/org-roam-id.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-log.el
+++ b/org-roam-log.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.0.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-log.el
+++ b/org-roam-log.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-migrate.el
+++ b/org-roam-migrate.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.0.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-migrate.el
+++ b/org-roam-migrate.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.0.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -441,7 +441,7 @@ In interactive calls OTHER-WINDOW is set with
     (with-current-buffer buf
       (widen)
       (goto-char point))
-    (when (org-invisible-p) (org-show-context))
+    (when (org-invisible-p) (org-fold-show-context))
     buf))
 
 (defun org-roam-preview-default-function ()
@@ -630,7 +630,7 @@ instead."
         (forward-line (1- row)))
       (when col
         (forward-char (1- col))))
-    (when (org-invisible-p) (org-show-context))
+    (when (org-invisible-p) (org-fold-show-context))
     buf))
 
 ;;;; Unlinked references

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -319,7 +319,7 @@ To toggle its display use `org-roam-buffer-toggle' command.")
 
 (define-inline org-roam-buffer--visibility ()
   "Return the current visibility state of the persistent `org-roam-buffer'.
-Valid states are 'visible, 'exists and 'none."
+Valid states are `visible', `exists' and `none'."
   (declare (side-effect-free t))
   (inline-quote
    (cond

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -32,6 +32,7 @@
 ;; interactively.
 ;;
 ;;; Code:
+(require 'crm)
 (require 'org-roam)
 
 ;;; Options
@@ -446,12 +447,11 @@ GROUP BY id")))
 ;;;; Finders
 (defun org-roam-node-marker (node)
   "Get the marker for NODE."
-  (unwind-protect
-      (let* ((file (org-roam-node-file node))
-             (buffer (or (find-buffer-visiting file)
-                         (find-file-noselect file))))
-        (with-current-buffer buffer
-          (move-marker (make-marker) (org-roam-node-point node) buffer)))))
+  (let* ((file (org-roam-node-file node))
+         (buffer (or (find-buffer-visiting file)
+                     (find-file-noselect file))))
+    (with-current-buffer buffer
+      (move-marker (make-marker) (org-roam-node-point node) buffer))))
 
 (defun org-roam-node-open (node &optional cmd force)
   "Go to the node NODE.
@@ -1057,7 +1057,7 @@ and when nil is returned the node will be filtered out."
   (let ((node (org-roam-node-at-point 'assert)))
     (save-excursion
       (goto-char (org-roam-node-point node))
-      (org-roam-property-add "ROAM_REFS" (if (memq " " (string-to-list ref))
+      (org-roam-property-add "ROAM_REFS" (if (member " " (string-to-list ref))
                                              (concat "\"" ref "\"")
                                            ref)))))
 

--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -478,7 +478,7 @@ NODE, unless FORCE is non-nil."
                           (org-roam-id-at-point))))
       (goto-char m))
     (move-marker m nil))
-  (org-show-context))
+  (org-fold-show-context))
 
 (defun org-roam-node-visit (node &optional other-window force)
   "From the current buffer, visit NODE. Return the visited buffer.

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -72,11 +72,10 @@ Like `string-equal', but case-insensitive."
 (defun org-roam-whitespace-content (s)
   "Return the whitespace content at the end of S."
   (with-temp-buffer
-    (let ((c 0))
-      (insert s)
-      (skip-chars-backward " \t\n")
-      (buffer-substring-no-properties
-       (point) (point-max)))))
+    (insert s)
+    (skip-chars-backward " \t\n")
+    (buffer-substring-no-properties
+     (point) (point-max))))
 
 (defun org-roam-strip-comments (s)
   "Strip Org comments from string S."
@@ -85,7 +84,8 @@ Like `string-equal', but case-insensitive."
     (goto-char (point-min))
     (while (not (eobp))
       (if (org-at-comment-p)
-          (delete-region (point-at-bol) (progn (forward-line) (point)))
+          (delete-region (line-beginning-position)
+                         (progn (forward-line) (point)))
         (forward-line)))
     (buffer-string)))
 

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -449,8 +449,10 @@ See <https://github.com/raxod502/straight.el/issues/520>."
                       (quit "N/A"))))
     (insert (format "- Org: %s\n" (org-version nil 'full)))
     (insert (format "- Org-roam: %s" (org-roam-version)))
-    (insert (format "- sqlite-connector: %s" org-roam-database-connector))))
-
+    (insert (format "- sqlite-connector: %s"
+                    (if-let ((conn (org-roam-db--get-connection)))
+                        (eieio-object-class conn)
+                      "not connected")))))
 
 (provide 'org-roam-utils)
 ;;; org-roam-utils.el ends here

--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -186,7 +186,7 @@ in the list is found.
 By default, `executable-find' will be used to look up the path to
 the executable. If a custom path is required, it can be specified
 together with the method symbol as a cons cell. For example:
-'(find (rg . \"/path/to/rg\"))."
+\\='(find (rg . \"/path/to/rg\"))."
   :type '(set
           (const :tag "find" find)
           (const :tag "fd" fd)

--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.0.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "4.1.0") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.6") (emacsql "4.1.0") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
That function was added two years ago and the first release that
provided it was v4.0.0.  It automatically picks the best available
back-end, `emacsql-sqlite-builtin` or `emacsql-sqlite-module`.
In v4.0.0 it could also fall back to the legacy `emacsql-sqlite`.
The inferior third-party back-ends are no longer supported.

Emacsql v4.1.0, which will be releases in early December, removes
the legacy `emacsql-sqlite` back-end (which used a custom binary).

This means that we now require an Emacs that was built with SQLite
and/or module support.

-------

###### Motivation for this change

EmacSQL now takes care of picking the best back-end itself.  Let's
use that.

By removing an option that offers no longer valid choices, we make
sure users cannot pick an invalid choice.