### PR TITLE
refactor: More sane `org-roam-with-temp-buffer`, slight perf

### DIFF
--- a/org-roam-utils.el
+++ b/org-roam-utils.el
@@ -136,11 +136,13 @@ If FILE, set `default-directory' to FILE's directory and insert its contents."
     `(let ((,current-org-roam-directory org-roam-directory))
        (with-temp-buffer
          (let ((org-roam-directory ,current-org-roam-directory)
+               (org-agenda-files nil) ; perf
+               (org-element-cache-persistent nil) ; perf
                (org-inhibit-startup t))
-           (delay-mode-hooks (org-mode))
            (when ,file
              (insert-file-contents ,file)
              (setq-local default-directory (file-name-directory ,file)))
+           (delay-mode-hooks (org-mode))
            ,@body)))))
 
 ;;; Formatting


### PR DESCRIPTION
# EDITED (Feb 2026)

This PR does two things: 

- a small change for performance
- a sanity fix

## Perf change

This matters little now that we won't even use this macro for generating backlink previews, since merging the excellent #2340.

It may have some impact if [as I've suggested](https://github.com/org-roam/org-roam/pull/2558#issuecomment-3505416637), we rework `org-roam-db-update-file` to make use of this macro (that is, the `org-roam-with-temp-buffer` macro). Which we definitely should, by the way, to avoid "too many files" error #2547.  

Then evalling `(org-roam-db-sync :force)` would create a temp buffer for every Org-roam file. How much this PR will matter in relative terms depends on how fast that'll be otherwise, which we don't know yet. 

In absolute terms on my system, the savings add up to just ~2 seconds across 2600 files. Meh.  And `(org-roam-db-sync :force)` takes ~120 seconds, so that's one pill in a barrel o'drugs for now.  FWIW, I think that 120 figure should be able to go down a lot.

Anyway, here's benchmark code you can run. Probably you see a bigger difference the more files you got in `org-agenda-files`.  

Without checking out the PR branch, compare these three benchmarks in your current Emacs:

```elisp

(setq FILES (org-roam-list-files))

(seq-let (total _ gc)
    (benchmark-run 1
      (let ((files (copy-sequence FILES)))
        (dolist (file files)
          (org-roam-with-temp-buffer file
            ;; Traverse elements to test the org-element cache... probably
            (while (= 0 (org-next-visible-heading 1))
              (org-roam-end-of-meta-data t))))))
  (- total gc))

(seq-let (total _ gc)
    (benchmark-run 1
      (let ((files (copy-sequence FILES))
            (org-agenda-files nil))
        (dolist (file files)
          (org-roam-with-temp-buffer file
            (while (= 0 (org-next-visible-heading 1))
              (org-roam-end-of-meta-data t))))))
  (- total gc))

(seq-let (total _ gc)
    (benchmark-run 1
      (let ((files (copy-sequence FILES))
            (org-agenda-files nil)
            (org-element-cache-persistent nil))
        (dolist (file files)
          (org-roam-with-temp-buffer file
            (while (= 0 (org-next-visible-heading 1))
              (org-roam-end-of-meta-data t))))))
  (- total gc))
```

For me with about 30 agenda files, binding `(org-agenda-files nil)` shaves ~40% off the runtime.

As for binding `(org-element-cache-persistent nil)`, that makes barely a difference on my testing today, but I remember it being a big deal once.  Could just be my emacs session's different.  

I can edit out that binding, but it should be harmless. The org-element cache should not try to persist cache for the contents of a temp buffer, it would never be reused!

## Sanity fix

Note I moved `(delay-mode-hooks (org-mode))` to *after* the file content is inserted.  

This is good hygiene because it allows the Org initialization to read file variables such as `#+STARTUP: odd`, so that functions like `org-do-promote` and `org-reduced-level` do the right thing.