### PR TITLE
(org-roam-capture): add new `prompt` target to the preselected node

### DIFF
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -132,6 +132,10 @@ The following options are supported for the :target property:
        The point will be placed for an existing node, based on either, its
        title, alias or ID.
 
+   (prompt)
+       The point will be placed at the node selected in the initial prompt
+       of the capture process.
+
 The rest of the entry is a property list of additional options.  Recognized
 properties are:
 
@@ -562,6 +566,11 @@ Return the ID of the location."
            ;; workers.
            (org-today)))))
        (setq p (point)))
+      (`(prompt)
+       (let ((node org-roam-capture--node))
+         (set-buffer (org-capture-target-buffer (org-roam-node-file node)))
+         (goto-char (org-roam-node-point node))
+         (setq p (org-roam-node-point node))))
       (`(node ,title-or-id)
        ;; first try to get ID, then try to get title/alias
        (let ((node (or (org-roam-node-from-id title-or-id)


### PR DESCRIPTION
###### Motivation for this change

Hi. II ran into #2505.

As @hpfr had pointed out in https://github.com/org-roam/org-roam/issues/2505#issuecomment-3017080776, the `node` target is confusing: `org-roam-capture` always prompts you for a node first, but then that node cannot be referenced in the `node` target. 

I had tried using `(node "${title}")`, but it seems expansion doesn't work within.

This PR leaves the `node` target as it is for compatibility, and instead adds a new target which just uses `org-capture-roam--node` (the prompted node) as the target.

Or, could we have `node`'s `title-or-id` possibly take in `nil`? I had initially done it this way:

```diff
--- a/org-roam-capture.el
+++ b/org-roam-capture.el
@@ -563,10 +563,13 @@ Return the ID of the location."
            (org-today)))))
        (setq p (point)))
       (=(node ,title-or-id)
-       ;; first try to get ID, then try to get title/alias
-       (let ((node (or (org-roam-node-from-id title-or-id)
-                       (org-roam-node-from-title-or-alias title-or-id)
-                       (user-error "No node with title or id \"%s\"" title-or-id))))
+       ;; if title-or-id is specified: first try to get ID, then try to get title/alias; else, use the (earlier) prompted node
+       (let ((node (if title-or-id
+                        (or
+                         (org-roam-node-from-id title-or-id)
+                         (org-roam-node-from-title-or-alias title-or-id)
+                         (user-error "No node with title or id \"%s\"" title-or-id))
+                      org-roam-capture--node)))
          (set-buffer (org-capture-target-buffer (org-roam-node-file node)))
          (goto-char (org-roam-node-point node))
          (setq p (org-roam-node-point node)))))
```

but found it a bit weird.

Thoughts?

Thanks