### PR TITLE
fix(node): preserve planning data when promoting subtree to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- (fix): org-roam-extract-subtree: fix property drawer handling and title spacing
+
 ## 2.3.2
 - [#2056](https://github.com/org-roam/org-roam/pull/2056) capture: IDs are now created for entries in capture templates
 


### PR DESCRIPTION
Fixes issues where planning data (SCHEDULED, DEADLINE, CLOSED) was not correctly handled when promoting a subtree to a file node. Also fixes title spacing and ensures property drawers are correctly positioned.

Related issues:
- Fixes #2425 (Prevent data loss when user has called org-roam-extract-subtree on folded org headline) - partially related to extraction robustness.
- Addresses issues with invalid Org structure generation during promotion.