### PR TITLE
FIX org-roam-alias-add check for already exsting alias

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -1133,9 +1133,11 @@ and when nil is returned the node will be filtered out."
   "Add ALIAS to the node at point."
   (interactive "sAlias: ")
   (let ((node (org-roam-node-at-point 'assert)))
-    (save-excursion
-      (goto-char (org-roam-node-point node))
-      (org-roam-property-add "ROAM_ALIASES" alias))))
+    (if (member alias (org-roam--get-titles))
+        (message "Alias %s already exists in the Org-roam database." alias)
+      (save-excursion
+        (goto-char (org-roam-node-point node))
+        (org-roam-property-add "ROAM_ALIASES" alias)))))
 
 (defun org-roam-alias-remove (&optional alias)
   "Remove an ALIAS from the node at point."


### PR DESCRIPTION
###### Motivation for this change
Adding an alias which was already take will result in the new node "eating" the reference of the previous one.
TODO: maybe add an interactive mode such that other names appear to avoid too much fail&retry when setting an alias.

Should i also update the changelog? I've seen the changes linked to already existing pull-request. This is my first pr on this project and github.