### PR TITLE
Fix emacsql version requirement

### DIFF
--- a/org-roam.el
+++ b/org-roam.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/org-roam/org-roam
 ;; Keywords: org-mode, roam, convenience
 ;; Version: 2.2.2
-;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "20230228") (magit-section "3.0.0"))
+;; Package-Requires: ((emacs "26.1") (dash "2.13") (org "9.4") (emacsql "3.1.1.50-git") (magit-section "3.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
* The Package-Version of emacsql around Feb 28, 2023 was actually 3.1.1.50-git.
* Using date as version value is too large and makes it unable to find a suitable candidate.
