### PR TITLE
(perf): Deprecate link :outline properties

### DIFF
--- a/org-roam-db.el
+++ b/org-roam-db.el
@@ -108,7 +108,7 @@ ROAM_REFS."
   :type '(alist))
 
 ;;; Variables
-(defconst org-roam-db-version 18)
+(defconst org-roam-db-version 19)
 
 (defvar org-roam-db--connection (make-hash-table :test #'equal)
   "Database connection to Org-roam database.")
@@ -214,7 +214,7 @@ The query is expected to be able to fail, in this situation, run HANDLER."
        (source :not-null)
        (dest :not-null)
        (type :not-null)
-       (properties :not-null)]
+       properties]
       (:foreign-key [source] :references nodes [id] :on-delete :cascade)))))
 
 (defconst org-roam-db--table-indices
@@ -507,11 +507,8 @@ INFO is the org-element parsed buffer."
            (path (if (not option) path
                    (substring path 0 (match-beginning 0))))
            (source (org-roam-id-at-point))
-           (properties (list :outline (ignore-errors
-                                        ;; This can error if link is not under any headline
-                                        (org-get-outline-path 'with-self 'use-cache))))
-           (properties (if option (plist-put properties :search-option option)
-                         properties)))
+           (properties (when option
+                         (list :search-option option))))
       ;; For Org-ref links, we need to split the path into the cite keys
       (when (and source path)
         (if (and (boundp 'org-ref-cite-types)
@@ -533,9 +530,7 @@ INFO is the org-element parsed buffer."
     (goto-char (org-element-property :begin citation))
     (let ((key (org-element-property :key citation))
           (source (org-roam-id-at-point))
-          (properties (list :outline (ignore-errors
-                                       ;; This can error if link is not under any headline
-                                       (org-get-outline-path 'with-self 'use-cache)))))
+          (properties nil))
       (when (and source key)
         (org-roam-db-query
          [:insert :into citations

--- a/org-roam-mode.el
+++ b/org-roam-mode.el
@@ -369,7 +369,7 @@ run at `post-command-hook'."
    (node :initform nil))
   "A `magit-section' used by `org-roam-mode' to outline NODE in its own heading.")
 
-(cl-defun org-roam-node-insert-section (&key source-node point properties)
+(cl-defun org-roam-node-insert-section (&key source-node point _properties)
   "Insert section for a link from SOURCE-NODE to some other node.
 The other node is normally `org-roam-buffer-current-node'.
 
@@ -393,7 +393,9 @@ the same time:
    other node) at POINT. Acts a child section of the previous
    one."
   (magit-insert-section section (org-roam-node-section)
-    (let ((outline (if-let ((outline (plist-get properties :outline)))
+    (let ((outline (if-let ((outline (append
+                                      (org-roam-node-olp source-node)
+                                      (list (org-roam-node-title source-node)))))
                        (mapconcat #'org-link-display-format outline " > ")
                      "Top")))
       (insert (concat (propertize (org-roam-node-title source-node)
@@ -534,8 +536,7 @@ SECTION-HEADING is the string used as a heading for the backlink section."
                        (funcall show-backlink-p backlink)))
           (org-roam-node-insert-section
            :source-node (org-roam-backlink-source-node backlink)
-           :point (org-roam-backlink-point backlink)
-           :properties (org-roam-backlink-properties backlink))))
+           :point (org-roam-backlink-point backlink))))
       (insert ?\n))))
 
 ;;;; Reflinks
@@ -590,8 +591,7 @@ Sorts by title."
       (dolist (reflink reflinks)
         (org-roam-node-insert-section
          :source-node (org-roam-reflink-source-node reflink)
-         :point (org-roam-reflink-point reflink)
-         :properties (org-roam-reflink-properties reflink)))
+         :point (org-roam-reflink-point reflink)))
       (insert ?\n))))
 
 ;;;; Grep


### PR DESCRIPTION
1. In `org-roam-db-insert-link`, stop adding `(list :outline OLP...)` 
   to every link object.

1. In `org-roam-node-insert-section`, reconstruct outline
   from one of its other arguments, `source-node`,
   permitting the `properties` argument to be nil.

   1. In callers of above function, don't bother to send 
      a `:properties` argument, since it won't be used.

1. Update schemata so link properties are not marked `:not-null`,
   making it legal for this field to be NULL.
   
   2. It may interest you to know that the `citations` table
      already was free of this restriction, so this change just affects
      the `links` table.

-------

###### Motivation for this change

As it happens, turning sexps into strings is one of the computationally
expensive steps in EmacSQL.

With an enormous number of links in the database, that's a lot of
`(:outline nil)` to stringify into `"(:outline nil)"`.

Its only use was in `org-roam-node-insert-section`, where the information
is very cheap to reconstruct.  It's already in one of the other
arguments!

This has passed unnoticed because `org-roam-db-sync` has other
performance tarpits, but it will probably be noticed eventually after
those get fixed.

---------

###### Full disclosure

Since many months ago, I've had a hack in my package
[org-node-fakeroam](https://github.com/meedstrom/org-node-fakeroam/blob/main/org-node-fakeroam.el),
to work around this performance issue, because it takes longer
to generate an org-roam.db that includes these link properties.

You can Ctrl+F `org-node-fakeroam--mk-link-props` if interested.

Now I'm working on a new package
[org-node-db.el](https://github.com/meedstrom/org-node/blob/dev/org-node-db.el) 
aiming to be 100% compatible with org-roam, using the same table schemata and all.  Which means I don't get to do the hack, and therefore this pull request.  Please consider it.

Benchmarks

- with the link props: ~1.00s to build org-roam.db
- without the link props: ~0.60s


Off-topic:  A related matter is the data-type of `atime` and `mtime` in the files table.  They are currently Lisp time values, and could easily be integers or floats instead.  Let me know if you would welcome a pullreq about that.