### PR TITLE
dailies: prevent matching .org_archive files

### DIFF
--- a/extensions/org-roam-dailies.el
+++ b/extensions/org-roam-dailies.el
@@ -269,7 +269,7 @@ negative, find note N days in the future."
   "List all files in `org-roam-dailies-directory'.
 EXTRA-FILES can be used to append extra files to the list."
   (let ((dir (expand-file-name org-roam-dailies-directory org-roam-directory))
-        (regexp (rx-to-string `(and "." (or ,@org-roam-file-extensions)))))
+        (regexp (rx-to-string `(seq (literal ".") (or ,@org-roam-file-extensions) eos))))
     (append (--remove (let ((file (file-name-nondirectory it)))
                         (when (or (auto-save-file-name-p file)
                                   (backup-file-name-p file)


### PR DESCRIPTION
`org-roam-dailies--list-files` would return `.org_archive` files along with `.org` files. The real issue is that `org-roam-dailies-goto-previous-note` can step into the archive file but not step out of the archive file. This could be fixed by not visiting the archive file or by fixing whatever issue prevents `org-roam-dailies-goto-previous-note` from stepping out of the archive file. this commit updates it to not consider archive files.
