### PR TITLE
Use regexp match to replace hard-coded path equal test

### DIFF
--- a/tests/test-org-roam-id.el
+++ b/tests/test-org-roam-id.el
@@ -66,12 +66,12 @@
 
   (it "finds the correct file node"
     (let ((location (org-roam-id-find "884b2341-b7fe-434d-848c-5282c0727861")))
-      (expect (car location) :to-equal "/home/runner/work/org-roam/org-roam/tests/roam-files/foo.org")
+      (expect (car location) :to-match ".*/tests/roam-files/foo.org")
       (expect (cdr location) :to-equal 1)))
 
   (it "finds the correct heading node"
     (let ((location (org-roam-id-find "0fa5bb3e-3d8c-4966-8bc9-78d32e505d69")))
-      (expect (car location) :to-equal "/home/runner/work/org-roam/org-roam/tests/roam-files/family.org")
+      (expect (car location) :to-match ".*/tests/roam-files/family.org")
       (expect (cdr location) :to-equal 156))))
 
 (provide 'test-org-roam-id)


### PR DESCRIPTION
Hard-coded paths cause the tests to fail when building under different environments, e.g. under Debian sbuild it fails with the following errors:

```
,----
| ========================================
| org-roam-id-find finds the correct file node
| FAILED: Expected `(car location)' to be `equal' to `"/home/runner/work/org-roam/org-roam/tests/roam-files/foo.org"', but instead it was `"/build/reproducible-path/org-roam-2.2.2+git20250105.cad3518/tests/roam-files/foo.org"' which does not match because: (arrays-of-different-length 84 60 "/build/reproducible-path/org-roam-2.2.2+git20250105.cad3518/tests/roam-files/foo.org" "/home/runner/work/org-roam/org-roam/tests/roam-files/foo.org" first-mismatch-at 1). |
| ========================================
| org-roam-id-find finds the correct heading node
| FAILED: Expected `(car location)' to be `equal' to `"/home/runner/work/org-roam/org-roam/tests/roam-files/family.org"', but instead it was `"/build/reproducible-path/org-roam-2.2.2+git20250105.cad3518/tests/roam-files/family.org"' which does not match because: (arrays-of-different-length 87 63 "/build/reproducible-path/org-roam-2.2.2+git20250105.cad3518/tests/roam-files/family.org" "/home/runner/work/org-roam/org-roam/tests/roam-files/family.org" first-mismatch-at 1). |
| Ran 41 specs, 2 failed, in 980.31ms.
| buttercup-run failed: ""
`----
```
