### PR TITLE
Set org-roam-directory to a non-existent path to ensure robust test

### DIFF
--- a/tests/test-org-roam.el
+++ b/tests/test-org-roam.el
@@ -28,6 +28,7 @@
 
 (describe "org-roam-file-p"
   (it "checks if given file respects criteria"
+    (setq org-roam-directory "/non-existent")
     (expect (org-roam-file-p "tests/roam-files/family.org") :to-equal nil)
 
     (setq org-roam-directory (expand-file-name "tests/roam-files"))


### PR DESCRIPTION
* In some rare case, the first expect of org-roam-file-p may return t when running in some environment (e.g. during autopkgtest in Debian).
* Setting org-roam-directory to a non-existent path ensure that the first check is always nil as expected.
