### PR TITLE
Add advice to org-id-find instead of full org-id-open rewrite

### DIFF
--- a/org-roam-id.el
+++ b/org-roam-id.el
@@ -63,30 +63,13 @@ With optional argument MARKERP, return the position as a new marker."
         (cons (org-roam-node-file node)
               (org-roam-node-point node))))))
 
-(defun org-roam-id-open (id _)
+(defun org-roam-id-open (link arg)
   "Go to the entry with id ID.
 Like `org-id-open', but additionally uses the Org-roam database."
-  (org-mark-ring-push)
-  (let ((m (or (org-roam-id-find id 'marker)
-               (org-id-find id 'marker)))
-        cmd)
-    (unless m
-      (error "Cannot find entry with ID \"%s\"" id))
-    ;; Use a buffer-switching command in analogy to finding files
-    (setq cmd
-          (or
-           (cdr
-            (assq
-             (cdr (assq 'file org-link-frame-setup))
-             '((find-file . switch-to-buffer)
-               (find-file-other-window . switch-to-buffer-other-window)
-               (find-file-other-frame . switch-to-buffer-other-frame))))
-           'switch-to-buffer-other-window))
-    (if (not (equal (current-buffer) (marker-buffer m)))
-        (funcall cmd (marker-buffer m)))
-    (goto-char m)
-    (move-marker m nil)
-    (org-show-context)))
+  (advice-add 'org-id-find :before-until #'org-roam-id-find)
+  (unwind-protect
+      (org-id-open link arg)
+    (advice-remove 'org-id-find #'org-roam-id-find)))
 
 (org-link-set-parameters "id" :follow #'org-roam-id-open)
 


### PR DESCRIPTION
###### Motivation for this change

Original `org-id-open` handles links like `id:XXX::opts`, but `org-roam-id-open` doesn't copy that functionality. Since `org-roam-id-open` is actually an incomplete copy of `org-id-open` it makes sense to use the original function and only add advice to `org-id-find`.